### PR TITLE
Support for conditional message sending

### DIFF
--- a/documentation/src/main/resources/_data/authors.yml
+++ b/documentation/src/main/resources/_data/authors.yml
@@ -57,3 +57,8 @@ vadim_guenther:
     name: Vadim Günther
     email: vadim.guenther@bosch.io
     web: https://github.com/VadimGue
+
+aleksandar_stanchev:
+  name: Aleksandar Stanchev
+  email: aleksandar.stanchev@bosch.io
+  web: https://github.com/alstanchev

--- a/documentation/src/main/resources/_posts/2022-10-30-live-message-conditions.md
+++ b/documentation/src/main/resources/_posts/2022-10-30-live-message-conditions.md
@@ -107,7 +107,7 @@ curl -X PATCH -H 'Content-Type: application/json' -H 'condition: eq(features/ala
 
 ### Conditional request with HTTP query parameter
 ```
-curl -X PATCH -H 'Content-Type: application/json' /api/2/things/org.eclipse.ditto:carbon-monoxide-alarm/outbox/messages/co-alarm?eq(features/alarm/properties/confirmed/,false) -d '{ "CO Level to high! Open your windows!" }'
+curl -X PATCH -H 'Content-Type: application/json' /api/2/things/org.eclipse.ditto:carbon-monoxide-alarm/outbox/messages/co-alarm?condition=eq(features/alarm/properties/confirmed/,false) -d '{ "CO Level to high! Open your windows!" }'
 ```
 
 ## Conditional request via Ditto protocol

