### PR TITLE
#1619 adjusted monitor to use in OutboundMappingProcessorActor

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -349,13 +349,21 @@ public final class OutboundMappingProcessorActor
     }
 
     @Override
-    protected void messageDiscarded(OutboundSignal message,  QueueOfferResult result) {
+    protected void messageDiscarded(final OutboundSignal message, final QueueOfferResult result) {
+        final Set<ConnectionMonitor> monitorsForOutboundSignal =
+                getMonitorsForOutboundSignal(message, MAPPED, LogType.MAPPED, responseMappedMonitor);
         if (QueueOfferResult.dropped().equals(result)) {
-            responseDispatchedMonitor.failure(message.getSource(), "Message is dropped as a result of backpressure strategy!");
+            monitorsForOutboundSignal.forEach(monitor ->
+                    monitor.failure(message.getSource(), "Message is dropped as a result of backpressure strategy!")
+            );
         } else if (result instanceof final QueueOfferResult.Failure failure) {
-            responseDispatchedMonitor.failure(message.getSource(), "Enqueue failed! - failure: {}", failure.cause());
+            monitorsForOutboundSignal.forEach(monitor ->
+                    monitor.failure(message.getSource(), "Enqueue failed! - failure: {}", failure.cause())
+            );
         } else {
-            responseDispatchedMonitor.failure(message.getSource(), "Enqueue failed without acknowledgement!");
+            monitorsForOutboundSignal.forEach(monitor ->
+                    monitor.failure(message.getSource(), "Enqueue failed without acknowledgement!")
+            );
         }
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
@@ -63,11 +63,11 @@ import akka.actor.Props;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
-@FixMethodOrder(MethodSorters.DEFAULT)
 /**
  * Tests in addition to {@link MessageMappingProcessorActorTest}
  * for {@link OutboundMappingProcessorActor} only.
  */
+@FixMethodOrder(MethodSorters.DEFAULT)
 public final class OutboundMappingProcessorActorTest {
 
     @ClassRule


### PR DESCRIPTION
* to not use `responseDispatchedMonitor`, but getMonitorsForOutboundSignal() with using `responseMappedMonitor` instead for responses

Fixes: #1619