### PR TITLE
#1614 enabled creating a thing for a "MergeThing" when it does not yet exist

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -458,18 +458,20 @@ paths:
                       temperature: 44
         description: JSON representation of the thing to be modified.
     patch:
-      summary: Patch a thing with a specified ID
+      summary: Create or patch a thing with a specified ID
       description: |-
-        Patch an existing thing specified by the `thingId` path parameter.
+        Create or patch an existing thing specified by the `thingId` path parameter.
 
-        Patching a thing will merge the provided request body with the exisiting thing.
+        If the thing did not yet exist, it will be created.
+        For an existing thing, patching a thing will merge the provided request body with the existing thing values.
         This makes it possible to change only some parts of a thing in single request without providing the full thing
         structure in the request body.
 
 
         ### Patch a thing
 
-        With this resource it is possible to add, update or delete parts of an existing thing.
+        With this resource it is possible to add, update or delete parts of an existing thing or to create the thing if it
+        does not yet exist.
         The request body provided in *JSON merge patch* (RFC-7396) format will be merged with the existing thing.
         Notice that the `null` value in the JSON body will delete the specified JSON key from the thing.
         For further documentation of JSON merge patch see [RFC 7396](https://tools.ietf.org/html/rfc7396).
@@ -595,6 +597,23 @@ paths:
         - $ref: '#/components/parameters/ConditionParam'
         - $ref: '#/components/parameters/ChannelParam'
       responses:
+        '201':
+          description: The thing was successfully created.
+          headers:
+            ETag:
+              description: |-
+                The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+                "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+              schema:
+                type: string
+            Location:
+              description: The location of the created thing resource
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
         '204':
           description: The thing was successfully patched.
           headers:

--- a/documentation/src/main/resources/openapi/sources/paths/things/thing.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/things/thing.yml
@@ -278,18 +278,20 @@ put:
         }
     description: JSON representation of the thing to be modified.
 patch:
-  summary: Patch a thing with a specified ID
+  summary: Create or patch a thing with a specified ID
   description: |-
-    Patch an existing thing specified by the `thingId` path parameter.
+    Create or patch an existing thing specified by the `thingId` path parameter.
 
-    Patching a thing will merge the provided request body with the exisiting thing.
+    If the thing did not yet exist, it will be created.
+    For an existing thing, patching a thing will merge the provided request body with the existing thing values.
     This makes it possible to change only some parts of a thing in single request without providing the full thing
     structure in the request body.
 
 
     ### Patch a thing
 
-    With this resource it is possible to add, update or delete parts of an existing thing.
+    With this resource it is possible to add, update or delete parts of an existing thing or to create the thing if it
+    does not yet exist.
     The request body provided in *JSON merge patch* (RFC-7396) format will be merged with the existing thing.
     Notice that the `null` value in the JSON body will delete the specified JSON key from the thing.
     For further documentation of JSON merge patch see [RFC 7396](https://tools.ietf.org/html/rfc7396).
@@ -415,6 +417,23 @@ patch:
     - $ref: '../../parameters/conditionParam.yml'
     - $ref: '../../parameters/channelParam.yml'
   responses:
+    '201':
+      description: The thing was successfully created.
+      headers:
+        ETag:
+          description: |-
+            The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+            "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+          schema:
+            type: string
+        Location:
+          description: The location of the created thing resource
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/things/thing.yml'
     '204':
       description: The thing was successfully patched.
       headers:

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-things-create-or-modify.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-things-create-or-modify.md
@@ -19,30 +19,30 @@ all permissions set to true will be created.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/create`     |
-| **path**  | `/`     |
+| Field     | Value                                                                                                                     |
+|-----------|---------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/create`                                                                |
+| **path**  | `/`                                                                                                                       |
 | **value** | The complete thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/create` |
-| **path**   |        | `/`                      |
+| Field      |        | Value                                                                                                                    |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/create`                                                               |
+| **path**   |        | `/`                                                                                                                      |
 | **value**  |        | The created Thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
-| **status** | *code* |                          | 
-|            | `201`  | Success - the thing was created successfully.       |
+| **status** | *code* |                                                                                                                          | 
+|            | `201`  | Success - the thing was created successfully.                                                                            |
 
 ### Event
 
 The event emitted by Ditto after a thing was created.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/`     |
+| Field     | Value                                                                                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                               |
+| **path**  | `/`                                                                                                                     |
 | **value** | The created thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload) |
 
 **Example:** [Create a Thing.](protocol-examples-creatething.html)
@@ -54,10 +54,10 @@ This command modifies the thing specified by the `<namespace>` and `<thingId>` i
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/`     |
+| Field     | Value                                                                                                                 |
+|-----------|-----------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                            |
+| **path**  | `/`                                                                                                                   |
 | **value** | The complete thing as JSON.<br/>see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload) |
 
 For modifying an existing thing, the authorized subject needs WRITE permission.<br/>
