### PR TITLE
fix that in Helm config `jwtOnly=false` will enabled pre-authentication in Ditto

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.4  # chart version is effectively set by release-job
+version: 3.3.5  # chart version is effectively set by release-job
 appVersion: 3.3.4
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -154,7 +154,7 @@ spec:
               value: "{{ .Values.global.prometheus.port }}"
             {{- end }}
             - name: ENABLE_PRE_AUTHENTICATION
-              value: "{{ .Values.gateway.config.authentication.enablePreAuthentication }}"
+              value: "{{ or .Values.gateway.config.authentication.enablePreAuthentication (not .Values.global.jwtOnly) }}"
             - name: DEVOPS_SECURED
               value: "{{ .Values.gateway.config.authentication.devops.secured }}"
             - name: DEVOPS_AUTHENTICATION_METHOD

--- a/deployment/helm/ditto/templates/swaggerui-deployment.yaml
+++ b/deployment/helm/ditto/templates/swaggerui-deployment.yaml
@@ -59,7 +59,7 @@ spec:
                echo "removing Google auth from ditto-api-2.yml"
                sed --in-place "/- Google:/,+1d" /usr/share/nginx/html/openapi/ditto-api-2.yml
                sed --in-place "/    Google:/,+9d" /usr/share/nginx/html/openapi/ditto-api-2.yml
-               {{- if not .Values.gateway.config.authentication.enablePreAuthentication }}
+               {{- if or (not .Values.gateway.config.authentication.enablePreAuthentication) .Values.global.jwtOnly }}
                echo "removing NginxBasic auth from ditto-api-2.yml"
                sed --in-place "/- NginxBasic: \[]/d" /usr/share/nginx/html/openapi/ditto-api-2.yml
                sed --in-place "/    NginxBasic:/,+3d" /usr/share/nginx/html/openapi/ditto-api-2.yml


### PR DESCRIPTION
* was not done by default before, so would have to be activated by default

Related to discussion: #1685 