### PR TITLE
fix MergeThing command being used for creating new things did not respect "inlinePolicy"

### DIFF
--- a/edge/service/src/test/java/org/eclipse/ditto/edge/service/placeholders/ImmutableFeaturePlaceholderTest.java
+++ b/edge/service/src/test/java/org/eclipse/ditto/edge/service/placeholders/ImmutableFeaturePlaceholderTest.java
@@ -146,7 +146,7 @@ public final class ImmutableFeaturePlaceholderTest {
                 .set(ThingCommand.JsonFields.TYPE, MergeThing.TYPE)
                 .set(ThingCommand.JsonFields.JSON_THING_ID, THING_ID.toString())
                 .set("path", "/")
-                .set("value", "This is wrong.")
+                .set("value", JsonObject.newBuilder().set("foo", "This is wrong.").build())
                 .build(), DittoHeaders.empty());
         assertThat(UNDER_TEST.resolveValues(mergeThing, "id")).isEmpty();
     }

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mapper/ThingMergeSignalMapper.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mapper/ThingMergeSignalMapper.java
@@ -23,7 +23,7 @@ final class ThingMergeSignalMapper extends AbstractModifySignalMapper<MergeThing
 
     @Override
     void enhancePayloadBuilder(final MergeThing command, final PayloadBuilder payloadBuilder) {
-        payloadBuilder.withValue(command.getValue());
+        payloadBuilder.withValue(command.getEntity().orElseGet(command::getValue));
     }
 
     @Override

--- a/protocol/src/test/java/org/eclipse/ditto/protocol/adapter/things/ThingMergeCommandAdapterTest.java
+++ b/protocol/src/test/java/org/eclipse/ditto/protocol/adapter/things/ThingMergeCommandAdapterTest.java
@@ -15,21 +15,22 @@ package org.eclipse.ditto.protocol.adapter.things;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.Assertions;
-import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonPointer;
-import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.base.model.exceptions.DittoJsonException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.contenttype.ContentType;
-import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.protocol.Adaptable;
-import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
 import org.eclipse.ditto.protocol.LiveTwinTest;
 import org.eclipse.ditto.protocol.Payload;
-import org.eclipse.ditto.protocol.adapter.ProtocolAdapterTest;
 import org.eclipse.ditto.protocol.TestConstants;
 import org.eclipse.ditto.protocol.TopicPath;
 import org.eclipse.ditto.protocol.UnknownPathException;
+import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
+import org.eclipse.ditto.protocol.adapter.ProtocolAdapterTest;
+import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.PolicyIdNotDeletableException;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingIdNotDeletableException;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingIdNotExplicitlySettableException;
@@ -125,6 +126,28 @@ public final class ThingMergeCommandAdapterTest extends LiveTwinTest implements 
                 .withPayload(Payload.newBuilder(TestConstants.POLICY_ID_POINTER)
                         .withValue(JsonValue.of(TestConstants.POLICY_ID))
                         .build())
