### PR TITLE
Fix blocking Akka dispatcher thread on WoT skeleton creation

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -571,8 +571,9 @@ public final class ConnectionPersistenceActor
     }
 
     @Override
-    public void onMutation(final Command<?> command, final ConnectivityEvent<?> event,
-            final WithDittoHeaders response, final boolean becomeCreated, final boolean becomeDeleted) {
+    public void onMutation(final Command<?> command, final CompletionStage<ConnectivityEvent<?>> event,
+            final CompletionStage<WithDittoHeaders> response, final boolean becomeCreated,
+            final boolean becomeDeleted) {
         if (command instanceof StagedCommand stagedCommand) {
             interpretStagedCommand(stagedCommand.withSenderUnlessDefined(getSender()));
         } else {
@@ -612,7 +613,7 @@ public final class ConnectionPersistenceActor
                             "Failed to handle staged command because required event wasn't present: <{}>",
                             command));
             case PERSIST_AND_APPLY_EVENT -> command.getEvent().ifPresentOrElse(
-                    event -> persistAndApplyEvent(event,
+                    event -> persistAndApplyEvent(CompletableFuture.completedStage(event),
                             (unusedEvent, connection) -> interpretStagedCommand(command.next())),
                     () -> log.error("Failed to handle staged command because required event wasn't present: <{}>",
                             command));

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/commands/AbstractCommandStrategies.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/commands/AbstractCommandStrategies.java
@@ -97,7 +97,7 @@ public abstract class AbstractCommandStrategies<C extends Command<?>, S, K, E ex
         if (commandStrategy != null) {
             context.getLog().withCorrelationId(command)
                     .debug("Applying command <{}>", command);
-            return commandStrategy.apply(context, entity, nextRevision, command).map(x -> x);
+            return (Result<E>) commandStrategy.apply(context, entity, nextRevision, command);
         } else {
             // this may happen when subclasses override the "isDefined" condition.
             return unhandled(context, entity, nextRevision, command);

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/EmptyResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/EmptyResult.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.ditto.base.model.signals.events.Event;
@@ -42,7 +43,7 @@ public final class EmptyResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public <F extends Event<?>> Result<F> map(final Function<E, F> mappingFunction) {
+    public <F extends Event<?>> Result<F> map(final Function<CompletionStage<E>, CompletionStage<F>> mappingFunction) {
         return getInstance();
     }
 

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ErrorResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ErrorResult.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
@@ -45,7 +46,7 @@ public final class ErrorResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public <F extends Event<?>> Result<F> map(final Function<E, F> mappingFunction) {
+    public <F extends Event<?>> Result<F> map(final Function<CompletionStage<E>, CompletionStage<F>> mappingFunction) {
         return new ErrorResult<>(dittoRuntimeException, errorCausingCommand);
     }
 }

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/QueryResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/QueryResult.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
@@ -47,7 +48,7 @@ public final class QueryResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public <F extends Event<?>> Result<F> map(final Function<E, F> mappingFunction) {
+    public <F extends Event<?>> Result<F> map(final Function<CompletionStage<E>, CompletionStage<F>> mappingFunction) {
         return new QueryResult<>(command, response);
     }
 }

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/Result.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/Result.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.ditto.base.model.signals.events.Event;
@@ -36,7 +37,7 @@ public interface Result<E extends Event<?>> {
      * @return the new result.
      * @since 2.0.0
      */
-    <F extends Event<?>> Result<F> map(Function<E, F> mappingFunction);
+    <F extends Event<?>> Result<F> map(Function<CompletionStage<E>, CompletionStage<F>> mappingFunction);
 
     /**
      * @return the empty result

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultFactory.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultFactory.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
@@ -41,6 +44,23 @@ public final class ResultFactory {
     public static <E extends Event<?>> Result<E> newMutationResult(final Command<?> command, final E eventToPersist,
             final WithDittoHeaders response) {
 
+        return newMutationResult(command, CompletableFuture.completedStage(eventToPersist),
+                CompletableFuture.completedStage(response));
+    }
+
+    /**
+     * Create a mutation result.
+     *
+     * @param command command that caused the mutation.
+     * @param eventToPersist event of the mutation.
+     * @param response response of the command.
+     * @param <E> type of the event.
+     * @return the result.
+     */
+    public static <E extends Event<?>> Result<E> newMutationResult(final Command<?> command,
+            final CompletionStage<E> eventToPersist,
+            final CompletionStage<WithDittoHeaders> response) {
+
         return new MutationResult<>(command, eventToPersist, response, false, false);
     }
 
@@ -58,6 +78,27 @@ public final class ResultFactory {
     public static <E extends Event<?>> Result<E> newMutationResult(final Command<?> command,
             final E eventToPersist,
             final WithDittoHeaders response,
+            final boolean becomeCreated,
+            final boolean becomeDeleted) {
+
+        return newMutationResult(command, CompletableFuture.completedStage(eventToPersist),
+                CompletableFuture.completedStage(response), becomeCreated, becomeDeleted);
+    }
+
+    /**
+     * Create a mutation result.
+     *
+     * @param command command that caused the mutation.
+     * @param eventToPersist event of the mutation.
+     * @param response response of the command.
+     * @param becomeCreated whether the actor should behave as if the entity is created.
+     * @param becomeDeleted whether the actor should behave as if the entity is deleted.
+     * @param <E> type of the event.
+     * @return the result.
+     */
+    public static <E extends Event<?>> Result<E> newMutationResult(final Command<?> command,
+            final CompletionStage<E> eventToPersist,
+            final CompletionStage<WithDittoHeaders> response,
             final boolean becomeCreated,
             final boolean becomeDeleted) {
 

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultVisitor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultVisitor.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.internal.utils.persistentactors.results;
 
+import java.util.concurrent.CompletionStage;
+
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
@@ -40,8 +42,8 @@ public interface ResultVisitor<E extends Event<?>> {
      * @param becomeCreated whether the actor should behave as if the entity is created.
      * @param becomeDeleted whether the actor should behave as if the entity is deleted.
      */
-    void onMutation(Command<?> command, E event, WithDittoHeaders response, boolean becomeCreated,
-            boolean becomeDeleted);
+    void onMutation(Command<?> command, CompletionStage<E> event, CompletionStage<WithDittoHeaders> response,
+            boolean becomeCreated, boolean becomeDeleted);
 
     /**
      * Evaluate a query result.

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/AbstractPolicyActionEvent.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/AbstractPolicyActionEvent.java
@@ -67,10 +67,10 @@ abstract class AbstractPolicyActionEvent<T extends AbstractPolicyActionEvent<T>>
      */
     protected SubjectsModifiedPartially aggregateWithSubjectCreatedOrModified(
             final Map<Label, Collection<Subject>> initialModifiedSubjects,
-            final Collection<PolicyActionEvent<?>> otherEvents) {
+            final Collection<PolicyActionEvent> otherEvents) {
 
         final Map<Label, Collection<Subject>> modifiedSubjects = new LinkedHashMap<>(initialModifiedSubjects);
-        for (final PolicyActionEvent<?> event : otherEvents) {
+        for (final PolicyActionEvent event : otherEvents) {
             if (event instanceof SubjectCreated) {
                 final SubjectCreated subjectCreated = (SubjectCreated) event;
                 final Set<Subject> mergedSubjects =
@@ -99,10 +99,10 @@ abstract class AbstractPolicyActionEvent<T extends AbstractPolicyActionEvent<T>>
      */
     protected SubjectsDeletedPartially aggregateWithSubjectDeleted(
             final Map<Label, Collection<SubjectId>> initialDeletedSubjectIds,
-            final Collection<PolicyActionEvent<?>> otherEvents) {
+            final Collection<PolicyActionEvent> otherEvents) {
 
         final Map<Label, Collection<SubjectId>> deletedSubjectIds = new LinkedHashMap<>(initialDeletedSubjectIds);
-        for (final PolicyActionEvent<?> event : otherEvents) {
+        for (final PolicyActionEvent event : otherEvents) {
             if (event instanceof SubjectDeleted) {
                 final SubjectDeleted subjectDeleted = (SubjectDeleted) event;
                 final Collection<SubjectId> existingSubjectIds = deletedSubjectIds.get(subjectDeleted.getLabel());

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyActionEvent.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyActionEvent.java
@@ -28,5 +28,5 @@ public interface PolicyActionEvent<T extends PolicyActionEvent<T>> extends Polic
      * @param otherPolicyActionEvents the collection of policy action events.
      * @return the aggregated event.
      */
-    PolicyEvent<?> aggregateWith(Collection<PolicyActionEvent<?>> otherPolicyActionEvents);
+    PolicyEvent<?> aggregateWith(Collection<PolicyActionEvent> otherPolicyActionEvents);
 }

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectCreated.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectCreated.java
@@ -202,7 +202,7 @@ public final class SubjectCreated extends AbstractPolicyActionEvent<SubjectCreat
     }
 
     @Override
-    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent<?>> otherPolicyActionEvents) {
+    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent> otherPolicyActionEvents) {
         final Map<Label, Collection<Subject>> initialCreatedSubjects =
                 Stream.of(0).collect(Collectors.toMap(i -> label, i -> Collections.singleton(subject),
                         (u, v) -> {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectDeleted.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectDeleted.java
@@ -188,7 +188,7 @@ public final class SubjectDeleted extends AbstractPolicyActionEvent<SubjectDelet
     }
 
     @Override
-    public SubjectsDeletedPartially aggregateWith(final Collection<PolicyActionEvent<?>> otherPolicyActionEvents) {
+    public SubjectsDeletedPartially aggregateWith(final Collection<PolicyActionEvent> otherPolicyActionEvents) {
         final Map<Label, Collection<SubjectId>> initialDeletedSubjectId =
                 Stream.of(0).collect(Collectors.toMap(i -> label, i -> Collections.singleton(subjectId),
                         (u, v) -> {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectModified.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectModified.java
@@ -202,7 +202,7 @@ public final class SubjectModified extends AbstractPolicyActionEvent<SubjectModi
     }
 
     @Override
-    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent<?>> otherPolicyActionEvents) {
+    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent> otherPolicyActionEvents) {
         final Map<Label, Collection<Subject>> initialModifiedSubjects =
                 Stream.of(0).collect(Collectors.toMap(i -> label, i -> Collections.singleton(subject),
                         (u, v) -> {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectsDeletedPartially.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectsDeletedPartially.java
@@ -190,7 +190,7 @@ public final class SubjectsDeletedPartially extends AbstractPolicyActionEvent<Su
     }
 
     @Override
-    public SubjectsDeletedPartially aggregateWith(final Collection<PolicyActionEvent<?>> otherPolicyActionEvents) {
+    public SubjectsDeletedPartially aggregateWith(final Collection<PolicyActionEvent> otherPolicyActionEvents) {
         return aggregateWithSubjectDeleted(deletedSubjectIds, otherPolicyActionEvents);
     }
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectsModifiedPartially.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/SubjectsModifiedPartially.java
@@ -184,7 +184,7 @@ public final class SubjectsModifiedPartially extends AbstractPolicyActionEvent<S
     }
 
     @Override
-    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent<?>> otherPolicyActionEvents) {
+    public SubjectsModifiedPartially aggregateWith(final Collection<PolicyActionEvent> otherPolicyActionEvents) {
         return aggregateWithSubjectCreatedOrModified(modifiedSubjects, otherPolicyActionEvents);
     }
 

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.policies.service.persistence.actors;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
@@ -245,12 +246,13 @@ public final class PolicyPersistenceActor
     }
 
     @Override
-    public void onMutation(final Command<?> command, final PolicyEvent<?> event, final WithDittoHeaders response,
+    public void onMutation(final Command<?> command, final CompletionStage<PolicyEvent<?>> event,
+            final CompletionStage<WithDittoHeaders> response,
             final boolean becomeCreated, final boolean becomeDeleted) {
 
         persistAndApplyEvent(event, (persistedEvent, resultingEntity) -> {
             if (shouldSendResponse(command.getDittoHeaders())) {
-                notifySender(getSender(), response);
+                response.thenAccept(rsp -> notifySender(getSender(), rsp));
             }
             if (becomeDeleted) {
                 becomeDeletedHandler();

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/AbstractPolicyCommandStrategyTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/AbstractPolicyCommandStrategyTest.java
@@ -21,10 +21,12 @@ import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.assertj.core.api.CompletableFutureAssert;
 import org.eclipse.ditto.base.model.auth.AuthorizationContext;
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
@@ -106,21 +108,27 @@ public abstract class AbstractPolicyCommandStrategyTest {
         final CommandStrategy.Context<PolicyId> context = getDefaultContext();
         final Result<?> result = applyStrategy(underTest, context, policy, command);
 
-        final ArgumentCaptor<T> event = ArgumentCaptor.forClass(expectedEventClass);
-        final ArgumentCaptor<R> response = ArgumentCaptor.forClass(expectedResponseClass);
+        final ArgumentCaptor<CompletionStage<T>> eventStage = ArgumentCaptor.forClass(CompletionStage.class);
+        final ArgumentCaptor<CompletionStage<WithDittoHeaders>> responseStage =
+                ArgumentCaptor.forClass(CompletionStage.class);
         final Dummy<T> mock = Dummy.mock();
         result.accept(cast(mock));
 
-        verify(mock).onMutation(any(), event.capture(), response.capture(), anyBoolean(), eq(false));
-        assertThat(event.getValue()).isInstanceOf(expectedEventClass);
-        assertThat(response.getValue()).isInstanceOf(expectedResponseClass);
+        verify(mock).onMutation(any(), eventStage.capture(), responseStage.capture(),
+                anyBoolean(), eq(false));
+        assertThat(eventStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(eventStage.getValue())
+                        .isCompletedWithValueMatching(t -> expectedEventClass.isAssignableFrom(t.getClass()));
+        assertThat(responseStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(responseStage.getValue())
+                .isCompletedWithValueMatching(t -> expectedResponseClass.isAssignableFrom(t.getClass()));
 
-        assertThat(event.getValue())
+        assertThat(eventStage.getValue().toCompletableFuture().join())
                 .describedAs("Event satisfactions failed for expected event of type '%s'",
                         expectedEventClass.getSimpleName())
                 .satisfies(eventSatisfactions);
-        assertThat(response.getValue())
-                .describedAs("Response predicate failed for expected response of type '%s'",
+        assertThat((R) responseStage.getValue().toCompletableFuture().join())
+                .describedAs("Response predicate failed for expected responseStage of type '%s'",
                         expectedResponseClass.getSimpleName())
                 .satisfies(responseSatisfactions);
     }
@@ -167,15 +175,22 @@ public abstract class AbstractPolicyCommandStrategyTest {
             final WithDittoHeaders expectedResponse,
             final boolean becomeDeleted) {
 
-        final ArgumentCaptor<T> event = ArgumentCaptor.forClass(eventClazz);
+        final ArgumentCaptor<CompletionStage<T>> eventStage = ArgumentCaptor.forClass(CompletionStage.class);
+        final ArgumentCaptor<CompletionStage<WithDittoHeaders>> responseStage =
+                ArgumentCaptor.forClass(CompletionStage.class);
 
         final Dummy<T> mock = Dummy.mock();
 
         result.accept(cast(mock));
 
-        verify(mock).onMutation(any(), event.capture(), eq(expectedResponse), anyBoolean(), eq(becomeDeleted));
-        assertThat(event.getValue()).isInstanceOf(eventClazz);
-        return event.getValue();
+        verify(mock).onMutation(any(), eventStage.capture(), responseStage.capture(), anyBoolean(), eq(becomeDeleted));
+        assertThat(eventStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(eventStage.getValue())
+                .isCompletedWithValueMatching(t -> eventClazz.isAssignableFrom(t.getClass()));
+        assertThat(responseStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(responseStage.getValue())
+                .isCompletedWithValue(expectedResponse);
+        return eventStage.getValue().toCompletableFuture().join();
     }
 
     static <C extends Command<?>, E extends Event<?>> Result<E> applyStrategy(
@@ -191,11 +206,12 @@ public abstract class AbstractPolicyCommandStrategyTest {
         final List<E> box = new ArrayList<>(1);
         result.accept(new ResultVisitor<>() {
             @Override
-            public void onMutation(final Command<?> command, final E event, final WithDittoHeaders response,
+            public void onMutation(final Command<?> command, final CompletionStage<E> event,
+                    final CompletionStage<WithDittoHeaders> response,
                     final boolean becomeCreated,
                     final boolean becomeDeleted) {
 
-                box.add(event);
+                box.add(event.toCompletableFuture().join());
             }
 
             @Override

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/PolicyConflictStrategyTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/PolicyConflictStrategyTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.concurrent.CompletionStage;
+
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
@@ -100,8 +102,9 @@ public final class PolicyConflictStrategyTest {
         }
 
         @Override
-        public void onMutation(final Command command, final PolicyEvent event, final WithDittoHeaders response,
-                final boolean becomeCreated, final boolean becomeDeleted) {
+        public void onMutation(final Command<?> command, final CompletionStage<PolicyEvent<?>> event,
+                final CompletionStage<WithDittoHeaders> response, final boolean becomeCreated,
+                final boolean becomeDeleted) {
             throw new AssertionError("Expect error, got mutation: " + event);
         }
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ResultFactoryTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ResultFactoryTest.java
@@ -13,13 +13,18 @@
 
 package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.concurrent.CompletionStage;
+
+import org.assertj.core.api.CompletableFutureAssert;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
 import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
@@ -30,6 +35,7 @@ import org.eclipse.ditto.things.model.signals.commands.query.ThingQueryCommand;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
 import org.eclipse.ditto.things.model.signals.events.ThingModifiedEvent;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for {@link org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory}.
@@ -84,8 +90,20 @@ public final class ResultFactoryTest {
                         becomeCreated,
                         becomeDeleted);
         result.accept(mock);
-        verify(mock).onMutation(eq(thingModifyCommand), eq(thingModifiedEvent), eq(response), eq(becomeCreated),
-                eq(becomeDeleted));
+
+        final ArgumentCaptor<CompletionStage<ThingEvent<?>>> eventStage = ArgumentCaptor.forClass(CompletionStage.class);
+        final ArgumentCaptor<CompletionStage<WithDittoHeaders>> responseStage = ArgumentCaptor.forClass(CompletionStage.class);
+
+        verify(mock).onMutation(eq(thingModifyCommand), eventStage.capture(),
+                responseStage.capture(), eq(becomeCreated), eq(becomeDeleted));
+
+        assertThat(eventStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(eventStage.getValue())
+                .isCompletedWithValue(thingModifiedEvent);
+
+        assertThat(responseStage.getValue()).isInstanceOf(CompletionStage.class);
+        CompletableFutureAssert.assertThatCompletionStage(responseStage.getValue())
+                .isCompletedWithValue(response);
     }
 
     interface Dummy extends ResultVisitor<ThingEvent<?>> {

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConflictStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingConflictStrategyTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.concurrent.CompletionStage;
+
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
@@ -95,8 +97,9 @@ public final class ThingConflictStrategyTest {
         }
 
         @Override
-        public void onMutation(final Command<?> command, final ThingEvent<?> event, final WithDittoHeaders response,
-                final boolean becomeCreated, final boolean becomeDeleted) {
+        public void onMutation(final Command<?> command, final CompletionStage<ThingEvent<?>> event,
+                final CompletionStage<WithDittoHeaders> response, final boolean becomeCreated,
+                final boolean becomeDeleted) {
             throw new AssertionError("Expect error, got mutation: " + event);
         }
 

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/provider/WotThingDescriptionProvider.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/provider/WotThingDescriptionProvider.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.wot.integration.provider;
 
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -88,7 +89,7 @@ public interface WotThingDescriptionProvider extends Extension {
      * @param dittoHeaders the DittoHeaders for possibly thrown DittoRuntimeExceptions.
      * @return an optional Thing skeleton or empty optional if something went wrong during the skeleton creation.
      */
-    Optional<Thing> provideThingSkeletonForCreation(ThingId thingId,
+    CompletionStage<Optional<Thing>> provideThingSkeletonForCreation(ThingId thingId,
             @Nullable ThingDefinition thingDefinition,
             DittoHeaders dittoHeaders);
 
@@ -104,7 +105,7 @@ public interface WotThingDescriptionProvider extends Extension {
      * @param dittoHeaders the DittoHeaders for possibly thrown DittoRuntimeExceptions.
      * @return an optional Feature skeleton or empty optional if something went wrong during the skeleton creation.
      */
-    Optional<Feature> provideFeatureSkeletonForCreation(String featureId,
+    CompletionStage<Optional<Feature>> provideFeatureSkeletonForCreation(String featureId,
             @Nullable FeatureDefinition featureDefinition,
             DittoHeaders dittoHeaders);
 


### PR DESCRIPTION
During creating of Things and Features with a given WoT "ThingModel" `definition`, an API was used which uses `CompletableFuture` and which does blocking calls (e.g. in order to retrieve the model(s) via HTTP).

This however was directly called via the Akka "dispatcher" thread - so other processing was completely halted, even the Actor system of the `things ` node could be affected by not being able to schedule any actor related work.

This bugfix enables the internal mechanisms of Ditto to be also able to deal with asynchronously provided `event`s to persist - which will offload the blocking operations to the already provided `"wot-dispatcher"` instead.