@@ -65,23 +65,34 @@ If the thing does not yet exist, the same rules apply as described for the [crea
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/`                      |
-| **value**  |        | The created Thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if the Thing already existed. |
+If the Thing was created successfully: 
+
+| Field      |        | Value                                                                                                                    |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/create`                                                               |
+| **path**   |        | `/`                                                                                                                      |
+| **value**  |        | The created Thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 | **status** | _code_ |    
-|            | `201`  | Success - the Thing was created successfully.       |
-|            | `204`  | Success - the Thing was modified successfully.       |
+|            | `201`  | Success - the Thing was created successfully.                                                                            |
+
+If the Thing was modified successfully:
+
+| Field      |        | Value                                                      |
+|------------|--------|------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
+| **path**   |        | `/`                                                        |
+| **value**  |        | This field is not available, if the Thing already existed. |
+| **status** | _code_ |    
+|            | `204`  | Success - the Thing was modified successfully.             |
 
 ### Event
 
 The event emitted by Ditto after a thing was modified.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/`     |
+| Field     | Value                                                                                                                 |
+|-----------|-----------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                            |
+| **path**  | `/`                                                                                                                   |
 | **value** | The modified Thing as JSON<br/>see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify a Thing](protocol-examples-modifything.html)
@@ -95,42 +106,42 @@ The Attributes will be replaced by the JSON in the `value`.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/attributes`     |
+| Field     | Value                                                                                                                                                                        |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                   |
+| **path**  | `/attributes`                                                                                                                                                                |
 | **value** | The attributes of the thing as JSON, see property `attributes` of Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/attributes`                      |
+| Field      |        | Value                                                                                                                                                                                                                                            |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                                                                       |
+| **path**   |        | `/attributes`                                                                                                                                                                                                                                    |
 | **value**  |        | The created attributes as JSON, see property `attributes` of Things JSON schema. See [Ditto protocol payload (JSON).](protocol-specification.html#dittoProtocolPayload). This field is not available, if the thing already contained attributes. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - Attributes were created successfully.       |
-|            | `204`  | Success - Attributes were modified successfully.       |
+| **status** | _code_ |                                                                                                                                                                                                                                                  | 
+|            | `201`  | Success - Attributes were created successfully.                                                                                                                                                                                                  |
+|            | `204`  | Success - Attributes were modified successfully.                                                                                                                                                                                                 |
 
 ### Event
 
 If the thing already contained attributes before the command was applied and they were thus overwritten, a `modified` 
 event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/attributes`     |
+| Field     | Value                                                                                                                                                                                     |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                                                                                |
+| **path**  | `/attributes`                                                                                                                                                                             |
 | **value** | The modified attributes of the thing as JSON, see property `attributes` of the Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify Attributes](protocol-examples-modifyattributes.html)
 
 If the thing did not yet contain attributes before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/attributes`     |
+| Field     | Value                                                                                                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                                                                              |
+| **path**  | `/attributes`                                                                                                                                                                          |
 | **value** | The created Attributes of the Thing as JSON, see property `attributes` of the Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create Attributes](protocol-examples-createattributes.html)
@@ -143,43 +154,43 @@ The attribute (JSON) can be referenced hierarchically by applying [JSON Pointer 
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/attributes/<attributePath>`     |
-| **value** | The specific attribute of the Thing as JSON. |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify` |
+| **path**  | `/attributes/<attributePath>`                              |
+| **value** | The specific attribute of the Thing as JSON.               |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/attributes/<attributePath>`                      |
+| Field      |        | Value                                                                                         |
+|------------|--------|-----------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                    |
+| **path**   |        | `/attributes/<attributePath>`                                                                 |
 | **value**  |        | The created attribute as JSON. This field is not available, if the attribute already existed. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - The Attribute was created successfully.       |
-|            | `204`  | Success - The Attribute was modified successfully.       |
+| **status** | _code_ |                                                                                               | 
+|            | `201`  | Success - The Attribute was created successfully.                                             |
+|            | `204`  | Success - The Attribute was modified successfully.                                            |
 
 ### Event
 
 If the attribute already existed before the command was applied and it was thus overwritten by the command, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/attributes/<attributePath>`     |
-| **value** | The modified Attribute of the Thing as JSON value. |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified` |
+| **path**  | `/attributes/<attributePath>`                              |
+| **value** | The modified Attribute of the Thing as JSON value.         |
 
 **Example:** [Modify a single Attribute](protocol-examples-modifyattribute.html)
 
 If the attribute did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/attributes/<attributePath>`     |
-| **value** | The created Attribute of the Thing as JSON value. |
+| Field     | Value                                                     |
+|-----------|-----------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created` |
+| **path**  | `/attributes/<attributePath>`                             |
+| **value** | The created Attribute of the Thing as JSON value.         |
 
 **Example:** [Create a single Attribute](protocol-examples-createattribute.html)
 
@@ -190,42 +201,42 @@ The definition will be created in case it doesn't exist yet, otherwise the thing
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/definition`     |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify` |
+| **path**  | `/definition`                                              |
 | **value** | The specific definition of the Thing as JSON string value. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/definition`                      |
+| Field      |        | Value                                                                                                        |
+|------------|--------|--------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                   |
+| **path**   |        | `/definition`                                                                                                |
 | **value**  |        | The created definition as JSON string value. This field is not available, if the definition already existed. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - The definition was created successfully.       |
-|            | `204`  | Success - The definition was modified successfully.       |
+| **status** | _code_ |                                                                                                              | 
+|            | `201`  | Success - The definition was created successfully.                                                           |
+|            | `204`  | Success - The definition was modified successfully.                                                          |
 
 ### Event
 
 If the definition already existed before the command was applied and it was thus overwritten by the command, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/definition`     |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified` |
+| **path**  | `/definition`                                              |
 | **value** | The modified definition of the Thing as JSON string value. |
 
 **Example:** [Modify a definition](protocol-examples-modifythingdefinition.html)
 
 If the definition did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/definition`     |
