### PR TITLE
Hono connection address suffix added - hono tenant id

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/hono/DefaultHonoConnectionFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/hono/DefaultHonoConnectionFactory.java
@@ -16,6 +16,8 @@ import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Set;
 
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
 import org.eclipse.ditto.connectivity.model.HonoAddressAlias;
 import org.eclipse.ditto.connectivity.model.UserPasswordCredentials;
 import org.eclipse.ditto.connectivity.service.config.DefaultHonoConfig;
@@ -33,6 +35,8 @@ public final class DefaultHonoConnectionFactory extends HonoConnectionFactory {
 
     private final HonoConfig honoConfig;
 
+    private ConnectionId connectionId;
+
     /**
      * Constructs a {@code DefaultHonoConnectionFactory} for the specified arguments.
      *
@@ -42,6 +46,11 @@ public final class DefaultHonoConnectionFactory extends HonoConnectionFactory {
      */
     public DefaultHonoConnectionFactory(final ActorSystem actorSystem, final Config config) {
         honoConfig = new DefaultHonoConfig(actorSystem);
+    }
+
+    @Override
+    protected void preConversion(final Connection honoConnection) {
+        connectionId = honoConnection.getId();
     }
 
     @Override
@@ -76,12 +85,14 @@ public final class DefaultHonoConnectionFactory extends HonoConnectionFactory {
 
     @Override
     protected String resolveSourceAddress(final HonoAddressAlias honoAddressAlias) {
-        return MessageFormat.format("hono.{0}", honoAddressAlias.getAliasValue());
+        return MessageFormat.format("hono.{0}.{1}",
+                honoAddressAlias.getAliasValue(), connectionId);
     }
 
     @Override
     protected String resolveTargetAddress(final HonoAddressAlias honoAddressAlias) {
-        return MessageFormat.format("hono.{0}/'{{thing:id}}'", honoAddressAlias.getAliasValue());
+        return MessageFormat.format("hono.{0}.{1}/'{{thing:id}}'",
+                honoAddressAlias.getAliasValue(), connectionId);
     }
 
 }

--- a/connectivity/service/src/test/resources/hono-connection-custom-expected.json
+++ b/connectivity/service/src/test/resources/hono-connection-custom-expected.json
@@ -7,7 +7,7 @@
   "sources": [
     {
       "addresses": [
-        "hono.telemetry"
+        "hono.telemetry.test-connection-id"
       ],
       "consumerCount": 1,
       "qos": 0,
@@ -32,7 +32,7 @@
         "implicitStandaloneThingCreation"
       ],
       "replyTarget": {
-        "address": "hono.command/{{thing:id}}",
+        "address": "hono.command.test-connection-id/{{thing:id}}",
         "headerMapping": {
           "device_id": "custom_value1",
           "user_key1": "user_value1",
@@ -48,7 +48,7 @@
     },
     {
       "addresses": [
-        "hono.event"
+        "hono.event.test-connection-id"
       ],
       "consumerCount": 1,
       "qos": 1,
@@ -72,7 +72,7 @@
         "implicitStandaloneThingCreation"
       ],
       "replyTarget": {
-        "address": "hono.command/{{thing:id}}",
+        "address": "hono.command.test-connection-id/{{thing:id}}",
         "headerMapping": {
           "device_id": "{{ thing:id }}",
           "subject": "custom_value2",
@@ -88,7 +88,7 @@
     },
     {
       "addresses": [
-        "hono.command_response"
+        "hono.command_response.test-connection-id"
       ],
       "consumerCount": 1,
       "qos": 0,
@@ -120,7 +120,7 @@
   ],
   "targets": [
     {
-      "address": "hono.command/{{thing:id}}",
+      "address": "hono.command.test-connection-id/{{thing:id}}",
       "topics": [
         "_/_/things/live/messages",
         "_/_/things/live/commands"
@@ -137,7 +137,7 @@
       }
     },
     {
-      "address": "hono.command/{{thing:id}}",
+      "address": "hono.command.test-connection-id/{{thing:id}}",
       "topics": [
         "_/_/things/twin/events",
         "_/_/things/live/events"

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
@@ -41,15 +41,15 @@ Runtime, these are resolved as following:
 * `event` -> `{%raw%}hono.event.{{connection:id}}{%endraw%}`
 * `telemetry` -> `{%raw%}hono.telemetry.{{connection:id}}{%endraw%}`
 * `command_response` -> `{%raw%}hono.command_response.{{connection:id}}{%endraw%}`
- 
-Note: The {{connection:id}} will be replaced by the value of connectionId
+
+Note: The `{%raw%}{{connection:id}}{%endraw%}` will be replaced by the value of connectionId
 
 #### Source reply target
 Similar to source addresses, the reply target `address` is an alias as well. The single valid value for it is `command`. 
 It is resolved to Kafka topic/key like this:
 * `command` -> `{%raw%}hono.command.{{connection:id}}/<thingId>{%endraw%}` (&lt;thingId> is substituted by thing ID value).
 
-Note: The {{connection:id}} will be replaced by the value of connectionId
+Note: The `{%raw%}{{connection:id}}{%endraw%}` will be replaced by the value of connectionId
 
 The needed header mappings for the `replyTarget` are also populated automatically at runtime and there is 
 no need to specify them in the connection definition. Any of the following specified value will be substituted (i.e. ignored).
@@ -101,7 +101,9 @@ and [Header mapping for connections](connectivity-header-mapping.html).
 #### Target address 
 The target `address` is specified as an alias and the only valid alias is `command`. 
 It is automatically resolved at runtime to the following Kafka topic/key:
-* `command` -> `hono.command/<thingId>` (&lt;thingId> is substituted by thing ID value).
+* `command` -> `{%raw%}hono.command.{{connection:id}}/<thingId>{%endraw%}` (&lt;thingId> is substituted by thing ID value).
+
+Note: The `{%raw%}{{connection:id}}{%endraw%}` will be replaced by the value of connectionId
 
 #### Target header mapping
 The target `headerMapping` section is also populated automatically at runtime and there is

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
@@ -8,13 +8,16 @@ permalink: connectivity-protocol-bindings-hono.html
 Consume messages from Eclipse Hono through Apache Kafka brokers and send messages to 
 Eclipse Hono the same manner as [Kafka connection](connectivity-protocol-bindings-kafka2.html) does.
 
-This connection type is created just for convenience - to avoid the need the user to be aware of the specific 
+This connection type is implemented just for convenience - to avoid the need the user to be aware of the specific 
 header mappings, address formats and Kafka specificConfig, which are required to connect to Eclipse Hono. 
 These specifics are applied automatically at runtime for the connections of type Hono.
 
 Hono connection is based on Kafka connection and uses it behind the scenes, so most of the 
 [Kafka connection documentation](connectivity-protocol-bindings-kafka2.html) is valid for Hono connection too, 
-but with the following specifics (exceptions): 
+but with some exceptions, described bellow.
+
+#### Important note
+During the creation of hono connection, the connection ID must be provided to be the same as `Hono-tenantId`. This is needed to match the Kafka topics (aka connection addresses) to the topics on which Hono will send and listen to. See bellow sections [Source addresses](#source-addresses), [Source reply target](#source-reply-target) and [Target Address](#target-address)
 
 ## Specific Hono connection configuration
 
@@ -30,20 +33,23 @@ protocol identifier and the host name of `base-uri` to form the connection URI l
 
 Note: If any of these parameters has to be changed, the service must be restarted to apply the new values.
 
-
 ### Source format
 #### Source addresses
 For a Hono connection source "addresses" are specified as aliases, which are resolved at runtime to Kafka topics to subscribe to. 
 Valid source addresses (aliases) are `event`, `telemetry` and `command_response`. 
 Runtime, these are resolved as following:
-* `event` -> `hono.event`
-* `telemetry` -> `hono.telemetry`
-* `command_response` -> `hono.command_response`
+* `event` -> `{%raw%}hono.event.{{connection:id}}{%endraw%}`
+* `telemetry` -> `{%raw%}hono.telemetry.{{connection:id}}{%endraw%}`
+* `command_response` -> `{%raw%}hono.command_response.{{connection:id}}{%endraw%}`
+ 
+Note: The {{connection:id}} will be replaced by the value of connectionId
 
 #### Source reply target
 Similar to source addresses, the reply target `address` is an alias as well. The single valid value for it is `command`. 
 It is resolved to Kafka topic/key like this:
-* `command` -> `hono.command/<thingId>` (&lt;thingId> is substituted by thing ID value).
+* `command` -> `{%raw%}hono.command.{{connection:id}}/<thingId>{%endraw%}` (&lt;thingId> is substituted by thing ID value).
+
+Note: The {{connection:id}} will be replaced by the value of connectionId
 
 The needed header mappings for the `replyTarget` are also populated automatically at runtime and there is 
 no need to specify them in the connection definition. Any of the following specified value will be substituted (i.e. ignored).


### PR DESCRIPTION
Resolves https://github.com/eclipse-ditto/ditto/issues/1574 
Address resolving for hono connections is fixed to include a hono-tenant suffix. 
Assuming there would be no more than 1 connection between ditto and hono, the connectionId is used for this suffix. 
Therefore the connectionId must be set during creation to be the same as hono-tenant-id