### PR TITLE
Fixed filtering desired properties signals. #1599

### DIFF
--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
@@ -127,9 +127,11 @@ import org.eclipse.ditto.protocol.ProtocolFactory;
 import org.eclipse.ditto.protocol.TopicPath;
 import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
 import org.eclipse.ditto.things.model.Attributes;
+import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThing;
+import org.eclipse.ditto.things.model.signals.events.FeatureDesiredPropertiesModified;
 import org.eclipse.ditto.things.model.signals.events.ThingModified;
 import org.eclipse.ditto.things.model.signals.events.ThingModifiedEvent;
 import org.mockito.Mockito;
@@ -323,6 +325,14 @@ public final class TestConstants {
         public static final String ID = "thing";
         public static final ThingId THING_ID = ThingId.of(NAMESPACE, ID);
         public static final Thing THING = Thing.newBuilder().setId(THING_ID).build();
+
+    }
+
+    public static final class Feature {
+
+        public static final String FEATURE_ID = "Feature";
+        public static final FeatureProperties FEATURE_DESIRED_PROPERTIES = FeatureProperties.newBuilder()
+                .set("property", "test").build();
 
     }
 
@@ -984,6 +994,12 @@ public final class TestConstants {
         final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().readGrantedSubjects(readSubjects).build();
         return ThingModified.of(Things.THING.toBuilder().setAttributes(attributes).build(), 1,
                 TestConstants.INSTANT, dittoHeaders, TestConstants.METADATA);
+    }
+
+    public static ThingModifiedEvent<?> featureDesiredPropertiesModified(Collection<AuthorizationSubject> readSubjects) {
+        DittoHeaders dittoHeaders = DittoHeaders.newBuilder().readGrantedSubjects(readSubjects).build();
+        return FeatureDesiredPropertiesModified.of(Things.THING_ID, Feature.FEATURE_ID,
+                Feature.FEATURE_DESIRED_PROPERTIES, 1, null, dittoHeaders, null);
     }
 
     public static MessageCommand<?, ?> sendThingMessage(final Collection<AuthorizationSubject> readSubjects) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/SignalFilterTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/SignalFilterTest.java
@@ -78,11 +78,11 @@ public final class SignalFilterTest {
     private static final HeaderMapping HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(Collections.singletonMap("reply-to", "{{fn:delete()}}"));
 
-    private static final Set<AuthorizationSubject> READ_SUBJECTS =
-            Sets.newSet(newAuthSubject("authorized"), newAuthSubject("ditto"));
-
     @Parameterized.Parameters(name = "topic={0}, readSubjects={1}, configuredTargets={2}, expectedTargets={3}")
     public static Collection<Object[]> data() {
+
+        final Set<AuthorizationSubject> readSubjects =
+                Sets.newSet(newAuthSubject("authorized"), newAuthSubject("ditto"));
 
         final Target twinAuthd = ConnectivityModelFactory.newTargetBuilder()
                 .address("twin/authorized")
@@ -196,38 +196,38 @@ public final class SignalFilterTest {
 
         final Collection<Object[]> params = new ArrayList<>();
 
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd), Lists.list(twinAuthd)});
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd), Lists.list(twinAuthd)});
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd, liveAuthd),
+        params.add(new Object[]{TWIN_EVENTS, readSubjects, Lists.list(twinAuthd), Lists.list(twinAuthd)});
+        params.add(new Object[]{TWIN_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd), Lists.list(twinAuthd)});
+        params.add(new Object[]{TWIN_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd, liveAuthd),
                 Lists.list(twinAuthd)});
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd, liveAuthd, liveUnauthd),
+        params.add(new Object[]{TWIN_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd, liveAuthd, liveUnauthd),
                 Lists.list(twinAuthd)});
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS,
+        params.add(new Object[]{TWIN_EVENTS, readSubjects,
                 Lists.list(enrichedFiltered, enrichedNotFiltered1, enrichedNotFiltered2),
                 Lists.list(enrichedFiltered)});
