### PR TITLE
#1663 fix that nginx's worker_processes setting 'auto' causes problems

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.0  # chart version is effectively set by release-job
+version: 3.3.1  # chart version is effectively set by release-job
 appVersion: 3.3.0
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/dittoui-config/nginx.conf
+++ b/deployment/helm/ditto/dittoui-config/nginx.conf
@@ -1,0 +1,36 @@
+worker_processes 1;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    server_tokens off; # Hide Nginx version
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/deployment/helm/ditto/templates/dittoui-config.yaml
+++ b/deployment/helm/ditto/templates/dittoui-config.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- if .Values.dittoui.enabled -}}
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+{{ range $path, $bytes := .Files.Glob "dittoui-config/**" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-{{ $path | replace "/" "-" | replace "." "-" }}
+  labels:
+    app.kubernetes.io/name: {{ $name }}-dittoui-config
+{{ $labels | indent 4 }}
+data:
+  {{ $path | replace "dittoui-config/" ""}}: |-
+{{ $root.Files.Get $path | indent 4 }}
+---
+{{- end -}}
+{{- end -}}

--- a/deployment/helm/ditto/templates/dittoui-deployment.yaml
+++ b/deployment/helm/ditto/templates/dittoui-deployment.yaml
@@ -63,4 +63,12 @@ spec:
             limits:
               # cpu: ""
               memory: {{ .Values.dittoui.resources.memoryMi }}Mi
+          volumeMounts:
+            - name: dittoui-nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: dittoui-nginx-conf
+          configMap:
+            name: {{ .Release.Name }}-dittoui-config-nginx-conf
 {{- end }}

--- a/deployment/helm/ditto/templates/nginx-configmap.yaml
+++ b/deployment/helm/ditto/templates/nginx-configmap.yaml
@@ -19,10 +19,10 @@ metadata:
 {{ include "ditto.labels" . | indent 4 }}
 data:
   nginx.conf: |-
-    worker_processes auto;
+    worker_processes {{ .Values.nginx.config.workerProcesses }};
 
     events {
-      worker_connections 1024;
+      worker_connections {{ .Values.nginx.config.workerConnections }};
     }
     
     http {

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1386,7 +1386,7 @@ nginx:
     # repository for the nginx docker image
     repository: docker.io/nginx
     # tag for the nginx docker image
-    tag: 1.23
+    tag: 1.25
     # pullPolicy for the nginx docker image
     pullPolicy: IfNotPresent
   # extraEnv to add arbitrary environment variables to nginx container
@@ -1504,7 +1504,7 @@ swaggerui:
     # repository for the swagger ui docker image
     repository: docker.io/swaggerapi/swagger-ui
     # tag for the swagger ui docker image
-    tag: v4.15.5
+    tag: v4.19.1
     # pullPolicy for the swagger ui docker image
     pullPolicy: IfNotPresent
   # extraEnv to add arbitrary environment variable to swagger ui container

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1429,6 +1429,13 @@ nginx:
       enabled: true
       name: wait-for-gateway
       image: rancher/curlimages-curl:7.73.0
+  # config holds nginx specific configuration
+  config:
+    # workerProcesses the 'worker_processes' option for nginx to use - can also be set to 'auto' in order to let nginx
+    # determine the worker processes based on the CPU count
+    workerProcesses: 4
+    # workerProcesses the 'events' 'worker_connections' option for nginx to use
+    workerConnections: 1024
 
 ## ----------------------------------------------------------------------------
 ## Ditto UI configuration


### PR DESCRIPTION
… when deploying Helm chart to worker with many CPUs

* configure the "dittoui"'s nginx to use 1 worker process (it only serves static content)
* add configuration option in values.yaml to configure the nginx's used worker_processes and default to 4

Fixes: #1663