### PR TITLE
fix(gha): Avoid running cron on forks

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -15,8 +15,11 @@ on:
     - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
+env:
+  GITHUB_REPOSITORY: eclipse-ditto/ditto
 jobs:
   build:
+    if: github.repository == ${{ env.GITHUB_REPOSITORY }}
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
The cron job of Ditto is triggered each day on forks, which leads to annoying failed jobs (see https://github.com/ertis-research/ditto/actions/runs/5459864259/jobs/9936273159, for example). Solution is based on the following sources:

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
- https://github.com/orgs/community/discussions/26684#discussioncomment-3252843 

PS: This change also triggered maven tests, which failed. See <https://github.com/ertis-research/ditto/actions/runs/5461992872/jobs/9940730952>. It may be wise to add `.github` to the list of ignored paths on maven.yml, and identify the reason why it failed.


