### PR TITLE
fixes wrong json method call

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionMongoSnapshotAdapter.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionMongoSnapshotAdapter.java
@@ -78,7 +78,7 @@ public final class ConnectionMongoSnapshotAdapter extends AbstractMongoSnapshotA
     @Override
     protected Connection createJsonifiableFrom(final JsonObject jsonObject) {
         if (encryptionConfig.getSymmetricalKey().isEmpty()) {
-            if(jsonObject.asString().contains(JsonFieldsEncryptor.ENCRYPTED_PREFIX)){
+            if(jsonObject.formatAsString().contains(JsonFieldsEncryptor.ENCRYPTED_PREFIX)){
                 LOGGER.warn("Encrypted fields will not be decrypted. Missing symmetrical key. " +
                         "Either configure the one used for encryption or edit connections and update encrypted fields");
             }


### PR DESCRIPTION
wrong call to asString instead of formatAsString causes errors when called on objects

Signed-off-by: Stanchev Aleksandar <aleksandar.stanchev@bosch.io>