+| Field     | Value                                                     |
+|-----------|-----------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created` |
+| **path**  | `/definition`                                             |
 | **value** | The created definition of the Thing as JSON string value. |
 
 **Example:** [Create a definition](protocol-examples-createthingdefinition.html)
@@ -237,42 +248,42 @@ The list of Features will be replaced by the JSON in the `value`.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features`     |
+| Field     | Value                                                                                                                                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                               |
+| **path**  | `/features`                                                                                                                                                              |
 | **value** | All Features of the Thing as JSON, see property `features` of Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features`                      |
+| Field      |        | Value                                                                                                                                                                                                                                   |
+|------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                                                              |
+| **path**   |        | `/features`                                                                                                                                                                                                                             |
 | **value**  |        | The created Features as JSON, see property `features` of Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if the thing already contained features. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - The Features were created successfully.       |
-|            | `204`  | Success - The Features were modified successfully.       |
+| **status** | _code_ |                                                                                                                                                                                                                                         | 
+|            | `201`  | Success - The Features were created successfully.                                                                                                                                                                                       |
+|            | `204`  | Success - The Features were modified successfully.                                                                                                                                                                                      |
 
 ### Event
 
 If the thing already contained Features before the command was applied and they were thus overwritten, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features`     |
+| Field     | Value                                                                                                                                                                        |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                                                                   |
+| **path**  | `/features`                                                                                                                                                                  |
 | **value** | All Features of the Thing as JSON, see property `features` of the Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify Features](protocol-examples-modifyfeatures.html)
 
 If the thing did not yet contain Features before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features`     |
+| Field     | Value                                                                                                                                                                      |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                                                                  |
+| **path**  | `/features`                                                                                                                                                                |
 | **value** | All Features of the Thing as JSON, see property `features` of the Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create Features](protocol-examples-createfeatures.html)
@@ -283,42 +294,42 @@ Create or modify a specific Feature (identified by the Feature ID in the `path`)
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>`     |
+| Field     | Value                                                                                                                             |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                        |
+| **path**  | `/features/<featureId>`                                                                                                           |
 | **value** | The specific Feature of the Thing as JSON. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>`                      |
+| Field      |        | Value                                                                                                                                                                            |
+|------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                       |
+| **path**   |        | `/features/<featureId>`                                                                                                                                                          |
 | **value**  |        | The created Feature as JSON. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if the Feature already existed. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - The Feature was created successfully.       |
-|            | `204`  | Success - the Feature was modified successfully.       |
+| **status** | _code_ |                                                                                                                                                                                  | 
+|            | `201`  | Success - The Feature was created successfully.                                                                                                                                  |
+|            | `204`  | Success - the Feature was modified successfully.                                                                                                                                 |
 
 ### Event
 
 If the Feature already existed before the command was applied and it was thus overwritten by the command, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>`     |
+| Field     | Value                                                                                                                             |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                        |
+| **path**  | `/features/<featureId>`                                                                                                           |
 | **value** | The modified Feature of the Thing as JSON. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify a single Feature](protocol-examples-modifyfeature.html)
 
 If the Feature did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>`     |
+| Field     | Value                                                                                                                                |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                            |
+| **path**  | `/features/<featureId>`                                                                                                              |
 | **value** | The created Feature of the Thing as JSON.<br/>see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create a single Feature](protocol-examples-createfeature.html)
@@ -329,42 +340,42 @@ Create or modify the Definition of a Feature (identified by the Feature ID in th
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>/definition`     |
+| Field     | Value                                                                                                                                                                                |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                           |
+| **path**  | `/features/<featureId>/definition`                                                                                                                                                   |
 | **value** | The Definition of the Feature as JSON array, see property `definition` of Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>/definition`                      |
+| Field      |        | Value                                                                                                                                                                                                                                                      |
+|------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                                                                                 |
+| **path**   |        | `/features/<featureId>/definition`                                                                                                                                                                                                                         |
 | **value**  |        | The created Definition of the Feature as JSON array, see property `definition` of Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if the Definition already existed. |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - the Definition was created successfully.       |
-|            | `204`  | Success - the Definition was modified successfully.       |
+| **status** | _code_ |                                                                                                                                                                                                                                                            | 
+|            | `201`  | Success - the Definition was created successfully.                                                                                                                                                                                                         |
+|            | `204`  | Success - the Definition was modified successfully.                                                                                                                                                                                                        |
 
 ### Event
 
 If the Feature Definition already existed before the command was applied and it was thus overwritten by the command, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>/definition`     |
+| Field     | Value                                                                                                                                                                                             |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                                                                                        |
+| **path**  | `/features/<featureId>/definition`                                                                                                                                                                |
 | **value** | The modified Definition of the Feature as JSON array, see property `properties` of the Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify Feature Definition](protocol-examples-modifydefinition.html)
 
 If the Feature Definition did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>/definition`     |
+| Field     | Value                                                                                                                                                                                          |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                                                                                      |
+| **path**  | `/features/<featureId>/definition`                                                                                                                                                             |
 | **value** | The created Definition of the Feature as JSON array, see property `definition` of the Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create Feature Definition](protocol-examples-createdefinition.html)
@@ -376,42 +387,42 @@ Create or modify the Properties of a Feature (identified by the Feature ID in th
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>/properties`     |
+| Field     | Value                                                                                                                                                                          |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                     |
+| **path**  | `/features/<featureId>/properties`                                                                                                                                             |
 | **value** | The Properties of the Feature as JSON, see property `properties` of Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>/properties`                      |
+| Field      |        | Value                                                                                                                                                                                                                                                             |
+|------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                                                                                        |
+| **path**   |        | `/features/<featureId>/properties`                                                                                                                                                                                                                                |
 | **value**  |        | The created Properties of the Feature as JSON object, see property `properties` of Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if Feature already contained Properties. |
-| **status** | *code* |                          | 
-|            | `201`  | Success - the Properties were created successfully.       |
-|            | `204`  | Success - the Properties were modified successfully.       |
+| **status** | *code* |                                                                                                                                                                                                                                                                   | 
+|            | `201`  | Success - the Properties were created successfully.                                                                                                                                                                                                               |
+|            | `204`  | Success - the Properties were modified successfully.                                                                                                                                                                                                              |
 
 ### Event
 
 If the Feature already contained Properties before the command was applied and they were thus overwritten by the 
 command, a `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>/properties`     |
+| Field     | Value                                                                                                                                                                                       |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                                                                                  |
+| **path**  | `/features/<featureId>/properties`                                                                                                                                                          |
 | **value** | The modified Properties of the Feature as JSON, see property `properties` of the Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify Feature Properties](protocol-examples-modifyproperties.html)
 
 If the Feature did not yet contain Properties before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>/properties`     |
