### PR TITLE
#1644 support query params in the style where not comma separation is used, but duplicated keys

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
@@ -17,6 +17,7 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -136,11 +137,15 @@ public abstract class AbstractRoute extends AllDirectives {
     /**
      * Calculates a JsonFieldSelector from the passed {@code fieldsString}.
      *
-     * @param fieldsString the fields as string.
+     * @param fields the fields as potentially comma separated strings.
      * @return the Optional JsonFieldSelector
      */
-    protected static Optional<JsonFieldSelector> calculateSelectedFields(final Optional<String> fieldsString) {
-        return fieldsString.map(fs -> JsonFactory.newFieldSelector(fs, JSON_FIELD_SELECTOR_PARSE_OPTIONS));
+    protected static Optional<JsonFieldSelector> calculateSelectedFields(final List<String> fields) {
+        if (fields.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(JsonFactory.newFieldSelector(fields, JSON_FIELD_SELECTOR_PARSE_OPTIONS));
+        }
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
@@ -145,10 +145,10 @@ public final class ConnectionsRoute extends AbstractRoute {
                 concat(
                         get(() -> // GET /connections?ids-only=false
                                 parameterOptional(ConnectionsParameter.IDS_ONLY.toString(), idsOnly ->
-                                        parameterOptional(ConnectionsParameter.FIELDS.toString(), fieldsString ->
+                                        parameterList(ConnectionsParameter.FIELDS.toString(), fields ->
                                                 {
                                                     final Optional<JsonFieldSelector> selectedFields =
-                                                            calculateSelectedFields(fieldsString);
+                                                            calculateSelectedFields(fields);
                                                     return handlePerRequest(ctx, RetrieveConnections.newInstance(
                                                             idsOnly.map(Boolean::valueOf).orElseGet(() -> selectedFields
                                                                     .filter(sf -> sf.getPointers().size() == 1 &&
@@ -219,9 +219,9 @@ public final class ConnectionsRoute extends AbstractRoute {
                                 )
                         ),
                         get(() -> // GET /connections/<connectionId>
-                                parameterOptional(ConnectionsParameter.FIELDS.toString(), fieldsString ->
+                                parameterList(ConnectionsParameter.FIELDS.toString(), fields ->
                                         handlePerRequest(ctx, RetrieveConnection.of(connectionId,
-                                                calculateSelectedFields(fieldsString).orElse(null),
+                                                calculateSelectedFields(fields).orElse(null),
                                                 dittoHeaders)
                                         )
                                 )

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
@@ -150,9 +150,9 @@ public final class PoliciesRoute extends AbstractRoute {
         return pathEndOrSingleSlash(() ->
                 concat(
                         // GET /policies/<policyId>?fields=<fieldsString>
-                        get(() -> parameterOptional(PoliciesParameter.FIELDS.toString(), fieldsString ->
+                        get(() -> parameterList(PoliciesParameter.FIELDS.toString(), fields ->
                                 handlePerRequest(ctx, RetrievePolicy.of(policyId, dittoHeaders,
-                                        calculateSelectedFields(fieldsString).orElse(null)))
+                                        calculateSelectedFields(fields).orElse(null)))
                         )),
                         put(() -> // PUT /policies/<policyId>
                                 ensureMediaTypeJsonWithFallbacksThenExtractDataBytes(ctx, dittoHeaders,

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -267,7 +267,7 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
                     // /things/<thingId>
                     rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), thingId ->
                             parameterMap(parameters -> {
-                                final HashMap<String, String> params = new HashMap<>(parameters);
+                                final Map<String, String> params = new HashMap<>(parameters);
                                 params.put(ThingsParameter.IDS.toString(), thingId);
 
                                 return concat(

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
@@ -105,9 +105,9 @@ final class FeaturesRoute extends AbstractRoute {
         return pathEndOrSingleSlash(() ->
                 concat(
                         // GET /features?fields=<fieldsString>
-                        get(() -> parameterOptional(ThingsParameter.FIELDS.toString(), fieldsString ->
+                        get(() -> parameterList(ThingsParameter.FIELDS.toString(), fields ->
                                         handlePerRequest(ctx, RetrieveFeatures.of(thingId,
-                                                calculateSelectedFields(fieldsString).orElse(null),
+                                                calculateSelectedFields(fields).orElse(null),
                                                 dittoHeaders))
                                 )
                         ),
@@ -143,9 +143,9 @@ final class FeaturesRoute extends AbstractRoute {
                 pathEndOrSingleSlash(() ->
                         concat(
                                 // GET /features/{featureId}?fields=<fieldsString>
-                                get(() -> parameterOptional(ThingsParameter.FIELDS.toString(),
-                                                fieldsString -> handlePerRequest(ctx, RetrieveFeature.of(thingId, featureId,
-                                                        calculateSelectedFields(fieldsString).orElse(null),
+                                get(() -> parameterList(ThingsParameter.FIELDS.toString(), fields ->
+                                                handlePerRequest(ctx, RetrieveFeature.of(thingId, featureId,
+                                                        calculateSelectedFields(fields).orElse(null),
                                                         dittoHeaders))
                                         )
                                 ),
@@ -235,10 +235,10 @@ final class FeaturesRoute extends AbstractRoute {
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         // GET /features/{featureId}/properties?fields=<fieldsString>
-                                        get(() -> parameterOptional(ThingsParameter.FIELDS.toString(),
-                                                        fieldsString -> handlePerRequest(ctx,
+                                        get(() -> parameterList(ThingsParameter.FIELDS.toString(), fields ->
+                                                        handlePerRequest(ctx,
                                                                 RetrieveFeatureProperties.of(thingId, featureId,
-                                                                        calculateSelectedFields(fieldsString).orElse(null),
+                                                                        calculateSelectedFields(fields).orElse(null),
                                                                         dittoHeaders))
                                                 )
                                         ),
@@ -334,10 +334,10 @@ final class FeaturesRoute extends AbstractRoute {
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         // GET /features/{featureId}/desiredProperties?fields=<fieldsString>
-                                        get(() -> parameterOptional(ThingsParameter.FIELDS.toString(),
-                                                        fieldsString -> handlePerRequest(ctx,
+                                        get(() -> parameterList(ThingsParameter.FIELDS.toString(), fields ->
+                                                        handlePerRequest(ctx,
                                                                 RetrieveFeatureDesiredProperties.of(thingId, featureId,
-                                                                        calculateSelectedFields(fieldsString).orElse(null),
+                                                                        calculateSelectedFields(fields).orElse(null),
                                                                         dittoHeaders))
                                                 )
                                         ),

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRouteTest.java
@@ -19,8 +19,8 @@ import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
 import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
 import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.things.model.ThingIdInvalidException;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.things.model.signals.commands.exceptions.MissingThingIdsException;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingNotCreatableException;
 import org.eclipse.ditto.things.model.signals.commands.modify.MergeThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyPolicyId;
@@ -158,7 +158,7 @@ public final class ThingsRouteTest extends EndpointTestBase {
     public void getThingsWithEmptyIdsList() {
         final var result = underTest.run(HttpRequest.GET("/things?ids="));
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
-        final var expectedEx = MissingThingIdsException.newBuilder()
+        final var expectedEx = ThingIdInvalidException.newBuilder("")
                 .dittoHeaders(dittoHeaders)
                 .build();
         result.assertEntity(expectedEx.toJsonString());

--- a/json/src/main/java/org/eclipse/ditto/json/JsonFactory.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonFactory.java
@@ -647,6 +647,7 @@ public final class JsonFactory {
             final JsonParseOptions options) {
 
         final Collection<JsonPointer> selectors = StreamSupport.stream(fieldSelectorStrings.spliterator(), false)
+                .filter(fieldSelectorString -> !fieldSelectorString.isEmpty())
                 .map(fieldSelectorString -> ImmutableJsonFieldSelectorFactory.newInstance(fieldSelectorString, options))
                 .map(ImmutableJsonFieldSelectorFactory::newJsonFieldSelector)
                 .flatMap(foo -> foo.getPointers().stream())

--- a/json/src/test/java/org/eclipse/ditto/json/JsonFactoryTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/JsonFactoryTest.java
@@ -381,7 +381,15 @@ public final class JsonFactoryTest {
 
     @Test
     public void newFieldSelectorFromNullStringIsEmpty() {
-        final JsonFieldSelector fieldSelector = JsonFactory.newFieldSelector(null,
+        final JsonFieldSelector fieldSelector = JsonFactory.newFieldSelector((String) null,
+                JsonFactory.newParseOptionsBuilder().withoutUrlDecoding().build());
+
+        assertThat(fieldSelector).isEmpty();
+    }
+
+    @Test
+    public void newFieldSelectorFromEmptyStringListIsEmpty() {
+        final JsonFieldSelector fieldSelector = JsonFactory.newFieldSelector(Collections.emptyList(),
                 JsonFactory.newParseOptionsBuilder().withoutUrlDecoding().build());
 
         assertThat(fieldSelector).isEmpty();

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThingsTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThingsTest.java
@@ -183,7 +183,7 @@ public final class RetrieveThingsTest {
 
     @Test
     public void checkRetrieveThingsWithEmptyJsonFieldSelectorBehavesEquallyAsOmittingFields() {
-        final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector(null, JSON_PARSE_OPTIONS);
+        final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector((String) null, JSON_PARSE_OPTIONS);
         final RetrieveThings retrieveThings = RetrieveThings
                 .getBuilder(TestConstants.Thing.THING_ID, ThingId.inDefaultNamespace("AnotherThingId"))
                 .selectedFields(selectedFields)


### PR DESCRIPTION
* e.g.: `?fields=thingId&fields=policyId`

Resolves: #1644 