### PR TITLE
Allow to use namespaces in search in Explorer UI

### DIFF
--- a/ui/modules/connections/connections.js
+++ b/ui/modules/connections/connections.js
@@ -264,9 +264,9 @@ function loadConnections() {
       row.id = id;
       if (API.env() === 'ditto_2') {
         API.callConnectionsAPI('retrieveConnection', (dittoConnection) => {
-         row.insertCell(0).innerHTML = dittoConnection.name;
-       },
-       id);
+          row.insertCell(0).innerHTML = dittoConnection.name;
+        },
+        id);
       } else {
         row.insertCell(0).innerHTML = connection.name;
       }

--- a/ui/modules/environments/environments.html
+++ b/ui/modules/environments/environments.html
@@ -14,6 +14,10 @@
 <hr />
 <div class="row resizable_pane" style="height: 80vh">
     <div class="col-md-4 resizable_flex_column">
+        <div class="input-group has-validation">
+            <input class="form-control" id="tableValidationEnvironments" hidden="true"></input>
+            <div class="invalid-feedback"></div>
+        </div>
         <div class="table-wrap">
             <table class="table table-striped table-hover table-sm">
                 <tbody id="tbodyEnvironments"></tbody>
@@ -50,6 +54,11 @@
                     <label class="input-group-text" data-bs-toggle="tooltip"
                         title="URI including protocol, host and port (e.g. http://localhost:8080)">API URI</label>
                     <input type="text" class="form-control form-control-sm" id="inputApiUri"></input>
+                </div>
+                <div class="input-group input-group-sm mt-1">
+                    <label class="input-group-text" data-bs-toggle="tooltip"
+                        title="A comma-separated list of namespaces (e.g. com.example.namespace). The given namespaces are used as a parameter for the Things search">Search Namespaces</label>
+                    <input type="text" class="form-control form-control-sm" spellcheck="false" id="inputSearchNamespaces"></input>
                 </div>
                 <div class="input-group input-group-sm mt-1">
                     <label class="input-group-text">Ditto Version</label>

--- a/ui/modules/things/fields.js
+++ b/ui/modules/things/fields.js
@@ -32,7 +32,7 @@ export function getQueryParameter() {
     Environments.current().fieldList = [];
   }
   const fields = Environments.current().fieldList.filter((f) => f.active).map((f) => f.path);
-  return 'fields=thingId' + (fields !== '' ? ',' + fields : '');
+  return 'fields=thingId' + (fields.length > 0 ? ',' + fields : '');
 }
 
 

--- a/ui/modules/things/things.js
+++ b/ui/modules/things/things.js
@@ -212,7 +212,6 @@ function fillThingsTable(thingsList) {
     }
     return result;
   }
-
 }
 
 /**
@@ -223,9 +222,12 @@ function fillThingsTable(thingsList) {
 export function searchThings(filter, cursor) {
   document.body.style.cursor = 'progress';
 
+  const namespaces = Environments.current().searchNamespaces;
+
   API.callDittoREST('GET',
       '/search/things?' + Fields.getQueryParameter() +
       ((filter && filter !== '') ? '&filter=' + encodeURIComponent(filter) : '') +
+      ((namespaces && namespaces !== '') ? '&namespaces=' + namespaces : '') +
       '&option=sort(%2BthingId)' +
       // ',size(3)' +
       (cursor ? ',cursor(' + cursor + ')' : ''),


### PR DESCRIPTION
Hi @thjaeckle,

I have a small PR. This allows search to work with namespaces.

Next to that
- Allow to rename an environment
- Small fix: search query fields contained trailing comma

Thank you for review, Thomas