### PR TITLE
fix(gha): Hardcode repo name into action

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -15,11 +15,9 @@ on:
     - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
-env:
-  GITHUB_REPOSITORY: eclipse-ditto/ditto
 jobs:
   build:
-    if: github.repository == ${{ env.GITHUB_REPOSITORY }}
+    if: github.repository == 'eclipse-ditto/ditto'
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
Sometimes I wish GHA were more consistent with what is allowed and what not.

This PR hardcodes the repo name instead of using the env namespace.