### PR TITLE
Credentials of URI in Hono-connection encoding added

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/hono/HonoConnectionFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/hono/HonoConnectionFactory.java
@@ -16,6 +16,8 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkArgument
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -150,7 +152,8 @@ public abstract class HonoConnectionFactory implements DittoExtensionPoint {
 
     private String combineUriWithCredentials(final String uri, final UserPasswordCredentials credentials) {
         return uri.replaceFirst("(\\S+://)(\\S+)",
-                "$1" + credentials.getUsername() + ":" + credentials.getPassword() + "@$2");
+                "$1" + URLEncoder.encode(credentials.getUsername(), StandardCharsets.UTF_8) + ":" +
+                        URLEncoder.encode(credentials.getPassword(), StandardCharsets.UTF_8) + "@$2");
     }
 
     private Map<String, String> makeupSpecificConfig(final Connection connection) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/hono/DefaultHonoConnectionFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/hono/DefaultHonoConnectionFactoryTest.java
@@ -19,6 +19,8 @@ import static org.eclipse.ditto.connectivity.model.HonoAddressAlias.TELEMETRY;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,8 +122,8 @@ public final class DefaultHonoConnectionFactoryTest {
         );
         return ConnectivityModelFactory.newConnectionBuilder(originalConnection)
                 .uri(honoConfig.getBaseUri().toString().replaceFirst("(\\S+://)(\\S+)",
-                        "$1" + honoConfig.getUserPasswordCredentials().getUsername()
-                                + ":" + honoConfig.getUserPasswordCredentials().getPassword()
+                        "$1" + URLEncoder.encode(honoConfig.getUserPasswordCredentials().getUsername(), StandardCharsets.UTF_8)
+                                + ":" + URLEncoder.encode(honoConfig.getUserPasswordCredentials().getPassword(), StandardCharsets.UTF_8)
                                 + "@$2"))
                 .validateCertificate(honoConfig.isValidateCertificates())
                 .specificConfig(Map.of(

--- a/connectivity/service/src/test/resources/hono-connection-custom-expected.json
+++ b/connectivity/service/src/test/resources/hono-connection-custom-expected.json
@@ -3,7 +3,7 @@
   "name": "Things-Hono Test 1",
   "connectionType": "hono",
   "connectionStatus": "open",
-  "uri": "tcp://test_username:test_password@localhost:9922",
+  "uri": "tcp://test_username:test_password_w%2Fspecial_char@localhost:9922",
   "sources": [
     {
       "addresses": [

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -103,7 +103,7 @@ ditto {
         sasl-mechanism = PLAIN
         bootstrap-servers = "tcp://server1:port1,tcp://server2:port2,tcp://server3:port3"
         username = test_username
-        password = test_password
+        password = test_password_w/special_char
     }
 
     connection {


### PR DESCRIPTION
When credentials of Hono-connection contain special chars (like slash), the generated URI is not valid.
- credentials encoding is added
- tests are updated to cover this case

Signed-off-by: Andrey Balarev <andrey.balarev@bosch.io>