### PR TITLE
fix reading configured WoT TD "json template" from system property

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -6822,6 +6822,7 @@ paths:
       description: Returns all connections.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -6874,6 +6875,7 @@ paths:
         Supported connection types are `amqp-091`, `amqp-10`, `mqtt`, `mqtt-5`, `kafka`, `hono` and `http-push`.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -6970,6 +6972,7 @@ paths:
       description: Returns the connection identified by the `connectionId` path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7011,6 +7014,7 @@ paths:
       description: Update the connection identified by the `connectionId` path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7085,6 +7089,7 @@ paths:
       description: Delete the connection identified by the `connectionId` path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7124,6 +7129,7 @@ paths:
         path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7175,6 +7181,7 @@ paths:
       description: Returns the status of the connection identified by the `connectionId` path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7216,6 +7223,7 @@ paths:
       description: Returns the metrics of the connection identified by the `connectionId` path parameter.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -7261,6 +7269,7 @@ paths:
         default. This allows to log possible errors on connection establishing.
       security:
         - DevOpsBasic: []
+        - DevOpsBearer: []
       tags:
         - Connections
       parameters:
@@ -9600,3 +9609,8 @@ components:
       type: http
       description: Eclipse Ditto devops user (devops) + password (foobar)
       scheme: basic
+    DevOpsBearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: A JSON Web Token issued by a supported OAuth 2.0 Identity Provider for the Eclipse Ditto devops user.

--- a/documentation/src/main/resources/openapi/sources/api-2-index.yml
+++ b/documentation/src/main/resources/openapi/sources/api-2-index.yml
@@ -399,3 +399,5 @@ components:
       $ref: './security/google.yml'
     DevOpsBasic:
       $ref: './security/devOpsBasic.yml'
+    DevOpsBearer:
+      $ref: './security/devOpsBearer.yml'

--- a/documentation/src/main/resources/openapi/sources/paths/connections/command.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/command.yml
@@ -14,7 +14,8 @@ post:
     Sends the command specified in the body to the connection identified by the `connectionId`
     path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/paths/connections/connectionId.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/connectionId.yml
@@ -13,7 +13,8 @@ get:
   description: |-
     Returns the connection identified by the `connectionId` path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:
@@ -57,7 +58,8 @@ put:
   description: |-
     Update the connection identified by the `connectionId` path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:
@@ -147,7 +149,8 @@ delete:
   description: |-
     Delete the connection identified by the `connectionId` path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/paths/connections/connections.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/connections.yml
@@ -13,7 +13,8 @@ get:
   description: |-
     Returns all connections.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:
@@ -68,7 +69,8 @@ post:
     prohibited.
     Supported connection types are `amqp-091`, `amqp-10`, `mqtt`, `mqtt-5`, `kafka`, `hono` and `http-push`.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/paths/connections/logs.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/logs.yml
@@ -16,7 +16,8 @@ get:
     `connectivity.commands:enableConnectionLogs`. When creating or opening an connection the logging is enabled per
     default. This allows to log possible errors on connection establishing.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/paths/connections/metrics.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/metrics.yml
@@ -13,7 +13,8 @@ get:
   description: |-
     Returns the metrics of the connection identified by the `connectionId` path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/paths/connections/status.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/connections/status.yml
@@ -13,7 +13,8 @@ get:
   description: |-
     Returns the status of the connection identified by the `connectionId` path parameter.
   security:
-    - DevOpsBasic: [ ]
+    - DevOpsBasic: []
+    - DevOpsBearer: []
   tags:
     - Connections
   parameters:

--- a/documentation/src/main/resources/openapi/sources/security/devOpsBearer.yml
+++ b/documentation/src/main/resources/openapi/sources/security/devOpsBearer.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+type: http
+scheme: bearer
+bearerFormat: JWT
+description: |-
+  A JSON Web Token issued by a supported OAuth 2.0 Identity Provider for the Eclipse Ditto devops user.

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/config/DefaultToThingDescriptionConfig.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/config/DefaultToThingDescriptionConfig.java
@@ -44,9 +44,13 @@ final class DefaultToThingDescriptionConfig implements ToThingDescriptionConfig 
 
     private DefaultToThingDescriptionConfig(final ScopedConfig scopedConfig) {
         basePrefix = scopedConfig.getString(ConfigValue.BASE_PREFIX.getConfigPath());
-        jsonTemplate = JsonFactory.readFrom(
-                scopedConfig.getValue(ConfigValue.JSON_TEMPLATE.getConfigPath()).render(ConfigRenderOptions.concise())
-        ).asObject();
+        final String jsonTemplateRendered =
+                scopedConfig.getValue(ConfigValue.JSON_TEMPLATE.getConfigPath()).render(ConfigRenderOptions.concise());
+        final String jsonTemplateStrippedStartEndQuotes =
+                (jsonTemplateRendered.startsWith("\"{") && jsonTemplateRendered.endsWith("}\"")) ?
+                jsonTemplateRendered.substring(1, jsonTemplateRendered.length()-1) : jsonTemplateRendered;
+        final String replaceEscapedQuotesJsonTemplate = jsonTemplateStrippedStartEndQuotes.replace("\\\"", "\"");
+        jsonTemplate = JsonFactory.readFrom(replaceEscapedQuotesJsonTemplate).asObject();
         placeholders = JsonFactory.readFrom(
                 scopedConfig.getValue(ConfigValue.PLACEHOLDERS.getConfigPath()).render(ConfigRenderOptions.concise())
         ).asObject()


### PR DESCRIPTION
* preserving the object structure

The problem currently is that when e.g. configuring the "json template" to add to a TD using system properties, like:
```
-Dditto.things.wot.to-thing-description.json-template="{\"security\":\"basic_sc\",\"securityDefinitions\":{\"basic_sc\":{\"in\":\"header\",\"scheme\":\"basic\"}},\"support\":\"https://www.eclipse.org/ditto/\"}"
```
This can't be parsed as a surrounding quote is inserted and the complete string is interpreted as JSON string.

Due to the nature of HOCON config I did not see another way other than stripping the `"` from e.g. a configured object: `"{}"` and also un-escaping all contained escaped strings.