### PR TITLE
Bugfix/client rebalancing

### DIFF
--- a/connectivity/api/src/main/java/org/eclipse/ditto/connectivity/api/commands/sudo/SudoRetrieveClientActorProps.java
+++ b/connectivity/api/src/main/java/org/eclipse/ditto/connectivity/api/commands/sudo/SudoRetrieveClientActorProps.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.api.commands.sudo;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.WithConnectionId;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+
+/**
+ * Command which requests the connection persistence actor to send arguments with which to construct client actor props.
+ *
+ * @since 3.1.0
+ */
+@Immutable
+@JsonParsableCommand(typePrefix = ConnectivitySudoCommand.TYPE_PREFIX, name = SudoRetrieveClientActorProps.NAME)
+public final class SudoRetrieveClientActorProps extends AbstractCommand<SudoRetrieveClientActorProps>
+        implements ConnectivitySudoCommand<SudoRetrieveClientActorProps>, WithConnectionId {
+
+    public static final String NAME = "sudoRetrieveClientActorProps";
+
+    public static final String TYPE = TYPE_PREFIX + NAME;
+
+    private static final JsonFieldDefinition<Integer> CLIENT_ACTOR_NUMBER =
+            JsonFactory.newIntFieldDefinition("clientActorNumber", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private final ConnectionId connectionId;
+    private final int clientActorNumber;
+
+    private SudoRetrieveClientActorProps(final ConnectionId connectionId, final int clientActorId,
+            final DittoHeaders dittoHeaders) {
+        super(TYPE, dittoHeaders);
+        this.connectionId = connectionId;
+        this.clientActorNumber = clientActorId;
+    }
+
+    /**
+     * Returns a new instance of {@code SudoRetrieveClientActorProps}.
+     *
+     * @param connectionId the Connection ID.
+     * @param clientActorNumber the client actor number.
+     * @param dittoHeaders the headers of the request.
+     * @return a new SudoRetrieveClientActorProps command.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static SudoRetrieveClientActorProps of(final ConnectionId connectionId,
+            final int clientActorNumber, final DittoHeaders dittoHeaders) {
+        return new SudoRetrieveClientActorProps(connectionId, clientActorNumber, dittoHeaders);
+    }
+
+    /**
+     * Creates a new {@code SudoRetrieveClientActorProps} from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the command is to be created.
+     * @param dittoHeaders the headers of the command.
+     * @return the command.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static SudoRetrieveClientActorProps fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return new CommandJsonDeserializer<SudoRetrieveClientActorProps>(TYPE, jsonObject).deserialize(
+                () -> {
+                    final String readConnectionId =
+                            jsonObject.getValueOrThrow(ConnectivitySudoCommand.JsonFields.JSON_CONNECTION_ID);
+                    final ConnectionId connectionId = ConnectionId.of(readConnectionId);
+                    final int clientNumber = jsonObject.getValueOrThrow(CLIENT_ACTOR_NUMBER);
+                    return of(connectionId, clientNumber, dittoHeaders);
+                });
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(ConnectivitySudoCommand.JsonFields.JSON_CONNECTION_ID, connectionId.toString(),
+                predicate);
+        jsonObjectBuilder.set(CLIENT_ACTOR_NUMBER, clientActorNumber);
+    }
+
+    @Override
+    public Category getCategory() {
+        return Category.QUERY;
+    }
+
+    @Override
+    public SudoRetrieveClientActorProps setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(connectionId, clientActorNumber, dittoHeaders);
+    }
+
+    @Override
+    public ConnectionId getEntityId() {
+        return connectionId;
+    }
+
+    /**
+     * Retrieve the client actor number.
+     *
+     * @return The client actor number.
+     */
+    public int getClientActorNumber() {
+        return clientActorNumber;
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof SudoRetrieveClientActorProps;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final SudoRetrieveClientActorProps that = (SudoRetrieveClientActorProps) o;
+        return Objects.equals(connectionId, that.connectionId) && clientActorNumber == that.clientActorNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), connectionId, clientActorNumber);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                super.toString() +
+                ", connectionId=" + connectionId +
+                ", clientActorNumber=" + clientActorNumber +
+                "]";
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/strategies/commands/ConnectionCreatedStrategies.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/strategies/commands/ConnectionCreatedStrategies.java
@@ -69,11 +69,6 @@ public final class ConnectionCreatedStrategies
     }
 
     @Override
