### PR TITLE
Wrong comment on config of json pointers to values to be encrypted

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultFieldsEncryptionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultFieldsEncryptionConfig.java
@@ -93,4 +93,5 @@ public final class DefaultFieldsEncryptionConfig implements FieldsEncryptionConf
                 ", jsonPointers=" + jsonPointers +
                 ']';
     }
+
 }

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -162,7 +162,7 @@ ditto {
         symmetrical-key = ""
         symmetrical-key = ${?CONNECTIVITY_CONNECTION_ENCRYPTION_KEY}
 
-        # A comma separated string of Json pointers to the fields to be encrypted
+        # A List of Json pointers to the fields to be encrypted
         json-pointers = ["/uri",
           "/credentials/key",
           "/sshTunnel/credentials/password",


### PR DESCRIPTION
This fixes a misleading comment in the connectivity.config regarding the fields to be encrypted of a connection

Signed-off-by: Stanchev Aleksandar <aleksandar.stanchev@bosch.io>