### PR TITLE
fix(helm): Allow connectivity inter cluster communication

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.2  # chart version is effectively set by release-job
+version: 3.3.3  # chart version is effectively set by release-job
 appVersion: 3.3.2
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1124,12 +1124,12 @@ connectivity:
       # allowedHostnames contains a comma separated list of explicitly allowed hostnames
       allowedHostnames: ""
       # blockedHostnames contains a comma separated list of blocked hostnames
-      blockedHostnames: "localhost"
+      blockedHostnames: ""
       # blockedSubnets holds a comma separated string of blocked subnets
       #  specify subnets to block in CIDR format e.g. "11.1.0.0/16"
       blockedSubnets: ""
       # blockedHostRegex contains the regex for blocked hostnames
-      blockedHostRegex: ^.*\\.svc.cluster.local$
+      blockedHostRegex: ""
       limits:
         # maxSources contains the max number of sources per connection
         maxSources: 5


### PR DESCRIPTION
Doesn't make much sense to block everything inside the cluster for connectivity, specially by default. You end up with confusing error responses such as this one, making it difficult to use the platform.

```json
{
    "status": 400,
    "error": "connectivity:connection.configuration.invalid",
    "message": "The configured host 'kafka.kafka' may not be used for the connection because the host is blocked: the hostname resolved to a site local address.",
    "description": "It is a blocked or otherwise forbidden hostname which may not be used."
}
```

Also, the regex original regex wasn't right:

```yml
# There is no scaping on plain strings
# https://yaml.org/spec/1.2.2/#plain-style
blockedHostRegex: ^.*\.svc\.cluster\.local$
```