### PR TITLE
fix default value of 'jwtOnly' being 'true' in Helm chart

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.4  # chart version is effectively set by release-job
+version: 3.3.5  # chart version is effectively set by release-job
 appVersion: 3.3.3
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -62,7 +62,7 @@ global:
   # jwtOnly controls whether only OpenID-Connect authentication is supported
   #  if false, both OpenID-Connect and basicAuth via nginx (see above "basicAuthUsers" and "hashedBasicAuthUsers") is used
   #  ref: https://www.eclipse.dev/ditto/installation-operating.html#openid-connect
-  jwtOnly: true
+  jwtOnly: false
   # jvmOptions defines the JVM options applied to all Ditto services running in the JVM, it is put in JAVA_TOOL_OPTIONS
   jvmOptions: >
     -XX:+ExitOnOutOfMemoryError


### PR DESCRIPTION
* changed to `false` as default so that simple setups can use nginx based auth