--- a/documentation/src/main/resources/_posts/2022-10-30-live-message-conditions.md
+++ b/documentation/src/main/resources/_posts/2022-10-30-live-message-conditions.md
@@ -1,0 +1,162 @@
+---
+title: "Support conditional requests for live messages"
+published: true
+permalink: 2022-10-30-live-message-conditions.html
+layout: post
+author: aleksandar_stanchev
+tags: [blog, http, protocol, rql]
+hide_sidebar: true
+sidebar: false
+toc: true
+---
+
+With the upcoming release of Eclipse Ditto **version 3.1.0** it will be possible to process live messages based on 
+conditions.
+
+## Conditional live messages
+Ditto now supports conditional message sending based on a specified condition in the request.
+This functionality can be used via the HTTP API with an HTTP header or query parameter, as well as via the Ditto protocol,
+and the Ditto Java Client.
+For all three ways there is an example provided in this blog post.
+
+This turns useful, if you want for example to send a message to your device, but only if its digital twin has a specific attribute set.
+
+To be more concrete let's say we have a thing with an attribute _temperature_, and we only want to
+send an alarm live message to the corresponding device, if the temperature of the thing is over 60 degrees.
+To achieve this the following HTTP request can be used:
+
+```
+PUT /api/2/things/org.eclipse.ditto:coffeebrewer/inbox/mesages/tempreatureAlarm?condition=gt(attributes/temperature,60)
+alarm!
+```
+
+Conditions can be specified using [RQL syntax](basic-rql.html) to check if a thing has a specific attribute
+or feature property value.
+
+In case the condition does not match to the actual state of the thing, the request will fail with
+HTTP status code **412 - Precondition Failed**. And the message will not be processed.
+
+If the given condition is invalid, the request will fail with HTTP status code **400 - Bad Request**.
+
+More documentation for this feature can be found here: [Conditional Requests](basic-conditional-requests.html)
+
+### Permissions for conditional requests
+
+In order to execute a conditional request, the authorized subject needs to have WRITE permission at the resource
+that should be changed by the request.
+
+Additionally, the authorized subject needs to have READ permission at the resource used in the specified condition.
+Given the condition from the introduction `condition=eq(attributes/location,"Wonderland")`,
+read access on the single attribute would be sufficient.
+However, the condition can also be more complex, or include other sub-structures of the thing.
+Then of course, the authorized subject needs READ permission on all parameters of the specified condition.
+
+## Examples
+The following sub-sections will show how to use conditional requests via the HTTP API, the Ditto protocol,
+and the Ditto Java Client.
+
+To demonstrate the new conditional request, we assume that the following thing already exists:
+
+```json
+{
+  "thingId": "org.eclipse.ditto:carbon-monoxide-alarm",
+  "policyId": "org.eclipse.ditto:carbon-monoxide-alarm",
+  "attributes": {
+    "manufacturer": "ACME demo corp.",
+    "location": "Wonderland",
+    "serialno": "42"
+  },
+  "features": {
+    "carbon-monoxide-level": {
+      "properties": {
+        "ppm,": 2
+      }
+    },
+    "alarm": {
+      "properties": {
+        "lastTriggered": "2021-09-23T07:01:56Z",
+        "confirmed": false
+        }
+      }
+    }
+  }
+}
+```
+
+### Condition based on alarm/confirmed
+In this example a live alarm message from the device should only be sent, if the alarm confirmed property is set to 
+false by the end user application. This is done to prevent duplicate received alarms by the customer.
+
+Another use case could be to i.e. only send a message to a device when the device is connected:
+```
+POST /api/2/things/org.eclipse.ditto:my-thing-1/inbox/messages/doSomething?condition=gt(features/ConnectionStatus/properties/status/readyUntil,time:now)
+```
+
+### Permissions to execute the example
+For this example, the authorized subject could have READ and WRITE permissions on the complete thing resource.
+However, it is only necessary on the path _thing:/features/alarm/properties/confirmed_.
+
+## Conditional requests via HTTP API
+Using the HTTP API the condition can either be specified via HTTP Header or via HTTP query parameter.  
+In this section, we will show how to use both options.
+
+### Conditional request with HTTP Header
+```
+curl -X PATCH -H 'Content-Type: application/json' -H 'condition: eq(features/alarm/properties/confirmed/,false)' /api/2/things/org.eclipse.ditto:carbon-monoxide-alarm/outbox/messages/co-alarm -d '{ "CO Level to high! Open your windows!" }'
+```
+
+### Conditional request with HTTP query parameter
+```
+curl -X PATCH -H 'Content-Type: application/json' /api/2/things/org.eclipse.ditto:carbon-monoxide-alarm/outbox/messages/co-alarm?eq(features/alarm/properties/confirmed/,false) -d '{ "CO Level to high! Open your windows!" }'
+```
+
+## Conditional request via Ditto protocol
+It is also possible to use conditional requests via the Ditto protocol.
+Applying the following Ditto command to the existing thing will lead to the same result as in the above HTTP example.
+
+```json
+{
+  "topic": "org.eclipse.ditto:carbon-monoxide-alarm/things/live/messages/co-alarm",
+  "headers": {
+    "content-type": "application/json",
+    "condition": "eq(features/alarm/properties/confirmed/,false)"
+  },
+  "path": "/outbox/messages/co-alarm",
+  "value": "CO Level to high! Open your windows!"
+}
+```
+
+## Using conditional requests in the Ditto Java Client
+The conditional requests are also supported via the [Ditto Java Client](client-sdk-java.html)
+with the upcoming (**Ditto Java Client version 3.1.0**).
+
+Example for a conditional update of a thing with the Ditto Java client:
+
+```java
+String thingId = "org.eclipse.ditto:carbon-monoxide-alarm";
+
+// initialize the ditto-client
+DittoClient dittoClient = ... ;
+
+dittoClient.live().message(Options.condition("eq(features/alarm/properties/confirmed/,false)"))
+        .from(thingId)
+        .subject("co-alarm")
+        .payload("CO Level to high! Open your windows!")
+        .send(String.class, (response, throwable) -> {
+    if (throwable != null) {
+        LOGGER.error("Received error while sending conditional update: '{}' ", throwable.toString());
+    } else {
+        LOGGER.info("Received response for conditional update: '{}'", response);
+    }
+});
+```
+
+## Feedback?
+
+Please [get in touch](feedback.html) if you have feedback or questions towards this new functionality.
+
+<br/>
+<br/>
+{% include image.html file="ditto.svg" alt="Ditto" max-width=500 %}
+--<br/> 
+The Eclipse Ditto team