-    public boolean isDefined(final Command<?> command) {
-        return command instanceof ConnectivityCommand || command instanceof ConnectivitySudoCommand;
-    }
-
-    @Override
     public Result<ConnectivityEvent<?>> unhandled(final Context<ConnectionState> context,
             @Nullable final Connection entity,
             final long nextRevision,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientSupervisorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientSupervisorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.service.UriEncoding;
+import org.eclipse.ditto.connectivity.api.commands.sudo.SudoRetrieveClientActorProps;
+import org.eclipse.ditto.connectivity.api.commands.sudo.SudoRetrieveConnectionStatus;
+import org.eclipse.ditto.connectivity.api.commands.sudo.SudoRetrieveConnectionStatusResponse;
+import org.eclipse.ditto.connectivity.model.ConnectivityStatus;
+import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.testkit.TestKit;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Tests {@link ClientSupervisor}.
+ */
+public final class ClientSupervisorTest {
+
+    @Rule
+    public final ActorSystemResource ACTOR_SYSTEM_RESOURCE = ActorSystemResource.newInstance(
+            ConfigFactory.parseMap(Map.of(
+                    "ditto.extensions.client-actor-props-factory.extension-class",
+                    MockClientActorPropsFactory.class.getName()
+            )).withFallback(TestConstants.CONFIG));
+
+    @Test
+    public void checkConnectionStatusOnStartUp() {
+        new TestKit(ACTOR_SYSTEM_RESOURCE.getActorSystem()) {{
+            final var props = ClientSupervisor.propsForTest(Duration.ofDays(1), testActor());
+            final var clientActorId = new ClientActorId(TestConstants.createRandomConnectionId(), 0);
+
+            // WHEN: Client supervisor starts
+            // THEN: It retrieves the connection status
+            final var underTest = childActorOf(props, UriEncoding.encodePath(clientActorId.toString()));
+            watch(underTest);
+            expectMsgClass(SudoRetrieveConnectionStatus.class);
+            assertThat(lastSender()).isEqualTo(underTest);
+
+            // WHEN: Connection status is open and the client actor is not started
+            // THEN: Client supervisor retrieves the client actor props args
+            underTest.tell(SudoRetrieveConnectionStatusResponse.of(ConnectivityStatus.OPEN, 1, DittoHeaders.empty()),
+                    testActor());
+            expectMsgClass(SudoRetrieveClientActorProps.class);
+
+            // WHEN: Connection status is closed
+            // THEN: Client supervisor terminates
+            underTest.tell(SudoRetrieveConnectionStatusResponse.of(ConnectivityStatus.CLOSED, 1, DittoHeaders.empty()),
+                    testActor());
+            expectTerminated(underTest, FiniteDuration.apply(10, "s"));
+        }};
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.base.model.correlationid.TestNameCorrelationId;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.connectivity.api.BaseClientState;
+import org.eclipse.ditto.connectivity.api.commands.sudo.SudoRetrieveClientActorProps;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.ConnectionConfigurationInvalidException;
 import org.eclipse.ditto.connectivity.model.ConnectionId;
@@ -68,6 +69,8 @@ import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConne
 import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnectionStatus;
 import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnectionStatusResponse;
 import org.eclipse.ditto.connectivity.model.signals.events.ConnectionDeleted;
+import org.eclipse.ditto.connectivity.service.messaging.ClientActorId;
+import org.eclipse.ditto.connectivity.service.messaging.ClientActorPropsArgs;
 import org.eclipse.ditto.connectivity.service.messaging.MockClientActorPropsFactory;
 import org.eclipse.ditto.connectivity.service.messaging.MockCommandValidator;
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
@@ -76,6 +79,7 @@ import org.eclipse.ditto.connectivity.service.util.ConnectionPubSub;
 import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
 import org.eclipse.ditto.internal.utils.akka.PingCommand;
 import org.eclipse.ditto.internal.utils.akka.controlflow.WithSender;
+import org.eclipse.ditto.internal.utils.cluster.ShardedBinaryEnvelope;
 import org.eclipse.ditto.internal.utils.persistentactors.AbstractPersistenceSupervisor;
 import org.eclipse.ditto.internal.utils.test.Retry;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracingInitResource;
@@ -674,10 +678,8 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
 
         // create connection
         underTest.tell(createConnection(), testProbe.ref());
-        testProbe.expectMsg(createConnectionResponse());
-
-        // wait for open connection of initial creation
         simulateSuccessfulOpenConnectionInClientActor();
+        testProbe.expectMsg(createConnectionResponse());
 
         // stop actor
         actorSystemResource1.stopActor(underTest);
@@ -1210,6 +1212,29 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
                 PartialFunction.fromFunction(msg -> msg instanceof DistributedPubSubMediator.Publish publish &&
                         publish.topic().equals(ConnectionDeleted.TYPE)));
         testProbe.expectTerminated(underTest, FiniteDuration.apply(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void retrieveClientActorProps() {
+        final var underTest = createSupervisor();
+        final var testProbe = actorSystemResource1.newTestProbe();
+        final var clientActorId = new ClientActorId(connectionId, 0);
+        final var command = SudoRetrieveClientActorProps.of(clientActorId.connectionId(),
+                clientActorId.clientNumber(), DittoHeaders.newBuilder().randomCorrelationId().build());
+
+        underTest.tell(command, testProbe.ref());
+        testProbe.expectMsgClass(ConnectionNotAccessibleException.class);
+
+        final var createConnection = createConnection();
+        underTest.tell(createConnection, testProbe.ref());
+        simulateSuccessfulOpenConnectionInClientActor();
+        testProbe.expectMsg(createConnectionResponse());
+
+        underTest.tell(command, testProbe.ref());
+        final var envelope = testProbe.expectMsgClass(ShardedBinaryEnvelope.class);
+        final var message = (ClientActorPropsArgs) envelope.message();
+        assertThat(message.connection()).isEqualTo(createConnection.getConnection());
+        assertThat(message.dittoHeaders()).isEqualTo(command.getDittoHeaders());
     }
 
     private ActorRef createSupervisor() {

--- a/internal/utils/config/src/main/resources/ditto-akka-config.conf
+++ b/internal/utils/config/src/main/resources/ditto-akka-config.conf
@@ -254,8 +254,8 @@ akka {
         rebalance-absolute-limit = 20
         rebalance-absolute-limit = ${?AKKA_CLUSTER_SHARDING_LEAST_SHARD_ALLOCATION_STRATEGY_REBALANCE_ABSOLUTE_LIMIT}
 
-        # must be <=1.0: having configured e.g. 100 shards, a relative limit of 0.1 would result to "10"
-        rebalance-relative-limit = 0.1
+        # must be <=1.0: with 100 active shards, a relative limit of 0.2 would result to "20"
+        rebalance-relative-limit = 0.2
         rebalance-relative-limit = ${?AKKA_CLUSTER_SHARDING_LEAST_SHARD_ALLOCATION_STRATEGY_REBALANCE_RELATIVE_LIMIT}
       }
     }

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
@@ -648,7 +648,12 @@ public abstract class AbstractPersistenceActor<
         return confirmedSnapshotRevision;
     }
 
-    private void notAccessible(final WithDittoHeaders withDittoHeaders) {
+    /**
+     * Reply a not-accessible exception using the Ditto headers of a message.
+     *
+     * @param withDittoHeaders The message with Ditto headers.
+     */
+    protected void notAccessible(final WithDittoHeaders withDittoHeaders) {
         final DittoRuntimeExceptionBuilder<?> builder = newNotAccessibleExceptionBuilder()
                 .dittoHeaders(withDittoHeaders.getDittoHeaders());
         notifySender(builder.build());


### PR DESCRIPTION
- Ensure that client supervisors do not get stuck if restart message is lost.
- Increase rebalancing relative limit to coincide with absolute limit when all shards are active.