### PR TITLE
Fix WoT dispatcher starvation by adding timeouts to fetch models

### DIFF
--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -349,6 +349,10 @@ wot-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
 }
+wot-dispatcher-cache-loader {
+  type = Dispatcher
+  executor = "org.eclipse.ditto.internal.utils.metrics.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+}
 
 blocked-namespaces-dispatcher {
   type = Dispatcher

--- a/things/service/src/test/resources/test.conf
+++ b/things/service/src/test/resources/test.conf
@@ -170,6 +170,10 @@ wot-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"
 }
+wot-dispatcher-cache-loader {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+}
 
 blocked-namespaces-dispatcher {
   type = Dispatcher

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/provider/DefaultWotThingModelFetcher.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/provider/DefaultWotThingModelFetcher.java
@@ -79,7 +79,7 @@ final class DefaultWotThingModelFetcher implements WotThingModelFetcher {
         thingModelCache = CacheFactory.createCache(loader,
                 wotConfig.getCacheConfig(),
                 "ditto_wot_thing_model_cache",
-                actorSystem.dispatchers().lookup("wot-dispatcher"));
+                actorSystem.dispatchers().lookup("wot-dispatcher-cache-loader"));
     }
 
     @Override


### PR DESCRIPTION
When fetching WoT TMs there was no timeout and a `join()` on a CompletableFuture then potentially blocks a thread forever.

I added timeouts whenever TMs are fetched via CompletableFuture which should fix this.