+                .withHeaders(TestConstants.HEADERS_V_2_FOR_MERGE_COMMANDS)
+                .build();
+
+        final MergeThing actual = underTest.fromAdaptable(adaptable);
+
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void mergeThingWithInlinePolicyFromAdaptable() {
+        final JsonObject initialPolicy = JsonObject.newBuilder().set("foo", "bar").build();
+        final MergeThing expected =
+                MergeThing.withThing(TestConstants.THING_ID, TestConstants.THING, initialPolicy, null,
+                        TestConstants.DITTO_HEADERS_V_2);
+        final Adaptable adaptable = Adaptable.newBuilder(topicPath)
+                .withPayload(Payload.newBuilder(JsonPointer.empty())
+                        .withValue(TestConstants.THING.toJson().toBuilder()
+                                .set(MergeThing.JSON_INLINE_POLICY.getPointer(), initialPolicy)
+                                .build()
+                        )
+                        .build()
+                )
                 .withHeaders(TestConstants.HEADERS_V_2_FOR_MERGE_COMMANDS)
                 .build();
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/modify/MergeThing.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/modify/MergeThing.java
@@ -497,12 +497,22 @@ public final class MergeThing extends AbstractCommand<MergeThing> implements Thi
 
     @Override
     public Optional<JsonValue> getEntity() {
-        return Optional.of(value);
+        if (path.isEmpty()) {
+            final JsonObject thingJson = value.asObject();
+            final JsonObject withInlinePolicyThingJson =
+                    getInitialPolicy().map(ip -> thingJson.set(JSON_INLINE_POLICY, ip)).orElse(thingJson);
+            final JsonObject fullThingJson = getPolicyIdOrPlaceholder().map(
+                    containedPolicyIdOrPlaceholder -> withInlinePolicyThingJson.set(JSON_COPY_POLICY_FROM,
+                            containedPolicyIdOrPlaceholder)).orElse(withInlinePolicyThingJson);
+            return Optional.of(fullThingJson);
+        } else {
+            return Optional.of(value);
+        }
     }
 
     @Override
     public Optional<JsonValue> getEntity(final JsonSchemaVersion schemaVersion) {
-        return Optional.of(value);
+        return getEntity();
     }
 
     @Override

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
@@ -493,7 +493,8 @@ final class ThingCommandEnforcement
         } else if (enforcer.hasPartialPermissions(thingResourceKey, authorizationContext, Permission.WRITE)) {
             // in case of partial permissions at thingResourceKey level check all leaves of merge patch for
             // unrestricted permissions
-            final Set<ResourceKey> resourceKeys = calculateLeaves(command.getPath(), command.getValue());
+            final Set<ResourceKey> resourceKeys = calculateLeaves(command.getPath(),
+                    command.getEntity().orElseGet(command::getValue));
             return enforcer.hasUnrestrictedPermissions(resourceKeys, authorizationContext, Permission.WRITE);
         } else {
             // not even partial permission

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/pre/ModifyToCreateThingTransformer.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/pre/ModifyToCreateThingTransformer.java
@@ -73,7 +73,7 @@ public final class ModifyToCreateThingTransformer implements SignalTransformer {
                     modifyThing.getPolicyIdOrPlaceholder().orElse(null)
             ));
         } else if (signal instanceof MergeThing mergeThing && mergeThing.getPath().isEmpty()) {
-            final JsonObject mergeThingObject = mergeThing.getValue().asObject();
+            final JsonObject mergeThingObject = mergeThing.getEntity().orElseGet(mergeThing::getValue).asObject();
             return Optional.of(new InputParams(mergeThing,
                     ThingsModelFactory.newThing(mergeThingObject),
                     mergeThing.getInitialPolicy().orElse(null),

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategy.java
@@ -93,7 +93,7 @@ final class MergeThingStrategy extends AbstractThingCommandStrategy<MergeThing> 
         // (this is required e.g. for updating the search-index)
         final DittoHeaders dittoHeaders = command.getDittoHeaders();
         final JsonPointer path = command.getPath();
-        final JsonValue value = command.getValue();
+        final JsonValue value = command.getEntity().orElseGet(command::getValue);
 
         final Thing mergedThing = wrapException(() -> mergeThing(context, command, thing, eventTs, nextRevision),
                 command.getDittoHeaders());
@@ -109,7 +109,8 @@ final class MergeThingStrategy extends AbstractThingCommandStrategy<MergeThing> 
     private Thing mergeThing(final Context<ThingId> context, final MergeThing command, final Thing thing,
             final Instant eventTs, final long nextRevision) {
         final JsonObject existingThingJson = thing.toJson(FieldType.all());
-        final JsonMergePatch jsonMergePatch = JsonMergePatch.of(command.getPath(), command.getValue());
+        final JsonMergePatch jsonMergePatch = JsonMergePatch.of(command.getPath(),
+                command.getEntity().orElseGet(command::getValue));
         final JsonObject mergedJson = jsonMergePatch.applyOn(existingThingJson).asObject();
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(


### PR DESCRIPTION
* when processed via Ditto "Adaptable" - there the "inlinePolicy" was missing

Relates to #1614 - due to this bug, using the "_policy" does not work when sending "MergeThing" via DittoProtocol