+| Field     | Value                                                                                                                                                                                           |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                                                                                       |
+| **path**  | `/features/<featureId>/properties`                                                                                                                                                              |
 | **value** | The created Properties of the Feature as JSON object, see property `properties` of the Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create Feature Properties](protocol-examples-createproperties.html)
@@ -422,41 +433,41 @@ Create or modify the desired Properties of a Feature (identified by the Feature 
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>/desiredProperties`     |
+| Field     | Value                                                                                                                                                                                         |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                    |
+| **path**  | `/features/<featureId>/desiredProperties`                                                                                                                                                     |
 | **value** | The desired Properties of the Feature as JSON, see property `desiredProperties` of Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>/desiredProperties`                      |
+| Field      |        | Value                                                                                                                                                                                                                                                                                    |
+|------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                                                                                                                                                                                               |
+| **path**   |        | `/features/<featureId>/desiredProperties`                                                                                                                                                                                                                                                |
 | **value**  |        | The created desired Properties of the Feature as JSON object, see property `desiredProperties` of Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). This field is not available, if Feature already contained desired Properties. |
-| **status** | *code* |                          | 
-|            | `201`  | Success - the desired Properties were created successfully.       |
-|            | `204`  | Success - the desired Properties were modified successfully.       |
+| **status** | *code* |                                                                                                                                                                                                                                                                                          | 
+|            | `201`  | Success - the desired Properties were created successfully.                                                                                                                                                                                                                              |
+|            | `204`  | Success - the desired Properties were modified successfully.                                                                                                                                                                                                                             |
 
 ### Event
 
 If the Feature already contained desired Properties before the command was applied and they were thus overwritten by the command, a `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>/desiredProperties`     |
+| Field     | Value                                                                                                                                                                                                      |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`                                                                                                                                                 |
+| **path**  | `/features/<featureId>/desiredProperties`                                                                                                                                                                  |
 | **value** | The modified desired Properties of the Feature as JSON, see property `desiredProperties` of the Things JSON schema. See [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Modify Feature Desired Properties](protocol-examples-modifydesiredproperties.html)
 
 If the Feature did not yet contain desired Properties before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>/desiredProperties`     |
+| Field     | Value                                                                                                                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`                                                                                                                                                      |
+| **path**  | `/features/<featureId>/desiredProperties`                                                                                                                                                                      |
 | **value** | The created desired Properties of the Feature as JSON object, see property `desiredProperties` of the Things JSON schema at [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
 
 **Example:** [Create Feature Desired Properties](protocol-examples-createdesiredproperties.html)
@@ -469,43 +480,43 @@ The Property (JSON) can be referenced hierarchically by applying [JSON Pointer n
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>/properties/<propertyPath>`     |
-| **value** | The specific Property of the Feature as JSON. |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify` |
+| **path**  | `/features/<featureId>/properties/<propertyPath>`          |
+| **value** | The specific Property of the Feature as JSON.              |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>/properties/<propertyPath>`                      |
+| Field      |        | Value                                                                                                      |
+|------------|--------|------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                 |
+| **path**   |        | `/features/<featureId>/properties/<propertyPath>`                                                          |
 | **value**  |        | The created Property of the Feature as JSON. This field is not available, if the Property already existed. |
-| **status** | *code* |                          | 
-|            | `201`  | Success - the Property was created successfully.       |               | 
-|            | `204`  | Success - the Property was modified successfully.       |
+| **status** | *code* |                                                                                                            | 
+|            | `201`  | Success - the Property was created successfully.                                                           |               | 
+|            | `204`  | Success - the Property was modified successfully.                                                          |
 
 ### Event
 
 If the Feature Property already existed before the command was applied and it was thus overwritten by the command, a 
 `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>/properties/<propertyPath>`     |
-| **value** | The modified Property of the Thing as JSON. |
+| Field     | Value                                                      |
+|-----------|------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified` |
+| **path**  | `/features/<featureId>/properties/<propertyPath>`          |
+| **value** | The modified Property of the Thing as JSON.                |
 
 **Example:** [Modify a single Feature Property](protocol-examples-modifyproperty.html)
 
 If the Feature Property did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>/properties/<propertyPath>`     |
-| **value** | The created Property of the Thing as JSON. |
+| Field     | Value                                                     |
+|-----------|-----------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created` |
+| **path**  | `/features/<featureId>/properties/<propertyPath>`         |
+| **value** | The created Property of the Thing as JSON.                |
 
 **Example:** [Create a single Feature Property](protocol-examples-createproperty.html)
 
@@ -517,41 +528,41 @@ The Property (JSON) can be referenced hierarchically by applying [JSON Pointer n
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`     |
-| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`     |
-| **value** | The specific desired Property of the Feature as JSON. |
+| Field     | Value                                                           |
+|-----------|-----------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/modify`      |
+| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>` |
+| **value** | The specific desired Property of the Feature as JSON.           |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify` |
-| **path**   |        | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`                      |
+| Field      |        | Value                                                                                                              |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/modify`                                                         |
+| **path**   |        | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`                                                    |
 | **value**  |        | The created desired Property of the Feature as JSON. This field is not available, if the Property already existed. |
-| **status** | *code* |                          | 
-|            | `201`  | Success - the desired Property was created successfully.       |               | 
-|            | `204`  | Success - the desired Property was modified successfully.       |
+| **status** | *code* |                                                                                                                    | 
+|            | `201`  | Success - the desired Property was created successfully.                                                           |               | 
+|            | `204`  | Success - the desired Property was modified successfully.                                                          |
 
 ### Event
 
 If the Feature desired Property already existed before the command was applied and it was thus overwritten by the command, a `modified` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`     |
-| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`     |
-| **value** | The modified desired Property of the Thing as JSON. |
+| Field     | Value                                                           |
+|-----------|-----------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/modified`      |
+| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>` |
+| **value** | The modified desired Property of the Thing as JSON.             |
 
 **Example:** [Modify a single Feature desired Property](protocol-examples-modifydesiredproperty.html)
 
 If the Feature desired Property did not yet exist before the command was applied, a `created` event will be emitted.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`     |
-| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`     |
-| **value** | The created Property of the Thing as JSON. |
+| Field     | Value                                                           |
+|-----------|-----------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/created`       |
+| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>` |
+| **value** | The created Property of the Thing as JSON.                      |
 
 **Example:** [Create a single Feature desired Property](protocol-examples-createdesiredproperty.html)

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-things-merge.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-things-merge.md
@@ -5,16 +5,18 @@ tags: [protocol]
 permalink: protocol-specification-things-merge.html
 ---
 
-All `topics` contain the `<channel>` which may be either `twin` or `live`.<br/>
+All `topics` contain the `<channel>` which may be either `twin` or `live`.  
 For the meaning of those two channels see [Protocol specification](protocol-specification.html).
 
 For all merge commands the `value` field is provided in [JSON merge patch](https://tools.ietf.org/html/rfc7396)
-format. In case of conflicts with the existing thing, the value provided in the patch overwrites the existing value.
+format. In case of conflicts with the existing Thing, the value provided in the patch overwrites the existing value.
 
-## Merge a thing
+## Merge a Thing
 
-This command merges the thing specified by the `<namespace>` and `<thingName>` in the topic with
+This command merges the Thing specified by the `<namespace>` and `<thingName>` in the topic with
 the [JSON merge patch](https://tools.ietf.org/html/rfc7396) defined by the JSON in the `value`.
+
+If the Thing did not yet exist, it is created.
 
 ### Command
 
@@ -22,308 +24,320 @@ the [JSON merge patch](https://tools.ietf.org/html/rfc7396) defined by the JSON 
 |-----------|-------------------------|
 | **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
 | **path**  | `/`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [thing](basic-thing.html#thing) referenced in the `topic`. |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [Thing](basic-thing.html#thing) referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+If the Thing was created successfully:
+
+| Field      |        | Value                                                                                                                    |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/create`                                                               |
+| **path**   |        | `/`                                                                                                                      |
+| **value**  |        | The created Thing as JSON object, see [Ditto protocol payload (JSON)](protocol-specification.html#dittoProtocolPayload). |
+| **status** | _code_ |
+|            | `201`  | Success - the Thing was created successfully.                                                                            |
+
+If the Thing was merged successfully:
+
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/`                      |
-| **status** | *code* |                          | 
-|            | `204`  | Success - the thing was merged successfully.       |
+| **path**   |        | `/`                                                       |
+| **status** | *code* |                                                           | 
+|            | `204`  | Success - the Thing was merged successfully.              |
 
 ### Event
 
-The event emitted by Ditto after a thing was merged.
+The event emitted by Ditto after a Thing was merged.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/`     |
-| **value** |  The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                |
+|-----------|----------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                             |
+| **path**  | `/`                                                                                                                  |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the Thing referenced in the `topic`. |
 
-**Example:** [Merge a thing.](protocol-examples-mergething.html)
+**Example:** [Merge a Thing](protocol-examples-mergething.html)
 
-## Merge all attributes of a thing
+## Merge all attributes of a Thing
 
-Merge the attributes of a thing identified by the `<namespace>` and `<thingName>` in the `topic`. The attributes will be
+Merge the attributes of a Thing identified by the `<namespace>` and `<thingName>` in the `topic`. The attributes will be
 merged with the JSON merge patch provided in the `value` field.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/attributes`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [attributes](basic-thing.html#attributes) of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                     |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                 |
+| **path**  | `/attributes`                                                                                                                                                                             |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [attributes](basic-thing.html#attributes) of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/attributes`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - attributes were merged successfully.       |
+| **path**   |        | `/attributes`                                             |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - attributes were merged successfully.            |
 
 ### Event
 
-The event emitted by Ditto after the attributes of a thing were merged.
+The event emitted by Ditto after the attributes of a Thing were merged.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/attributes`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the attributes of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                               |
+| **path**  | `/attributes`                                                                                                                          |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the attributes of the Thing referenced in the `topic`. |
 
 **Example:** [Merge attributes](protocol-examples-mergeattributes.html)
 
-## Merge a single attribute of a thing
+## Merge a single attribute of a Thing
 
-Merge a specific attribute identified by the `<attributePath>` of the thing. The attribute (JSON) can be referenced
+Merge a specific attribute identified by the `<attributePath>` of the Thing. The attribute (JSON) can be referenced
 hierarchically by applying [JSON Pointer notation (RFC-6901)](https://tools.ietf.org/html/rfc6901).
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/attributes/<attributePath>`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [attribute](basic-thing.html#attributes) identified by `path`  of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                      |
+| **path**  | `/attributes/<attributePath>`                                                                                                                                                                                  |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [attribute](basic-thing.html#attributes) identified by `path`  of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/attributes/<attributePath>`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - The attribute was merged successfully.       |
+| **path**   |        | `/attributes/<attributePath>`                             |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - The attribute was merged successfully.          |
 
 ### Event
 
 The event emitted by Ditto after a single attribute was merged.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/attributes/<attributePath>`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the attribute identified by `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                      |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                   |
+| **path**  | `/attributes/<attributePath>`                                                                                                                              |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the attribute identified by `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge a single attribute](protocol-examples-mergeattribute.html)
 
-## Merge the definition of a thing
+## Merge the definition of a Thing
 
-Merge the definition of a thing.
-
-### Command
-
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/definition`     |
-| **value** | A valid [thing definition](basic-thing.html#definition) that replaces the definition of the thing referenced in the `topic`. |
-
-### Response
-
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/definition`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - The definition was merged successfully.       |
-
-## Merge the policy ID of a thing
-
-Merge the policy ID of a thing.
+Merge the definition of a Thing.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/policyId`     |
-| **value** | A valid [policy ID](basic-thing.html#access-control) that replaces the policyId of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                        |
+|-----------|------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                    |
+| **path**  | `/definition`                                                                                                                |
+| **value** | A valid [Thing definition](basic-thing.html#definition) that replaces the definition of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/definition`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - The definition was merged successfully.       |
+| **path**   |        | `/definition`                                             |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - The definition was merged successfully.         |
+
+## Merge the policy ID of a Thing
+
+Merge the policy ID of a Thing.
+
+### Command
+
+| Field     | Value                                                                                                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                               |
+| **path**  | `/policyId`                                                                                                             |
+| **value** | A valid [policy ID](basic-thing.html#access-control) that replaces the policyId of the Thing referenced in the `topic`. |
+
+### Response
+
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
+| **path**   |        | `/definition`                                             |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - The definition was merged successfully.         |
 
 ### Event
 
 The event emitted by Ditto after the definition was merged.
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/definition`     |
-| **value** |  The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the definition of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                               |
+| **path**  | `/definition`                                                                                                                          |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the definition of the Thing referenced in the `topic`. |
 
 **Example:** [Merge a definition](protocol-examples-mergethingdefinition.html)
 
-## Merge all features of a thing
+## Merge all features of a Thing
 
-Merge the features of a thing identified by the `<namespace>` and the `<thingName>` in the topic.<br/>
+Merge the features of a Thing identified by the `<namespace>` and the `<thingName>` in the topic.<br/>
 The list of features will be merged with the JSON merge patch provided in the `value`.
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features`     |
-| **value**| The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [features](basic-thing.html#features) of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                 |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                             |
+| **path**  | `/features`                                                                                                                                                                           |
+| **value**| The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [features](basic-thing.html#features) of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - The features were modified successfully.       |
+| **path**   |        | `/features`                                               |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - The features were modified successfully.        |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the features of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                             |
+| **path**  | `/features`                                                                                                                          |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the features of the Thing referenced in the `topic`. |
 
 **Example:** [Merge features](protocol-examples-mergefeatures.html)
 
-## Merge a single feature of a thing
+## Merge a single feature of a Thing
 
-Merge a specific feature (identified by the feature ID in the `path`) of the thing (identified by the `<namespace>` and
+Merge a specific feature (identified by the feature ID in the `path`) of the Thing (identified by the `<namespace>` and
 the `<thingName>` in the topic).
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the specific [feature](basic-thing.html#features) identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                                                    |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                |
+| **path**  | `/features/<featureId>`                                                                                                                                                                                                                  |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the specific [feature](basic-thing.html#features) identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>`                      |
-| **status** | _code_ |                          | 
-|            | `201`  | Success - The feature was created successfully.       |
+| **path**   |        | `/features/<featureId>`                                   |
+| **status** | _code_ |                                                           | 
+|            | `201`  | Success - The feature was created successfully.           |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the specific feature identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                   |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                |
+| **path**  | `/features/<featureId>`                                                                                                                                                                 |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the specific feature identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge a single feature](protocol-examples-mergefeature.html)
 
 ## Merge the definition of a feature
 
-Merge the definition of a feature (identified by the feature ID in the `path`) of the thing (identified by the
+Merge the definition of a feature (identified by the feature ID in the `path`) of the Thing (identified by the
 `<namespace>` and the `<thingName>` in the `topic`).
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>/definition`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [definition of the feature](basic-feature.html#feature-definition) identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                                                                         |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                                     |
+| **path**  | `/features/<featureId>/definition`                                                                                                                                                                                                                            |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [definition of the feature](basic-feature.html#feature-definition) identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>/definition`                      |
-| **status** | _code_ |                          | 
-|            | `204`  | Success - the definition was merged successfully.       |
+| **path**   |        | `/features/<featureId>/definition`                        |
+| **status** | _code_ |                                                           | 
+|            | `204`  | Success - the definition was merged successfully.         |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>/definition`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the definition of the feature identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                            |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                         |
+| **path**  | `/features/<featureId>/definition`                                                                                                                                                               |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the definition of the feature identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge feature definition](protocol-examples-mergefeaturedefinition.html)
 
 ## Merge all properties of a feature
 
-Merge the properties of a feature (identified by the feature ID in the `path`) of the thing (identified by the
+Merge the properties of a feature (identified by the feature ID in the `path`) of the Thing (identified by the
 `<namespace>` and the `<thingName>` in the `topic`).
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>/properties`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [properties of the feature](basic-feature.html#feature-properties) identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                                                                         |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                                     |
+| **path**  | `/features/<featureId>/properties`                                                                                                                                                                                                                            |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [properties of the feature](basic-feature.html#feature-properties) identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>/properties`                      |
-| **status** | *code* |                          | 
-|            | `204`  | Success - the properties were modified successfully.       |
+| **path**   |        | `/features/<featureId>/properties`                        |
+| **status** | *code* |                                                           | 
+|            | `204`  | Success - the properties were modified successfully.      |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>/properties`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the properties of the feature identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                            |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                         |
+| **path**  | `/features/<featureId>/properties`                                                                                                                                                               |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the properties of the feature identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge feature properties](protocol-examples-mergeproperties.html)
 
 ## Merge all desired properties of a feature
 
-Merge the desired properties of a feature (identified by the feature ID in the `path`) of the thing (identified by the
+Merge the desired properties of a feature (identified by the feature ID in the `path`) of the Thing (identified by the
 `<namespace>` and the `<thingName>` in the `topic`).
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>/desiredProperties`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [desired properties of the feature](basic-feature.html#feature-desired-properties) identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                                                                                         |
+|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                                                     |
+| **path**  | `/features/<featureId>/desiredProperties`                                                                                                                                                                                                                                     |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [desired properties of the feature](basic-feature.html#feature-desired-properties) identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>/desiredProperties`                      |
-| **status** | *code* |                          | 
-|            | `204`  | Success - the desired properties were modified successfully.       |
+| Field      |        | Value                                                        |
+|------------|--------|--------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge`    |
+| **path**   |        | `/features/<featureId>/desiredProperties`                    |
+| **status** | *code* |                                                              | 
+|            | `204`  | Success - the desired properties were modified successfully. |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>/desiredProperties`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the desired properties of the feature identified by the feature ID in the `path` of the thing referenced in the `topic`. |
+| Field     | Value                                                                                                                                                                                                    |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                                 |
+| **path**  | `/features/<featureId>/desiredProperties`                                                                                                                                                                |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the desired properties of the feature identified by the feature ID in the `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge feature desired properties](protocol-examples-mergedesiredproperties.html)
 
@@ -335,28 +349,28 @@ applying [JSON Pointer notation (RFC-6901)](https://tools.ietf.org/html/rfc6901)
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>/properties/<propertyPath>`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [property](basic-feature.html#feature-properties) identified by the property path and the feature ID in `path` of the thing referenced in the `topic`.|
+| Field     | Value                                                                                                                                                                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                                      |
+| **path**  | `/features/<featureId>/properties/<propertyPath>`                                                                                                                                                                                                              |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [property](basic-feature.html#feature-properties) identified by the property path and the feature ID in `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
+| Field      |        | Value                                                     |
+|------------|--------|-----------------------------------------------------------|
 | **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>/properties/<propertyPath>`                      |
-| **status** | *code* |                          | 
-|            | `204`  | Success - the property was merged successfully.       |
+| **path**   |        | `/features/<featureId>/properties/<propertyPath>`         |
+| **status** | *code* |                                                           | 
+|            | `204`  | Success - the property was merged successfully.           |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>/properties/<propertyPath>`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the property identified by the property path and the feature ID in `path` of the thing referenced in the `topic`.|
+| Field     | Value                                                                                                                                                                                             |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                          |
+| **path**  | `/features/<featureId>/properties/<propertyPath>`                                                                                                                                                 |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the property identified by the property path and the feature ID in `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge a single feature property](protocol-examples-mergeproperty.html)
 
@@ -368,27 +382,27 @@ applying [JSON Pointer notation (RFC-6901)](https://tools.ietf.org/html/rfc6901)
 
 ### Command
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`     |
-| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`     |
-| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [desired property](basic-feature.html#feature-desired-properties) identified by the desired property path and the feature ID in `path` of the thing referenced in the `topic`.|
+| Field     | Value                                                                                                                                                                                                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/commands/merge`                                                                                                                                                                                                                              |
+| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`                                                                                                                                                                                                                        |
+| **value** | The JSON value in [JSON merge patch](https://tools.ietf.org/html/rfc7396) format that is applied to the [desired property](basic-feature.html#feature-desired-properties) identified by the desired property path and the feature ID in `path` of the Thing referenced in the `topic`. |
 
 ### Response
 
-| Field      |        | Value                    |
-|------------|--------|--------------------------|
-| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge` |
-| **path**   |        | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`                      |
-| **status** | *code* |                          | 
-|            | `204`  | Success - the desired property was merged successfully.       |
+| Field      |        | Value                                                           |
+|------------|--------|-----------------------------------------------------------------|
+| **topic**  |        | `<namespace>/<thingName>/things/<channel>/commands/merge`       |
+| **path**   |        | `/features/<featureId>/desiredProperties/<desiredPropertyPath>` |
+| **status** | *code* |                                                                 | 
+|            | `204`  | Success - the desired property was merged successfully.         |
 
 ### Event
 
-| Field     | Value                   |
-|-----------|-------------------------|
-| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`     |
-| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`     |
-| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the property identified by the desired property path and the feature ID in `path` of the thing referenced in the `topic`.|
+| Field     | Value                                                                                                                                                                                                     |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **topic** | `<namespace>/<thingName>/things/<channel>/events/merged`                                                                                                                                                  |
+| **path**  | `/features/<featureId>/desiredProperties/<desiredPropertyPath>`                                                                                                                                           |
+| **value** | The [JSON merge patch](https://tools.ietf.org/html/rfc7396) that was applied to the property identified by the desired property path and the feature ID in `path` of the Thing referenced in the `topic`. |
 
 **Example:** [Merge a single feature desired property](protocol-examples-mergedesiredproperty.html)

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-things.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-things.md
@@ -51,12 +51,12 @@ The `"topic"` of such errors differ from the command `"topic"` - correlation is 
 
 The following table contains common error codes for Thing commands:
 
-| **status** | Value                    |
-|------------|--------------------------|
-|    `400`   | Bad Format - The request could not be completed due to malformed request syntax. |
-|    `401`   | Unauthorized - The request could not be completed due to missing authentication.       |
-|    `403`   | Forbidden - The Thing could not be modified as the requester had insufficient permissions ('WRITE' is required).          |
-|    `404`   | Not Found - The request could not be completed. The Thing with the given ID was not found in the context of the authenticated user.  |
+| **status** | Value                                                                                                                                                                                                                                                                    |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    `400`   | Bad Format - The request could not be completed due to malformed request syntax.                                                                                                                                                                                         |
+|    `401`   | Unauthorized - The request could not be completed due to missing authentication.                                                                                                                                                                                         |
+|    `403`   | Forbidden - The Thing could not be modified as the requester had insufficient permissions ('WRITE' is required).                                                                                                                                                         |
+|    `404`   | Not Found - The request could not be completed. The Thing with the given ID was not found in the context of the authenticated user.                                                                                                                                      |
 |    `412`   | Precondition Failed - A precondition for reading or writing the (sub-)resource failed. This will happen for write requests, if you specified an `If-Match` or `If-None-Match` header, which fails the precondition check against the current ETag of the (sub-)resource. |
-|    `413`   | Request Entity Too Large - The created or modified entity is larger than the configured limit (defaults to 100 kB).  |
-|    `429`   | Too many modifying requests are already outstanding to a specific Thing. |
+|    `413`   | Request Entity Too Large - The created or modified entity is larger than the configured limit (defaults to 100 kB).                                                                                                                                                      |
+|    `429`   | Too many modifying requests are already outstanding to a specific Thing.                                                                                                                                                                                                 |

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/commands/merge/mergething.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/commands/merge/mergething.md
@@ -2,7 +2,7 @@
 
 ```json
 {
-  "topic": "org.eclipse.ditto/fancy-thing/things/twin/commands/merge",
+  "topic": "org.eclipse.ditto/fancy-thing_53/things/twin/commands/merge",
   "headers": {
     "content-type": "application/merge-patch+json",
     "correlation-id": "<command-correlation-id>"
@@ -10,7 +10,6 @@
   "path": "/",
   "value": {
     "thingId": "org.eclipse.ditto:fancy-thing_53",
-    "policyId": "org.eclipse.ditto:the_policy_id",
     "definition": "org.eclipse.ditto:SomeModel:1.0.0",
     "attributes": {
       "location": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/commands/merge/mergethingresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/commands/merge/mergethingresponse.md
@@ -2,7 +2,7 @@
 
 ```json
 {
-  "topic": "org.eclipse.ditto/fancy-thing/things/twin/commands/merge",
+  "topic": "org.eclipse.ditto/fancy-thing_53/things/twin/commands/merge",
   "headers": {
     "correlation-id": "<preserved-command-correlation-id>"
   },

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRoute.java
@@ -352,6 +352,8 @@ public final class ThingsRoute extends AbstractRoute {
                                 payloadSource -> handlePerRequest(ctx, dittoHeaders, payloadSource,
                                         thingJson -> MergeThing.withThing(thingId,
                                                 thingFromJsonForPatch(thingJson, thingId, dittoHeaders),
+                                                createInlinePolicyJson(thingJson),
+                                                getCopyPolicyFrom(thingJson),
                                                 dittoHeaders)))
                         ),
                         // DELETE /things/<thingId>

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/modify/ModifyThing.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/modify/ModifyThing.java
@@ -35,6 +35,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
@@ -86,7 +87,7 @@ public final class ModifyThing extends AbstractCommand<ModifyThing> implements T
      * Json Field definition for the optional initial "inline" policy for usage in getEntity().
      */
     public static final JsonFieldDefinition<JsonObject> JSON_INLINE_POLICY =
-            JsonFactory.newJsonObjectFieldDefinition("_policy", FieldType.REGULAR, JsonSchemaVersion.V_2);
+            JsonFactory.newJsonObjectFieldDefinition(Policy.INLINED_FIELD_NAME, FieldType.REGULAR, JsonSchemaVersion.V_2);
 
     private final ThingId thingId;
     private final Thing thing;

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/signals/commands/modify/MergeThingTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/signals/commands/modify/MergeThingTest.java
@@ -62,7 +62,7 @@ public final class MergeThingTest {
     public void assertImmutability() {
         assertInstancesOf(MergeThing.class,
                 areImmutable(),
-                provided(JsonPointer.class, JsonValue.class, ThingId.class).isAlsoImmutable());
+                provided(JsonPointer.class, JsonValue.class, ThingId.class, JsonObject.class).isAlsoImmutable());
     }
 
     @Test

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/pre/ThingExistenceChecker.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/pre/ThingExistenceChecker.java
@@ -23,7 +23,7 @@ import org.eclipse.ditto.policies.enforcement.config.EnforcementConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.things.api.ThingsMessagingConstants;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThing;
+import org.eclipse.ditto.things.model.signals.commands.modify.ThingModifyCommand;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 
@@ -62,7 +62,7 @@ final class ThingExistenceChecker {
                 thingsShardRegion);
     }
 
-    public CompletionStage<Boolean> checkExistence(final ModifyThing signal) {
+    public CompletionStage<Boolean> checkExistence(final ThingModifyCommand<?> signal) {
         try {
             return thingIdLoader.asyncLoad(signal.getEntityId(),
                             actorSystem.dispatchers().lookup(ENFORCEMENT_CACHE_DISPATCHER))


### PR DESCRIPTION
* enhanced ModifyToCreateThingTransformer to also handle "MergeThing" in addition to "ModifyThing"
* adjusted ThingsRoute to also support using "_policy" and "_copyPolicyFrom"

Resolves: #1614