### PR TITLE
add CPU limits for nginx based deployments for Helm chart

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.0  # chart version is effectively set by release-job
+version: 3.3.1  # chart version is effectively set by release-job
 appVersion: 3.3.0
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/dittoui-deployment.yaml
+++ b/deployment/helm/ditto/templates/dittoui-deployment.yaml
@@ -61,6 +61,6 @@ spec:
               cpu: {{ mulf .Values.dittoui.resources.cpu 1000 }}m
               memory: {{ .Values.dittoui.resources.memoryMi }}Mi
             limits:
-              # cpu: ""
+              cpu: {{ mulf .Values.dittoui.resources.cpu 1000 }}m
               memory: {{ .Values.dittoui.resources.memoryMi }}Mi
 {{- end }}

--- a/deployment/helm/ditto/templates/nginx-deployment.yaml
+++ b/deployment/helm/ditto/templates/nginx-deployment.yaml
@@ -86,7 +86,7 @@ spec:
               cpu: {{ mulf .Values.nginx.resources.cpu 1000 }}m
               memory: {{ .Values.nginx.resources.memoryMi }}Mi
             limits:
-              # cpu: ""
+              cpu: {{ mulf .Values.nginx.resources.cpu 1000 }}m
               memory: {{ .Values.nginx.resources.memoryMi }}Mi
           volumeMounts:
             - name: nginx-conf

--- a/deployment/helm/ditto/templates/swaggerui-deployment.yaml
+++ b/deployment/helm/ditto/templates/swaggerui-deployment.yaml
@@ -97,7 +97,7 @@ spec:
               cpu: {{ mulf .Values.swaggerui.resources.cpu 1000 }}m
               memory: {{ .Values.swaggerui.resources.memoryMi }}Mi
             limits:
-              # cpu: ""
+              cpu: {{ mulf .Values.swaggerui.resources.cpu 1000 }}m
               memory: {{ .Values.swaggerui.resources.memoryMi }}Mi
           volumeMounts:
             - name: swagger-ui-init-config


### PR DESCRIPTION
The Helm chart lacks to define "limits" for the nginx deployments.
That could cause for machines with a a lot of available CPUs that nginx would create a lot of worker threads, resuling in much memory needs.

Applied the configured "request" also to be used as "limit".