### PR TITLE
Improved search filter in explorer ui

### DIFF
--- a/ui/index.css
+++ b/ui/index.css
@@ -151,3 +151,8 @@ h5, h6 {
 hr {
     margin: 0.25rem;
 }
+
+.dropdown-menu {
+    max-height: 80vh;
+    overflow-y: auto;
+}

--- a/ui/modules/things/searchFilter.js
+++ b/ui/modules/things/searchFilter.js
@@ -25,9 +25,13 @@ const filterExamples = [
   'like(attributes/key1,"known-chars-at-start*")',
 ];
 
+const filterHistory = [];
+
 let keyStrokeTimeout;
 
 let lastSearch = '';
+
+const FILTER_PLACEHOLDER = '*****';
 
 const dom = {
   filterList: null,
@@ -51,7 +55,10 @@ export async function ready() {
     if (event.target && event.target.classList.contains('dropdown-item')) {
       dom.searchFilterEdit.value = event.target.textContent;
       checkIfFavourite();
-      Things.searchThings(event.target.textContent);
+      const filterEditNeeded = checkAndMarkParameter();
+      if (!filterEditNeeded) {
+        Things.searchThings(event.target.textContent);
+      }
     }
   });
 
@@ -103,6 +110,7 @@ function onEnvironmentChanged() {
  */
 function searchTriggered(filter) {
   lastSearch = filter;
+  fillHistory(filter);
   const regex = /^(eq\(|ne\(|gt\(|ge\(|lt\(|le\(|in\(|like\(|exists\(|and\(|or\(|not\().*/;
   if (filter === '' || regex.test(filter)) {
     Things.searchThings(filter);
@@ -140,8 +148,13 @@ function updateFilterList() {
   dom.filterList.innerHTML = '';
   Utils.addDropDownEntries(dom.filterList, ['Favourite search filters'], true);
   Utils.addDropDownEntries(dom.filterList, Environments.current().filterList);
+  Utils.addDropDownEntries(dom.filterList, ['Field search filters'], true);
+  Utils.addDropDownEntries(dom.filterList, Environments.current().fieldList
+      .map((f) => `eq(${f.path},${FILTER_PLACEHOLDER})`));
   Utils.addDropDownEntries(dom.filterList, ['Example search filters'], true);
   Utils.addDropDownEntries(dom.filterList, filterExamples);
+  Utils.addDropDownEntries(dom.filterList, ['Recent search filters'], true);
+  Utils.addDropDownEntries(dom.filterList, filterHistory);
 }
 
 /**
@@ -171,6 +184,24 @@ function checkIfFavourite() {
     dom.favIcon.classList.replace('bi-star', 'bi-star-fill');
   } else {
     dom.favIcon.classList.replace('bi-star-fill', 'bi-star');
+  }
+}
+
+function checkAndMarkParameter() {
+  const index = dom.searchFilterEdit.value.indexOf(FILTER_PLACEHOLDER);
+  if (index >= 0) {
+    dom.searchFilterEdit.focus();
+    dom.searchFilterEdit.setSelectionRange(index, index + FILTER_PLACEHOLDER.length);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function fillHistory(filter) {
+  if (!filterHistory.includes(filter)) {
+    filterHistory.unshift(filter);
+    updateFilterList();
   }
 }
 


### PR DESCRIPTION
Two small extensions to improve usage of things searches

### Create search filter for fields
- There is often the need to do a search for known fields in some attribute or feature (like serial number, device type, ...). If you have defined a field (that is already used for columns), you can easily create a rql with the correct path of a field (only eqal search by now)
- Future ideas:
  - have a friendly name for each search filter (like "serialnumber == 42" for "eq(attributes/serialnumber,42")
  - generate all variants for eq, like, not eq, etc.
  - replace the drop down selection with a typeahead search field

### Simple session based history of searches
- If you forget to save a filter as a favourite, you need to type it again.
- Now you have a transient history to recall you last search. This history is cleaned up automatically on the next session.
