### PR TITLE
[#1592] provide "Bearer" authentication for devops resources controlled via UI

### DIFF
--- a/ui/index.css
+++ b/ui/index.css
@@ -46,6 +46,10 @@ body {
     padding-top: 60px;
 }
 
+#authorizationModal label {
+    display: inline;
+}
+
 .toast-header {
     color: #842029;
     background-color: #f8d7da;

--- a/ui/modules/api.js
+++ b/ui/modules/api.js
@@ -277,18 +277,25 @@ let authHeaderValue;
  * @param {boolean} forDevOps if true, the credentials for the dev ops api will be used.
  */
 export function setAuthHeader(forDevOps) {
-  if (forDevOps && Environments.current().useBasicAuth) {
-    authHeaderKey = 'Authorization';
-    authHeaderValue = 'Basic ' + window.btoa(Environments.current().usernamePasswordDevOps);
-  } else if (Environments.current().useBasicAuth) {
-    authHeaderKey = 'Authorization';
-    authHeaderValue = 'Basic ' + window.btoa(Environments.current().usernamePassword);
-  } else if (Environments.current().useDittoPreAuthenticatedAuth) {
-    authHeaderKey = 'x-ditto-pre-authenticated';
-    authHeaderValue = Environments.current().dittoPreAuthenticatedUsername;
+  if (forDevOps) {
+    if (Environments.current().devopsAuth === 'basic') {
+      authHeaderKey = 'Authorization';
+      authHeaderValue = 'Basic ' + window.btoa(Environments.current().usernamePasswordDevOps);
+    } else if (Environments.current().devopsAuth === 'bearer') {
+      authHeaderKey = 'Authorization';
+      authHeaderValue ='Bearer ' + Environments.current().bearerDevOps;
+    }
   } else {
-    authHeaderKey = 'Authorization';
-    authHeaderValue ='Bearer ' + Environments.current().bearer;
+    if (Environments.current().mainAuth === 'basic') {
+      authHeaderKey = 'Authorization';
+      authHeaderValue = 'Basic ' + window.btoa(Environments.current().usernamePassword);
+    } else if (Environments.current().mainAuth === 'pre') {
+      authHeaderKey = 'x-ditto-pre-authenticated';
+      authHeaderValue = Environments.current().dittoPreAuthenticatedUsername;
+    } else if (Environments.current().mainAuth === 'bearer') {
+      authHeaderKey = 'Authorization';
+      authHeaderValue ='Bearer ' + Environments.current().bearer;
+    }
   }
 }
 

--- a/ui/modules/environments/authorization.html
+++ b/ui/modules/environments/authorization.html
@@ -18,78 +18,94 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <h5>Basic Auth</h5>
-                <hr />
                 <div class="row">
-                    <div class="col-md-5">
-                        <label>Main User</label>
-                    </div>
-                    <div class="col-md-7">
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">Username</label>
-                            <input type="text" class="form-control form-control-sm" id="userName"></input>
+                    <h5>Basic Auth</h5>
+                    <hr />
+                    <div class="row">
+                        <div class="col-md-5">
+                            <input type="radio" id="main-userpass" name="main-auth" value="basic"></input>
+                            <label for="main-userpass">Main User</label>
                         </div>
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">Password</label>
-                            <input type="password" class="form-control form-control-sm" id="password"></input>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="userName" class="input-group-text">Username</label>
+                                <input type="text" class="form-control form-control-sm" id="userName"></input>
+                            </div>
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="password" class="input-group-text">Password</label>
+                                <input type="password" class="form-control form-control-sm" id="password"></input>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-5">
+                            <input type="radio" id="devops-userpass" name="devops-auth" value="basic"></input>
+                            <label for="devops-userpass">DevOps User<br /><small>(for Connections, optional)</small></label>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="devOpsUserName" class="input-group-text">DevOps Username</label>
+                                <input type="text" class="form-control form-control-sm" id="devOpsUserName"></input>
+                            </div>
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="devOpsPassword" class="input-group-text">DevOps Password</label>
+                                <input type="password" class="form-control form-control-sm" id="devOpsPassword"></input>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="row">
-                    <div class="col-md-5">
-                        <label>DevOps User<br /><small>(for Connections, optional)</small></label>
-                    </div>
-                    <div class="col-md-7">
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">DevOps Username</label>
-                            <input type="text" class="form-control form-control-sm" id="devOpsUserName"></input>
+                <div class="row mt-3">
+                    <h5>Bearer</h5>
+                    <hr />
+                    <div class="row">
+                        <div class="col-md-5">
+                            <input type="radio" id="main-bearer" name="main-auth" value="bearer"></input>
+                            <label for="main-bearer">Main User<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
                         </div>
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">DevOps Password</label>
-                            <input type="password" class="form-control form-control-sm" id="devOpsPassword"></input>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="bearer" class="input-group-text">Bearer</label>
+                                <input type="password" class="form-control form-control-sm" id="bearer"></input>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-5">
+                            <input type="radio" id="devops-bearer" name="devops-auth" value="bearer"></input>
+                            <label for="devops-bearer">DevOps User<br /><small>(JWT OAuth2.0 Bearer token, optional)</small></label>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="bearerDevOps" class="input-group-text">DevOps Bearer</label>
+                                <input type="password" class="form-control form-control-sm" id="bearerDevOps"></input>
+                            </div>
+                            <div class="input-group input-group-sm mb-1">
+                        </div>
+                    </div>
+                    </div>
+                </div>
+                <div class="row mt-3">
+                    <h5>Ditto Pre Authenticated</h5>
+                    <hr />
+                    <div class="row">
+                        <div class="col-md-5">
+                            <input type="radio" id="main-pre" name="main-auth" value="pre"></input>
+                            <label for="main-pre">Main User<br />
+                                <small>(via HTTP header 'x-ditto-pre-authenticated', must take the form
+                                    <code>prefix:suffix</code>)</small>
+                            </label>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="dittoPreAuthenticatedUsername" class="input-group-text">prefix:suffix</label>
+                                <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername"></input>
+                            </div>
                         </div>
                     </div>
                 </div>
                 <div class="input-group input-group-sm" style="flex-direction: row-reverse;">
                     <button class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal"
-                        id="authorizeBasic">Authorize</button>
-                </div>
-                <h5>Bearer</h5>
-                <hr />
-                <div class="row">
-                    <div class="col-md-5">
-                        <label>Main User<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
-                    </div>
-                    <div class="col-md-7">
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">Bearer</label>
-                            <input type="password" class="form-control form-control-sm" id="bearer"></input>
-                        </div>
-                    </div>
-                </div>
-                <div class="input-group input-group-sm" style="flex-direction: row-reverse;">
-                    <button class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal"
-                        id="authorizeBearer">Authorize</button>
-                </div>
-                <h5>Ditto Pre Authenticated</h5>
-                <hr />
-                <div class="row">
-                    <div class="col-md-5">
-                        <label>Main User<br />
-                            <small>(via HTTP header 'x-ditto-pre-authenticated', must take the form
-                                <code>prefix:suffix</code>)</small>
-                        </label>
-                    </div>
-                    <div class="col-md-7">
-                        <div class="input-group input-group-sm mb-1">
-                            <label class="input-group-text">Username</label>
-                            <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername"></input>
-                        </div>
-                    </div>
-                </div>
-                <div class="input-group input-group-sm" style="flex-direction: row-reverse;">
-                    <button class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal"
-                        id="authorizePreAuthenticated">Authorize</button>
+                        id="authorizeSubmit">Authorize</button>
                 </div>
             </div>
         </div>

--- a/ui/modules/environments/authorization.html
+++ b/ui/modules/environments/authorization.html
@@ -19,12 +19,12 @@
             </div>
             <div class="modal-body">
                 <div class="row">
-                    <h5>Basic Auth</h5>
+                    <h5>Main authentication</h5>
                     <hr />
                     <div class="row">
                         <div class="col-md-5">
                             <input type="radio" id="main-userpass" name="main-auth" value="basic"></input>
-                            <label for="main-userpass">Main User</label>
+                            <label for="main-userpass">Basic</label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
@@ -37,10 +37,42 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row pt-2">
+                        <div class="col-md-5">
+                            <input type="radio" id="main-bearer" name="main-auth" value="bearer"></input>
+                            <label for="main-bearer">Bearer<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="bearer" class="input-group-text">Bearer</label>
+                                <input type="password" class="form-control form-control-sm" id="bearer"></input>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row pt-2">
+                        <div class="col-md-5">
+                            <input type="radio" id="main-pre" name="main-auth" value="pre"></input>
+                            <label for="main-pre">Pre authenticated<br />
+                                <small>(via HTTP header 'x-ditto-pre-authenticated', must take the form
+                                    <code>prefix:suffix</code>)</small>
+                            </label>
+                        </div>
+                        <div class="col-md-7">
+                            <div class="input-group input-group-sm mb-1">
+                                <label for="dittoPreAuthenticatedUsername" class="input-group-text">prefix:suffix</label>
+                                <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername"></input>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row mt-3">
+                    <h5>DevOps authentication</h5>
+                    <small>(for Connections and administrative tasks, optional)</small>
+                    <hr />
                     <div class="row">
                         <div class="col-md-5">
                             <input type="radio" id="devops-userpass" name="devops-auth" value="basic"></input>
-                            <label for="devops-userpass">DevOps User<br /><small>(for Connections, optional)</small></label>
+                            <label for="devops-userpass">Basic<br /></label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
@@ -53,26 +85,10 @@
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="row mt-3">
-                    <h5>Bearer</h5>
-                    <hr />
-                    <div class="row">
-                        <div class="col-md-5">
-                            <input type="radio" id="main-bearer" name="main-auth" value="bearer"></input>
-                            <label for="main-bearer">Main User<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
-                        </div>
-                        <div class="col-md-7">
-                            <div class="input-group input-group-sm mb-1">
-                                <label for="bearer" class="input-group-text">Bearer</label>
-                                <input type="password" class="form-control form-control-sm" id="bearer"></input>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
+                    <div class="row pt-2">
                         <div class="col-md-5">
                             <input type="radio" id="devops-bearer" name="devops-auth" value="bearer"></input>
-                            <label for="devops-bearer">DevOps User<br /><small>(JWT OAuth2.0 Bearer token, optional)</small></label>
+                            <label for="devops-bearer">Bearer<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
@@ -82,25 +98,6 @@
                             <div class="input-group input-group-sm mb-1">
                         </div>
                     </div>
-                    </div>
-                </div>
-                <div class="row mt-3">
-                    <h5>Ditto Pre Authenticated</h5>
-                    <hr />
-                    <div class="row">
-                        <div class="col-md-5">
-                            <input type="radio" id="main-pre" name="main-auth" value="pre"></input>
-                            <label for="main-pre">Main User<br />
-                                <small>(via HTTP header 'x-ditto-pre-authenticated', must take the form
-                                    <code>prefix:suffix</code>)</small>
-                            </label>
-                        </div>
-                        <div class="col-md-7">
-                            <div class="input-group input-group-sm mb-1">
-                                <label for="dittoPreAuthenticatedUsername" class="input-group-text">prefix:suffix</label>
-                                <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername"></input>
-                            </div>
-                        </div>
                     </div>
                 </div>
                 <div class="input-group input-group-sm" style="flex-direction: row-reverse;">

--- a/ui/modules/environments/authorization.js
+++ b/ui/modules/environments/authorization.js
@@ -21,6 +21,7 @@ let dom = {
   bearer: null,
   userName: null,
   password: null,
+  bearerDevOps: null,
   devOpsUserName: null,
   devOpsPassword: null,
   dittoPreAuthenticatedUsername: null,
@@ -30,24 +31,50 @@ let dom = {
 export function ready() {
   Utils.getAllElementsById(dom);
 
-  document.getElementById('authorizeBearer').onclick = () => {
-    Environments.current().useBasicAuth = false;
-    Environments.current().useDittoPreAuthenticatedAuth = false;
-    Environments.current().bearer = dom.bearer.value;
-    Environments.environmentsJsonChanged('authorization');
+  document.getElementById('authorize').onclick = () => {
+    let mainAuth = Environments.current().mainAuth;
+    let devopsAuth = Environments.current().devopsAuth;
+
+    if (!mainAuth) {
+      if (dom.dittoPreAuthenticatedUsername.value && dom.dittoPreAuthenticatedUsername.value.length > 0) {
+        mainAuth = 'pre';
+      } else if (dom.bearer.value && dom.bearer.value.length > 0) {
+        mainAuth = 'bearer';
+      } else if (dom.userName.value && dom.userName.value.length > 0) {
+        mainAuth = 'basic';
+      }
+    }
+    if (!devopsAuth) {
+      if (dom.bearerDevOps.value && dom.bearerDevOps.value.length > 0) {
+        devopsAuth = 'bearer';
+      } else if (dom.devOpsUserName.value && dom.devOpsUserName.value.length > 0) {
+        devopsAuth = 'basic';
+      }
+    }
+
+    const mainAuths = document.querySelectorAll('input[name="main-auth"]');
+    for(let i = 0; i < mainAuths.length; i++) {
+      mainAuths[i].checked = mainAuths[i].value === mainAuth;
+    }
+
+    const devopsAuths = document.querySelectorAll('input[name="devops-auth"]');
+    for(let i = 0; i < devopsAuths.length; i++) {
+      devopsAuths[i].checked = devopsAuths[i].value === devopsAuth;
+    }
+
   };
 
-  document.getElementById('authorizeBasic').onclick = () => {
-    Environments.current().useBasicAuth = true;
-    Environments.current().useDittoPreAuthenticatedAuth = false;
+  document.getElementById('authorizeSubmit').onclick = () => {
+    const mainAuthSelector = document.querySelector('input[name="main-auth"]:checked');
+    const mainAuth = mainAuthSelector ? mainAuthSelector.value : undefined;
+    const devopsAuthSelector = document.querySelector('input[name="devops-auth"]:checked');
+    const devopsAuth = devopsAuthSelector ? devopsAuthSelector.value : undefined;
+    Environments.current().mainAuth = mainAuth;
+    Environments.current().devopsAuth = devopsAuth;
     Environments.current().usernamePassword = dom.userName.value + ':' + dom.password.value;
     Environments.current().usernamePasswordDevOps = dom.devOpsUserName.value + ':' + dom.devOpsPassword.value;
-    Environments.environmentsJsonChanged('authorization');
-  };
-
-  document.getElementById('authorizePreAuthenticated').onclick = () => {
-    Environments.current().useBasicAuth = false;
-    Environments.current().useDittoPreAuthenticatedAuth = true;
+    Environments.current().bearer = dom.bearer.value;
+    Environments.current().bearerDevOps = dom.bearerDevOps.value;
     Environments.current().dittoPreAuthenticatedUsername = dom.dittoPreAuthenticatedUsername.value;
     Environments.environmentsJsonChanged();
   };
@@ -63,6 +90,7 @@ export function onEnvironmentChanged() {
   dom.devOpsUserName.value = usernamePassword.split(':')[0];
   dom.devOpsPassword.value = usernamePassword.split(':')[1];
   dom.bearer.value = Environments.current().bearer ? Environments.current().bearer : '';
+  dom.bearerDevOps.value = Environments.current().bearerDevOps ? Environments.current().bearerDevOps : '';
   dom.dittoPreAuthenticatedUsername.value = Environments.current().dittoPreAuthenticatedUsername ?
                                             Environments.current().dittoPreAuthenticatedUsername :
                                             '';

--- a/ui/templates/environmentTemplates.json
+++ b/ui/templates/environmentTemplates.json
@@ -3,30 +3,33 @@
     "api_uri": "http://localhost:8080",
     "ditto_version": 3,
     "bearer": null,
+    "bearerDevOps": null,
     "defaultUsernamePassword": "ditto:ditto",
+    "defaultDittoPreAuthenticatedUsername": null,
     "defaultUsernamePasswordDevOps": "devops:foobar",
-    "useBasicAuth": true,
-    "useDittoPreAuthenticatedAuth": false,
-    "defaultDittoPreAuthenticatedUsername": null
+    "mainAuth": "basic",
+    "devopsAuth": "basic"
   },
   "local_ditto_ide": {
     "api_uri": "http://localhost:8080",
     "ditto_version": 3,
     "bearer": null,
+    "bearerDevOps": null,
     "defaultUsernamePassword": null,
-    "defaultUsernamePasswordDevOps": null,
-    "useBasicAuth": false,
-    "useDittoPreAuthenticatedAuth": true,
-    "defaultDittoPreAuthenticatedUsername": "pre:ditto"
+    "defaultDittoPreAuthenticatedUsername": "pre:ditto",
+    "defaultUsernamePasswordDevOps": "devops:foobar",
+    "mainAuth": "pre",
+    "devopsAuth": "basic"
   },
   "ditto_sandbox": {
     "api_uri": "https://ditto.eclipseprojects.io",
     "ditto_version": 3,
     "bearer": null,
+    "bearerDevOps": null,
     "defaultUsernamePassword": "ditto:ditto",
+    "defaultDittoPreAuthenticatedUsername": null,
     "defaultUsernamePasswordDevOps": null,
-    "useBasicAuth": true,
-    "useDittoPreAuthenticatedAuth": false,
-    "defaultDittoPreAuthenticatedUsername": null
+    "mainAuth": "basic",
+    "devopsAuth": null
   }
 }


### PR DESCRIPTION
* added radiobutton groups so that "Authorize" modal clearly shows/states which authentication to use where
* reduced to a single "Authorize" button in modal
* simplified environment a bit

Resolves: #1592

Screenshot of modal:
![Screen Shot 2023-03-06 at 20 12 36 PM](https://user-images.githubusercontent.com/1331526/223207898-d6031d9b-b094-4a18-8400-c9e83996bc78.png)