-        params.add(new Object[]{TWIN_EVENTS, READ_SUBJECTS,
+        params.add(new Object[]{TWIN_EVENTS, readSubjects,
                 Lists.list(filteredEventTopicPath1, filteredEventTopicPath2, notFilteredEventTopicPath1, notFilteredEventTopicPath2),
                 Lists.list(filteredEventTopicPath1, filteredEventTopicPath2)});
 
-        params.add(new Object[]{LIVE_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd), emptyList()});
-        params.add(new Object[]{LIVE_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd), emptyList()});
-        params.add(new Object[]{LIVE_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd, liveAuthd),
+        params.add(new Object[]{LIVE_EVENTS, readSubjects, Lists.list(twinAuthd), emptyList()});
+        params.add(new Object[]{LIVE_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd), emptyList()});
+        params.add(new Object[]{LIVE_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd, liveAuthd),
                 Lists.list(liveAuthd)});
-        params.add(new Object[]{LIVE_EVENTS, READ_SUBJECTS, Lists.list(twinAuthd, twinUnauthd, liveAuthd, liveUnauthd),
+        params.add(new Object[]{LIVE_EVENTS, readSubjects, Lists.list(twinAuthd, twinUnauthd, liveAuthd, liveUnauthd),
                 Lists.list(liveAuthd)});
 
-        params.add(new Object[]{LIVE_MESSAGES, READ_SUBJECTS,
+        params.add(new Object[]{LIVE_MESSAGES, readSubjects,
                 Lists.list(twinAuthd, twinUnauthd, liveAuthd, liveUnauthd),
                 Lists.list(twinAuthd, liveAuthd)});
-        params.add(new Object[]{LIVE_MESSAGES, READ_SUBJECTS,
+        params.add(new Object[]{LIVE_MESSAGES, readSubjects,
                 Lists.list(filteredLiveMessageTopicPath1, filteredLiveMessageTopicPath2, notFilteredLiveMessageTopicPath),
                 Lists.list(filteredLiveMessageTopicPath1, filteredLiveMessageTopicPath2)});
 
-        params.add(new Object[]{POLICY_ANNOUNCEMENTS, READ_SUBJECTS,
+        params.add(new Object[]{POLICY_ANNOUNCEMENTS, readSubjects,
                 Lists.list(policyAuthd, policyUnauthd),
                 Lists.list(policyAuthd, policyUnauthd)});
 
-        params.add(new Object[]{CONNECTION_ANNOUNCEMENTS, READ_SUBJECTS,
+        params.add(new Object[]{CONNECTION_ANNOUNCEMENTS, readSubjects,
                 Lists.list(connectionAuthd, connectionUnauthd),
                 Lists.list(connectionAuthd, connectionUnauthd)});
 
@@ -273,7 +273,7 @@ public final class SignalFilterTest {
                         URI).targets(targets).build();
 
         final SignalFilter signalFilter = new SignalFilter(connection, connectionMonitorRegistry);
-        final List<Target> filteredTargets = signalFilter.filter(signal(signalTopic, READ_SUBJECTS));
+        final List<Target> filteredTargets = signalFilter.filter(signal(signalTopic, readSubjects));
         Assertions.assertThat(filteredTargets)
                 .isEqualTo(expectedTargets);
     }
@@ -346,22 +346,4 @@ public final class SignalFilterTest {
         }
     }
 
-    /**
-     * Test that target filtering works also for desired properties events. Issue #1599
-     */
-    @Test
-    public void testFilterFeatureDesiredPropertiesModified() {
-        Target target = ConnectivityModelFactory.newTargetBuilder().address("address")
-                .authorizationContext(newAuthContext(DittoAuthorizationContextType.UNSPECIFIED, AUTHORIZED, DUMMY))
-                .topics(ConnectivityModelFactory.newFilteredTopicBuilder(TWIN_EVENTS)
-                        .withFilter("like(resource:path,'/features/" + TestConstants.Feature.FEATURE_ID + "*')")
-                        .build()).build();
-        ConnectionId connectionId = ConnectionId.of("testFilterFeatureDesiredPropertiesModified");
-        Connection connection = TestConstants.createConnection(connectionId, target);
-        SignalFilter signalFilter = new SignalFilter(connection, connectionMonitorRegistry);
-        Signal<?> signal = TestConstants.featureDesiredPropertiesModified(READ_SUBJECTS);
-
-        List<Target> filteredTargets = signalFilter.filter(signal);
-        Assertions.assertThat(filteredTargets).hasSize(1).contains(target);
-    }
 }

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingEventToThingConverter.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingEventToThingConverter.java
@@ -175,6 +175,25 @@ public final class ThingEventToThingConverter {
                         ((FeaturePropertyModified) te).getPropertyValue()).build());
         mappers.put(FeaturePropertyDeleted.class, (te, tb) -> tb.build());
 
+        mappers.put(FeatureDesiredPropertiesCreated.class, (te, tb) -> tb.setFeature(Feature.newBuilder()
+                .desiredProperties(((FeatureDesiredPropertiesCreated) te).getDesiredProperties())
+                .withId(((FeatureDesiredPropertiesCreated) te).getFeatureId())
+                .build()).build());
+        mappers.put(FeatureDesiredPropertiesModified.class, (te, tb) -> tb.setFeature(Feature.newBuilder()
+                .desiredProperties(((FeatureDesiredPropertiesModified) te).getDesiredProperties())
+                .withId(((FeatureDesiredPropertiesModified) te).getFeatureId())
+                .build()).build());
+        mappers.put(FeatureDesiredPropertiesDeleted.class, (te, tb) -> tb.build());
+        mappers.put(FeatureDesiredPropertyCreated.class, (te, tb) ->
+                tb.setFeatureDesiredProperty(((FeatureDesiredPropertyCreated) te).getFeatureId(),
+                        ((FeatureDesiredPropertyCreated) te).getDesiredPropertyPointer(),
+                        ((FeatureDesiredPropertyCreated) te).getDesiredPropertyValue()).build());
+        mappers.put(FeatureDesiredPropertyModified.class, (te, tb) ->
+                tb.setFeatureDesiredProperty(((FeatureDesiredPropertyModified) te).getFeatureId(),
+                        ((FeatureDesiredPropertyModified) te).getDesiredPropertyPointer(),
+                        ((FeatureDesiredPropertyModified) te).getDesiredPropertyValue()).build());
+        mappers.put(FeatureDesiredPropertyDeleted.class, (te, tb) -> tb.build());
+
         return mappers;
     }
 

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/signals/events/ThingEventToThingConverterTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/signals/events/ThingEventToThingConverterTest.java
@@ -21,11 +21,7 @@ import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.things.model.Attributes;
-import org.eclipse.ditto.things.model.Feature;
-import org.eclipse.ditto.things.model.FeatureProperties;
-import org.eclipse.ditto.things.model.Thing;
-import org.eclipse.ditto.things.model.ThingRevision;
+import org.eclipse.ditto.things.model.*;
 import org.junit.Test;
 
 /**
@@ -38,6 +34,8 @@ public final class ThingEventToThingConverterTest {
 
     private static final String ATTR_KEY_CITY = "city";
     private static final String KNOWN_CITY = "Immenstaad am Bodensee";
+
+    private static final JsonPointer DESIRED_PROPERTY_POINTER = JsonPointer.of("target_year_1");
 
     @Test
     public void ensureMergeWithExtraFieldsMergesCorrectly() {
@@ -123,5 +121,105 @@ public final class ThingEventToThingConverterTest {
         assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
         assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
         assertThat(thing.getAttributes()).contains(Attributes.newBuilder().set("foo", "bar").build());
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertiesCreated() {
+        long revision = 23L;
+        FeatureDesiredPropertiesCreated desiredPropertiesCreated = FeatureDesiredPropertiesCreated.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                TestConstants.Feature.FLUX_CAPACITOR_PROPERTIES, revision,null, DittoHeaders.empty(), null);
+
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertiesCreated);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
+        FeatureProperties desiredProperties = getDesiredProperties(thing);
+        assertThat(desiredProperties).isEqualTo(TestConstants.Feature.FLUX_CAPACITOR_PROPERTIES);
+    }
+
+    private FeatureProperties getDesiredProperties(Thing thing) {
+        Optional<Features> featuresOpt = thing.getFeatures();
+        assertThat(featuresOpt).isPresent();
+        Optional<Feature> featureOpt = featuresOpt.get().getFeature(TestConstants.Feature.FLUX_CAPACITOR_ID);
+        assertThat(featureOpt).isPresent();
+        Optional<FeatureProperties> desiredPropertiesOpt = featureOpt.get().getDesiredProperties();
+        assertThat(desiredPropertiesOpt).isPresent();
+        return desiredPropertiesOpt.get();
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertiesModified() {
+        long revision = 23L;
+        FeatureDesiredPropertiesModified desiredPropertiesModified = FeatureDesiredPropertiesModified.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                TestConstants.Feature.FLUX_CAPACITOR_PROPERTIES, revision,null, DittoHeaders.empty(), null);
+
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertiesModified);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
+        FeatureProperties desiredProperties = getDesiredProperties(thing);
+        assertThat(desiredProperties).isEqualTo(TestConstants.Feature.FLUX_CAPACITOR_PROPERTIES);
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertiesDeleted() {
+        long revision = 23L;
+        FeatureDesiredPropertiesDeleted desiredPropertiesDeleted = FeatureDesiredPropertiesDeleted.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID, revision,null,
+                DittoHeaders.empty(), null);
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertiesDeleted);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertyCreated() {
+        long revision = 23L;
+        JsonValue value = JsonValue.of(1955);
+        FeatureDesiredPropertyCreated desiredPropertyCreated = FeatureDesiredPropertyCreated.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID, DESIRED_PROPERTY_POINTER, value,
+                revision, null, DittoHeaders.empty(), null);
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertyCreated);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
+        FeatureProperties desiredProperties = getDesiredProperties(thing);
+        assertThat(desiredProperties).isEqualTo(FeatureProperties.newBuilder().set("target_year_1", 1955).build());
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertyModified() {
+        long revision = 23L;
+        JsonValue value = JsonValue.of(1955);
+        FeatureDesiredPropertyModified desiredPropertyModified = FeatureDesiredPropertyModified.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID, DESIRED_PROPERTY_POINTER, value,
+                revision, null, DittoHeaders.empty(), null);
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertyModified);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
+        FeatureProperties desiredProperties = getDesiredProperties(thing);
+        assertThat(desiredProperties).isEqualTo(FeatureProperties.newBuilder().set("target_year_1", 1955).build());
+    }
+
+    @Test
+    public void testThingEventToThingConvertsFeatureDesiredPropertyDeleted() {
+        long revision = 23L;
+        FeatureDesiredPropertyDeleted desiredPropertyDeleted = FeatureDesiredPropertyDeleted.of(
+                TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID, DESIRED_PROPERTY_POINTER, revision,
+                null, DittoHeaders.empty(), null);
+        Optional<Thing> thingOpt = ThingEventToThingConverter.thingEventToThing(desiredPropertyDeleted);
+        assertThat(thingOpt).isPresent();
+        Thing thing = thingOpt.get();
+        assertThat(thing.getEntityId()).contains(TestConstants.Thing.THING_ID);
+        assertThat(thing.getRevision()).contains(ThingRevision.newInstance(revision));
     }
 }


### PR DESCRIPTION
This PR is fixing a bug which caused that signal filtering did not work for desired properties changes. There was missing implementation of mapping to Thing model for such events. More details described in #1599.

I've added few unit tests covering new code and the bug itself. Also tested it manually with my K8s deployment with Kafka and it works as expected now.

I didn't want to change a code too much but maybe would worth to move the conversion function to ThingEvent interface an use polymorphism; so no one will forget to implement it anymore in case of new events.

fixes #1599