--- a/documentation/src/main/resources/openapi/README.md
+++ b/documentation/src/main/resources/openapi/README.md
@@ -16,9 +16,6 @@ To extend or update the OpenAPI of Ditto you can add or change the files in the 
 // go to sources
 $ cd sources
 
-// only v2
-$ npm run build-v2
-
-// both
+// run build
 $ npm run build
 ```

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -4211,6 +4211,7 @@ paths:
         - $ref: '#/components/parameters/MessageSubjectPathParam'
         - $ref: '#/components/parameters/MessageTimeoutParam'
         - $ref: '#/components/parameters/LiveMessageRequestedAcksParam'
+        - $ref: '#/components/parameters/ConditionParam'
       responses:
         '202':
           description: The message was sent but not necessarily received by the thing (fire and forget).
@@ -4253,6 +4254,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         '413':
           $ref: '#/components/responses/MessageTooLarge'
         '424':
@@ -4290,6 +4293,7 @@ paths:
         - $ref: '#/components/parameters/MessageSubjectPathParam'
         - $ref: '#/components/parameters/MessageTimeoutParam'
         - $ref: '#/components/parameters/LiveMessageRequestedAcksParam'
+        - $ref: '#/components/parameters/ConditionParam'
       responses:
         '202':
           description: The message was sent (fire and forget).
@@ -4332,6 +4336,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         '413':
           $ref: '#/components/responses/MessageTooLarge'
         '424':
@@ -4371,6 +4377,7 @@ paths:
         - $ref: '#/components/parameters/MessageSubjectPathParam'
         - $ref: '#/components/parameters/MessageTimeoutParam'
         - $ref: '#/components/parameters/LiveMessageRequestedAcksParam'
+        - $ref: '#/components/parameters/ConditionParam'
       responses:
         '202':
           description: |-
@@ -4415,6 +4422,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         '413':
           $ref: '#/components/responses/MessageTooLarge'
         '424':
@@ -4454,6 +4463,7 @@ paths:
         - $ref: '#/components/parameters/MessageSubjectPathParam'
         - $ref: '#/components/parameters/MessageTimeoutParam'
         - $ref: '#/components/parameters/LiveMessageRequestedAcksParam'
+        - $ref: '#/components/parameters/ConditionParam'
       responses:
         '202':
           description: The message was sent (fire and forget).
@@ -4496,6 +4506,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         '413':
           $ref: '#/components/responses/MessageTooLarge'
         '424':
@@ -7179,7 +7191,7 @@ components:
       name: condition
       in: query
       description: |-
-        Defines that the request should only be applied to a thing if the given condition is met. The condition can be specified using RQL syntax. 
+        Defines that the request should only be processed if the given condition is met. The condition can be specified using RQL syntax. 
         #### Examples
         E.g. if the temperature is not 23.9 update it to 23.9:
         * ```PUT /api/2/things/{thingId}/features/temperature/properties/value?condition=ne(features/temperature/properties/value,23.9)```
@@ -8095,7 +8107,7 @@ components:
         randomizationInterval:
           type: string
           default: 5m
-          description: 'Interval in which the announcement can be sent earlier in effort to prevent announcement peaks. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
+          description: 'Interval in which the announcement can be sent earlier than the configured `beforeExpiry`. The actual point in time when the announcement will be sent is `beforeExpire` plus a randomly chosen time within the `randomizationInterval`. E.g assuming `beforeExpiry` is set to 5m and `randomizationInterval` is set to 1m, the announcements will be sent between 5 and 6 minutes before the subject expires. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
       example:
         beforeExpiry: 5m
         whenDeleted: true

--- a/documentation/src/main/resources/openapi/sources/parameters/conditionParam.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/conditionParam.yml
@@ -11,7 +11,7 @@
 name: condition
 in: query
 description: >-
-  Defines that the request should only be applied to a thing if the given condition is met.
+  Defines that the request should only be processed if the given condition is met.
   The condition can be specified using RQL syntax. 
 
   #### Examples

--- a/documentation/src/main/resources/openapi/sources/paths/messages/feature-inbox-message.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/messages/feature-inbox-message.yml
@@ -40,6 +40,7 @@ post:
     - $ref: '../../parameters/messageSubjectPathParam.yml'
     - $ref: '../../parameters/messageTimeoutParam.yml'
     - $ref: '../../parameters/liveMessageRequestedAcksParam.yml'
+    - $ref: '../../parameters/conditionParam.yml'
   responses:
     '202':
       description: |-
@@ -84,6 +85,8 @@ post:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
     '413':
       $ref: '../../responses/messageTooLarge.yml'
     '424':

--- a/documentation/src/main/resources/openapi/sources/paths/messages/feature-outbox-message.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/messages/feature-outbox-message.yml
@@ -40,6 +40,7 @@ post:
     - $ref: '../../parameters/messageSubjectPathParam.yml'
     - $ref: '../../parameters/messageTimeoutParam.yml'
     - $ref: '../../parameters/liveMessageRequestedAcksParam.yml'
+    - $ref: '../../parameters/conditionParam.yml'
   responses:
     '202':
       description: The message was sent (fire and forget).
@@ -82,6 +83,8 @@ post:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
     '413':
       $ref: '../../responses/messageTooLarge.yml'
     '424':

--- a/documentation/src/main/resources/openapi/sources/paths/messages/inbox-message.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/messages/inbox-message.yml
@@ -51,6 +51,7 @@ post:
     - $ref: '../../parameters/messageSubjectPathParam.yml'
     - $ref: '../../parameters/messageTimeoutParam.yml'
     - $ref: '../../parameters/liveMessageRequestedAcksParam.yml'
+    - $ref: '../../parameters/conditionParam.yml'
   responses:
     '202':
       description: |-
@@ -94,6 +95,8 @@ post:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
     '413':
       $ref: '../../responses/messageTooLarge.yml'
     '424':

--- a/documentation/src/main/resources/openapi/sources/paths/messages/outbox-message.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/messages/outbox-message.yml
@@ -38,6 +38,7 @@ post:
     - $ref: '../../parameters/messageSubjectPathParam.yml'
     - $ref: '../../parameters/messageTimeoutParam.yml'
     - $ref: '../../parameters/liveMessageRequestedAcksParam.yml'
+    - $ref: '../../parameters/conditionParam.yml'
   responses:
     '202':
       description: The message was sent (fire and forget).
@@ -80,6 +81,8 @@ post:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
     '413':
       $ref: '../../responses/messageTooLarge.yml'
     '424':

--- a/documentation/src/main/resources/pages/ditto/basic-conditional-requests.md
+++ b/documentation/src/main/resources/pages/ditto/basic-conditional-requests.md
@@ -12,8 +12,8 @@ It is possible to combine both headers within one request. If you use both heade
 
 ## Defining conditions
 
-Ditto supports retrieving, modifying, and deleting things based on specific conditions of the current persisted twin state.
-Conditions are not intended to be used for message dispatching.
+Ditto supports retrieving, modifying, deleting and sending messages to/from things based on specific conditions of the 
+current persisted twin state.
 For example, if you want to update the value of an attribute, but only if the current attribute value is not already 42,
 you can specify a condition:
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/SupervisorLiveChannelDispatching.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/SupervisorLiveChannelDispatching.java
@@ -14,6 +14,7 @@
 package org.eclipse.ditto.things.service.persistence.actors;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -21,6 +22,9 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.eclipse.ditto.base.model.entity.id.WithEntityId;
+import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.Signal;
@@ -29,20 +33,33 @@ import org.eclipse.ditto.base.model.signals.UnsupportedSignalException;
 import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.base.model.signals.commands.exceptions.CommandTimeoutException;
 import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
+import org.eclipse.ditto.internal.utils.cacheloaders.AskWithRetry;
+import org.eclipse.ditto.internal.utils.cacheloaders.config.AskWithRetryConfig;
+import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.persistentactors.DistributedPubWithMessage;
 import org.eclipse.ditto.internal.utils.persistentactors.TargetActorWithMessage;
 import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
 import org.eclipse.ditto.internal.utils.pubsub.StreamingType;
 import org.eclipse.ditto.internal.utils.pubsub.extractors.AckExtractor;
 import org.eclipse.ditto.internal.utils.pubsubthings.LiveSignalPub;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.messages.model.signals.commands.MessageCommand;
+import org.eclipse.ditto.policies.enforcement.config.DefaultEnforcementConfig;
 import org.eclipse.ditto.policies.enforcement.config.EnforcementConfig;
+import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThing;
+import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
+import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
+import org.eclipse.ditto.things.model.signals.commands.ThingErrorResponse;
 import org.eclipse.ditto.things.model.signals.commands.query.ThingQueryCommand;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
+import org.eclipse.ditto.things.service.persistence.actors.strategies.commands.ThingConditionValidator;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorRefFactory;
+import akka.actor.ActorSystem;
 import akka.pattern.AskTimeoutException;
 
 /**
@@ -65,18 +82,32 @@ final class SupervisorLiveChannelDispatching {
     private final ResponseReceiverCache responseReceiverCache;
     private final LiveSignalPub liveSignalPub;
     private final ActorRefFactory actorRefFactory;
+    private final ActorRef thingsShardRegion;
+    private final ActorSystem actorSystem;
+    private final AskWithRetryConfig askWithRetryConfig;
 
     SupervisorLiveChannelDispatching(final ThreadSafeDittoLoggingAdapter log,
             final EnforcementConfig enforcementConfig,
             final ResponseReceiverCache responseReceiverCache,
             final LiveSignalPub liveSignalPub,
-            final ActorRefFactory actorRefFactory) {
+            final ActorRefFactory actorRefFactory,
+            final ActorRef thingsShardRegion,
+            final ActorSystem actorSystem) {
 
         this.log = log;
         this.enforcementConfig = enforcementConfig;
         this.responseReceiverCache = responseReceiverCache;
         this.liveSignalPub = liveSignalPub;
         this.actorRefFactory = actorRefFactory;
+        this.thingsShardRegion = thingsShardRegion;
+        this.actorSystem = actorSystem;
+        this.askWithRetryConfig = getAskWithRetryConfig(actorSystem);
+    }
+
+    private static AskWithRetryConfig getAskWithRetryConfig(final ActorSystem actorSystem) {
+        final DefaultScopedConfig dittoScoped = DefaultScopedConfig.dittoScoped(actorSystem.settings().config());
+        final var enforcementConfig = DefaultEnforcementConfig.of(dittoScoped);
+        return enforcementConfig.getAskWithRetryConfig();
     }
 
     /**
@@ -158,36 +189,112 @@ final class SupervisorLiveChannelDispatching {
      * @return a CompletionStage which will be completed with a target actor and a message to send to this target actor
      */
     CompletionStage<TargetActorWithMessage> dispatchLiveSignal(final Signal<?> signal, final ActorRef sender) {
-        final UnaryOperator<Object> errorHandler =
-                response -> handleEncounteredAskTimeoutsAsCommandTimeoutException(signal.getDittoHeaders(), response);
-        final DistributedPubWithMessage distributedPubWithMessage = selectLiveSignalPublisher(signal);
-        if (enforcementConfig.shouldDispatchGlobally(signal)) {
-            return responseReceiverCache.insertResponseReceiverConflictFree(signal,
-                            newSignal -> sender,
-                            (newSignal, receiver) -> {
-                                log.withCorrelationId(newSignal)
-                                        .info("Publishing message to pub-sub: <{}>", newSignal.getType());
-                                if (newSignal.equals(signal)) {
-                                    return distributedPubWithMessage;
-                                } else {
-                                    return selectLiveSignalPublisher(newSignal);
-                                }
-                            })
-                    .thenApply(distributedPub -> new TargetActorWithMessage(
-                            distributedPub.pub().getPublisher(),
-                            distributedPub.wrappedSignalForPublication(),
-                            calculateLiveChannelTimeout(distributedPub.signal().getDittoHeaders()),
-                            errorHandler
-                    ));
+
+        return evaluateCondition(signal).thenCompose(s -> {
+            final UnaryOperator<Object> errorHandler =
+                    response -> handleEncounteredAskTimeoutsAsCommandTimeoutException(signal.getDittoHeaders(),
+                            response);
+            final DistributedPubWithMessage distributedPubWithMessage = selectLiveSignalPublisher(signal);
+            if (enforcementConfig.shouldDispatchGlobally(signal)) {
+                return responseReceiverCache.insertResponseReceiverConflictFree(signal,
+                                newSignal -> sender,
+                                (newSignal, receiver) -> {
+                                    log.withCorrelationId(newSignal)
+                                            .info("Publishing message to pub-sub: <{}>", newSignal.getType());
+                                    if (newSignal.equals(signal)) {
+                                        return distributedPubWithMessage;
+                                    } else {
+                                        return selectLiveSignalPublisher(newSignal);
+                                    }
+                                })
+                        .thenApply(distributedPub -> new TargetActorWithMessage(
+                                distributedPub.pub().getPublisher(),
+                                distributedPub.wrappedSignalForPublication(),
+                                calculateLiveChannelTimeout(distributedPub.signal().getDittoHeaders()),
+                                errorHandler
+                        ));
+            } else {
+                log.withCorrelationId(signal)
+                        .debug("Publish message to pub-sub: <{}>", signal);
+                return CompletableFuture.completedStage(new TargetActorWithMessage(
+                        distributedPubWithMessage.pub().getPublisher(),
+                        distributedPubWithMessage.wrappedSignalForPublication(),
+                        calculateLiveChannelTimeout(signal.getDittoHeaders()),
+                        errorHandler
+                ));
+            }
+        });
+    }
+
+    private CompletionStage<Signal<?>> evaluateCondition(final Signal<?> signal) {
+        final var condition = signal.getDittoHeaders().getCondition();
+
+        if (condition.isPresent()) {
+            final var retrieveThing = getRetrieveThing(signal);
+            if (retrieveThing.isPresent()) {
+                final var thing = AskWithRetry.askWithRetry(thingsShardRegion, retrieveThing.get(), askWithRetryConfig,
+                        actorSystem,
+                        response -> handleRetrieveThingResponse(response, signal.getDittoHeaders())
+                );
+                return thing.thenApply(t -> {
+                    final var optionalException = ThingConditionValidator.validate(signal, condition.get(), t);
+                    if (optionalException.isPresent()) {
+                        log.withCorrelationId(signal).info("Live-message was filtered due to not matching condition.");
+                        throw optionalException.get();
+                    } else {
+                        return signal;
+                    }
+                });
+            }
+        }
+        return CompletableFuture.completedFuture(signal);
+    }
+
+    private Optional<SudoRetrieveThing> getRetrieveThing(final Signal<?> signal) {
+        final Optional<SudoRetrieveThing> result;
+        if (signal instanceof WithEntityId withEntityId) {
+            if (withEntityId.getEntityId() instanceof ThingId thingId) {
+                result = Optional.of(SudoRetrieveThing.of(thingId, signal.getDittoHeaders()));
+            } else {
+                result = Optional.empty();
+                log.withCorrelationId(signal).error("Skipping live-message condition validation, because entityId " +
+                        "is no thingId.");
+            }
         } else {
-            log.withCorrelationId(signal)
-                    .debug("Publish message to pub-sub: <{}>", signal);
-            return CompletableFuture.completedStage(new TargetActorWithMessage(
-                    distributedPubWithMessage.pub().getPublisher(),
-                    distributedPubWithMessage.wrappedSignalForPublication(),
-                    calculateLiveChannelTimeout(signal.getDittoHeaders()),
-                    errorHandler
-            ));
+            result = Optional.empty();
+            log.withCorrelationId(signal).error("Skipping live-message condition validation, because message " +
+                    "does not contain an entityId.");
+        }
+        return result;
+    }
+
+    private Thing handleRetrieveThingResponse(final Object response, final DittoHeaders dittoHeaders) {
+
+        if (response instanceof SudoRetrieveThingResponse retrieveThingResponse) {
+            final JsonValue entity = retrieveThingResponse.getEntity();
+            if (!entity.isObject()) {
+                log.withCorrelationId(dittoHeaders)
+                        .error("Expected SudoRetrieveThingResponse to contain a JsonObject as Entity but was: {}",
+                                entity);
+                throw DittoInternalErrorException.newBuilder().dittoHeaders(dittoHeaders).build();
+            }
+            return ThingsModelFactory.newThing(entity.asObject());
+
+        } else if (response instanceof ThingErrorResponse thingErrorResponse) {
+            log.withCorrelationId(dittoHeaders)
+                    .info("Got ThingErrorResponse when waiting on RetrieveThingResponse when validating live-message " +
+                            "condition.");
+            throw thingErrorResponse.getDittoRuntimeException();
+        } else if (response instanceof DittoRuntimeException dre) {
+            log.withCorrelationId(dittoHeaders)
+                    .info("Got Exception when waiting on RetrieveThingResponse when validating live-message condition: {}",
+                            dre.getMessage());
+            throw dre;
+        } else {
+            log.withCorrelationId(dittoHeaders)
+                    .error("Did not retrieve expected RetrieveThingResponse when validating live-message condition: {}",
+                            response);
+            throw DittoInternalErrorException.newBuilder().dittoHeaders(dittoHeaders).build();
         }
     }
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConditionValidator.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConditionValidator.java
@@ -50,7 +50,7 @@ public final class ThingConditionValidator {
     public static Optional<ThingConditionFailedException> validate(final Signal<?> signal,
             final String condition, @Nullable final Thing entity) {
 
-        checkNotNull(signal, "Command");
+        checkNotNull(signal, "Signal");
 
         final Optional<ThingConditionFailedException> result;
         if (!(signal instanceof CreateThing) && entity != null) {

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConditionValidator.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConditionValidator.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.placeholders.TimePlaceholder;
 import org.eclipse.ditto.rql.parser.RqlPredicateParser;
@@ -31,7 +31,7 @@ import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingCondition
 import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
 
 @Immutable
-final class ThingConditionValidator {
+public final class ThingConditionValidator {
 
     private static final TimePlaceholder TIME_PLACEHOLDER = TimePlaceholder.getInstance();
 
@@ -42,19 +42,19 @@ final class ThingConditionValidator {
     /**
      * Validates if the given condition matches the actual thing state.
      *
-     * @param command the command used for checking if validation should be applied.
+     * @param signal the signal used for checking if validation should be applied.
      * @param condition the condition which should be verified against the thing.
      * @param entity the actual thing entity.
-     * @return either void or the ThingConditionFailedException in case the condition couldN't be validated.
+     * @return either void or the ThingConditionFailedException in case the condition couldn't be validated.
      */
-    public static Optional<ThingConditionFailedException> validate(final Command<?> command,
+    public static Optional<ThingConditionFailedException> validate(final Signal<?> signal,
             final String condition, @Nullable final Thing entity) {
 
-        checkNotNull(command, "Command");
+        checkNotNull(signal, "Command");
 
         final Optional<ThingConditionFailedException> result;
-        if (!(command instanceof CreateThing) && entity != null) {
-            result = validateConditionForEntity(condition, entity, command.getDittoHeaders());
+        if (!(signal instanceof CreateThing) && entity != null) {
+            result = validateConditionForEntity(condition, entity, signal.getDittoHeaders());
         } else {
             result = Optional.empty();
         }


### PR DESCRIPTION
- Only send messages to devices when a specified condition if fulfilled. 
- Ditto's HTTP Messages API supports to specify a "condition" query parameter with an RQL expression.
- Conditions are applied to the currently known twin/thing state
- When a condition is not passed, an immediate response is returned (e.g. HTTP 412 pre-condition failed) 


Fixes #1363