### PR TITLE
fix: move visitor accept implementation to the undermost class

### DIFF
--- a/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/RootNode.java
+++ b/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/RootNode.java
@@ -17,4 +17,10 @@ package org.eclipse.ditto.rql.model.predicates.ast;
  */
 public final class RootNode extends SuperNode {
 
+    /**
+     * {@inheritDoc}
+     */
+    public void accept(final PredicateVisitor predicateVisitor) {
+        predicateVisitor.visit(this);
+    }
 }

--- a/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/SuperNode.java
+++ b/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/SuperNode.java
@@ -38,13 +38,6 @@ public abstract class SuperNode implements Node {
         return children;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public void accept(final PredicateVisitor predicateVisitor) {
-        predicateVisitor.visit(this);
-    }
-
     @Override
     public String toString() {
         return "SuperNode [children=" + children + "]";


### PR DESCRIPTION
When calling `rootNode.accept(v)`, `v.visit(Node node)` is called instead of `v.visit(RootNode node)`.