### PR TITLE
Support HTTP POST method for /search and /count

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -6666,6 +6666,265 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+    post:
+      summary: Search for things
+      description: |-
+        This resource can be used to search for things.
+
+        * The parameter `filter` is not mandatory. If it is not set, the
+          result contains all things which the logged in user is allowed to read.
+
+        * The search is case sensitive. In case you don't know how exactly the
+          spelling of value of the namespace, name, attribute, feature etc. is, use the *like*
+          notation instead of *eq* for filtering.
+
+        * The resource supports sorting and paging. If paging is not explicitly
+          specified by means of the `size` option, a default count of `25`
+          documents is returned.
+
+        * The internal search index is "eventually consistent".  Consistency with the latest
+          thing updates should recover within milliseconds.
+      tags:
+        - Things-Search
+      responses:
+        '200':
+          description: An array of the matching things.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResultThings'
+        '400':
+          description: |-
+            The request could not be completed. A provided parameter is in a
+            wrong format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '401':
+          description: The request could not be completed due to missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '403':
+          description: The request could not be completed due to an invalid authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '504':
+          description: The request ran out of time to execute on the the back-end. Optimize your query and try again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                filter:
+                  description: |-
+
+                    #### Filter predicates:
+
+                    * ```eq({property},{value})```  (i.e. equal to the given value)
+
+                    * ```ne({property},{value})```  (i.e. not equal to the given value)
+
+                    * ```gt({property},{value})```  (i.e. greater than the given value)
+
+                    * ```ge({property},{value})```  (i.e. equal to the given value or greater than it)
+
+                    * ```lt({property},{value})```  (i.e. lower than the given value or equal to it)
+
+                    * ```le({property},{value})```  (i.e. lower than the given value)
+
+                    * ```in({property},{value},{value},...)```  (i.e. contains at least one of the values listed)
+
+                    * ```like({property},{value})```  (i.e. contains values similar to the expressions listed)
+
+                    * ```ilike({property},{value})```  (i.e. contains values similar and case insensitive to the expressions listed)
+
+                    * ```exists({property})```  (i.e. all things in which the given path exists)
+
+
+                    Note: When using filter operations, only things with the specified properties are returned.
+                    For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
+                    the `owner` attribute.
+
+
+                    #### Logical operations:
+
+
+                    * ```and({query},{query},...)```
+
+                    * ```or({query},{query},...)```
+
+                    * ```not({query})```
+
+
+                    #### Examples:
+
+                    * ```eq(attributes/location,"kitchen")```
+
+                    * ```ge(thingId,"myThing1")```
+
+                    * ```gt(_created,"2020-08-05T12:17")```
+
+                    * ```exists(features/featureId)```
+
+                    * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
+
+                    * ```or(eq(attributes/location,"kitchen"),eq(attributes/location,"living-room"))```
+
+                    * ```like(attributes/key1,"known-chars-at-start*")```
+
+                    * ```like(attributes/key1,"*known-chars-at-end")```
+
+                    * ```like(attributes/key1,"*known-chars-in-between*")```
+
+                    * ```like(attributes/key1,"just-som?-char?-unkn?wn")```
+
+                    The `like` filters with the wildcard `*` at the beginning can slow down your search request.
+                  type: string
+                namespaces:
+                  description: |-
+                    A comma-separated list of namespaces. This list is used to limit the query to things in the given namespaces
+                    only.
+
+
+                    #### Examples:
+
+                    * `?namespaces=com.example.namespace`
+
+                    * `?namespaces=com.example.namespace1,com.example.namespace2`
+                  type: string
+                fields:
+                  description: |-
+                    Contains a comma-separated list of fields to be included in the returned
+                    JSON. attributes can be selected in the same manner.
+
+                    #### Selectable fields
+
+                    * `thingId`
+                    * `policyId`
+                    * `definition`
+                    * `attributes`
+
+                       Supports selecting arbitrary sub-fields by using a comma-separated list:
+                        * several attribute paths can be passed as a comma-separated list of JSON pointers (RFC-6901)
+
+                          For example:
+                            * `?fields=attributes/model` would select only `model` attribute value (if present)
+                            * `?fields=attributes/model,attributes/location` would select only `model` and
+                               `location` attribute values (if present)
+
+                      Supports selecting arbitrary sub-fields of objects by wrapping sub-fields inside parentheses `( )`:
+                        * a comma-separated list of sub-fields (a sub-field is a JSON pointer (RFC-6901)
+                          separated with `/`) to select
+
+                        * sub-selectors can be used to request only specific sub-fields by placing expressions
+                          in parentheses `( )` after a selected subfield
+
+                          For example:
+                           * `?fields=attributes(model,location)` would select only `model`
+                              and `location` attribute values (if present)
+                           * `?fields=attributes(coffeemaker/serialno)` would select the `serialno` value
+                              inside the `coffeemaker` object
+                           * `?fields=attributes/address/postal(city,street)` would select the `city` and
+                              `street` values inside the `postal` object inside the `address` object
+
+                    * `features`
+
+                      Supports selecting arbitrary fields in features similar to `attributes` (see also features documentation for more details)
+
+                    * `_namespace`
+
+                      Specifically selects the namespace also contained in the `thingId`
+
+                    * `_revision`
+
+                      Specifically selects the revision of the thing. The revision is a counter, which is incremented on each modification of a thing.
+
+                    * `_created`
+
+                      Specifically selects the created timestamp of the thing in ISO-8601 UTC format. The timestamp is set on creation of a thing.
+
+                    * `_modified`
+
+                      Specifically selects the modified timestamp of the thing in ISO-8601 UTC format. The timestamp is set on each modification of a thing.
+
+                    * `_metadata`
+
+                      Specifically selects the Metadata of the thing. The content is a JSON object having the Thing's JSON structure with the difference that the JSON leaves of the Thing are JSON objects containing the metadata.
+
+                    * `_policy`
+
+                      Specifically selects the content of the policy associated to the thing. (By default, only the policyId is returned.)
+
+                    #### Examples
+
+                    * `?fields=thingId,attributes,features`
+                    * `?fields=attributes(model,manufacturer),features`
+                  type: string
+                option:
+                  description: |-
+                    Possible values for the parameter:
+
+                    #### Sort operations
+
+                    * ```sort([+|-]{property})```
+                    * ```sort([+|-]{property},[+|-]{property},...)```
+
+                    #### Paging operations
+
+                    * ```size({page-size})```  Maximum allowed page size is `200`. Default page size is `25`.
+                    * ```cursor({cursor-id})```  Start the search from the cursor location. Specify the cursor ID without
+                    quotation marks. Cursor IDs are given in search responses and mark the position after the last entry of
+                    the previous search. The meaning of cursor IDs is unspecified and may change without notice.
+
+                    The paging option `limit({offset},{count})` is deprecated.
+                    It may result in slow queries or timeouts and will be removed eventually.
+
+                    #### Examples:
+
+                    * ```sort(+thingId)```
+                    * ```sort(-attributes/manufacturer)```
+                    * ```sort(+thingId,-attributes/manufacturer)```
+                    * ```size(10)``` return 10 results
+                    * ```cursor(LOREMIPSUM)```  return results after the position of the cursor `LOREMIPSUM`.
+
+                    #### Combine:
+
+                    If you need to specify multiple options, when using the swagger UI just write each option in a new line.
+                    When using the plain REST API programmatically,
+                    you will need to separate the options using a comma (,) character.
+
+                    ```size(200),cursor(LOREMIPSUM)```
+
+                    The deprecated paging option `limit` may not be combined with the other paging options `size` and `cursor`.
+                  type: string
+            encoding:
+              filter:
+                style: form
+                explode: false
+              namespaces:
+                style: form
+                explode: false
+              fields:
+                style: form
+                explode: false
+              option:
+                style: form
+                explode: false
+            example:
+              filter: 'and(like(definition,"*test*"))'
+              namespaces: 'org.eclipse.ditto,foo.bar'
+              fields: 'attributes/model,attributes/location'
+              option: 'limit(0,5)'
   /api/2/search/things/count:
     get:
       summary: Count things
@@ -6721,6 +6980,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdvancedError'
+    post:
+      summary: Count things
+      description: |-
+        This resource can be used to count things.
+
+        The parameter `filter` is not mandatory. If it is not set there is
+        returned the total amount of things which the logged in user is allowed
+        to read.
+
+        To search for nested properties, we use JSON Pointer notation
+        (RFC-6901). See the following example how to search for the sub property
+        `location` of the parent property `attributes` with a forward slash as
+        separator:
+
+        ```eq(attributes/location,"kitchen")```
+      tags:
+        - Things-Search
+      responses:
+        '200':
+          description: A number indicating the amount of matched things
+          content:
+            application/json:
+              schema:
+                type: integer
+        '400':
+          description: |-
+            The request could not be completed. A provided parameter is in a
+            wrong format.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '401':
+          description: The request could not be completed due to missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '403':
+          description: The request could not be completed due to an invalid authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '504':
+          description: The request ran out of time to execute on the the back-end. Optimize your query and try again.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                filter:
+                  $ref: '#/paths/~1api~12~1search~1things/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/filter'
+                namespaces:
+                  $ref: '#/paths/~1api~12~1search~1things/post/requestBody/content/application~1x-www-form-urlencoded/schema/properties/namespaces'
+            encoding:
+              filter:
+                style: form
+                explode: false
+              namespaces:
+                style: form
+                explode: false
+            example:
+              filter: 'and(like(definition,"*test*"))'
+              namespaces: 'org.eclipse.ditto,foo.bar'
   /api/2/cloudevents:
     post:
       summary: Processes a CloudEvent sent in Ditto Protocol

--- a/documentation/src/main/resources/openapi/sources/paths/search/things-count.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/search/things-count.yml
@@ -62,3 +62,73 @@ get:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+post:
+  summary: Count things
+  description: |-
+    This resource can be used to count things.
+
+    The parameter `filter` is not mandatory. If it is not set there is
+    returned the total amount of things which the logged in user is allowed
+    to read.
+
+    To search for nested properties, we use JSON Pointer notation
+    (RFC-6901). See the following example how to search for the sub property
+    `location` of the parent property `attributes` with a forward slash as
+    separator:
+
+    ```eq(attributes/location,"kitchen")```
+  tags:
+    - Things-Search
+  responses:
+    '200':
+      description: A number indicating the amount of matched things
+      content:
+        application/json:
+          schema:
+            type: integer
+    '400':
+      description: |-
+        The request could not be completed. A provided parameter is in a
+        wrong format.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '401':
+      description: The request could not be completed due to missing authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '403':
+      description: The request could not be completed due to an invalid authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '504':
+      description: The request ran out of time to execute on the the back-end. Optimize your query and try again.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+  requestBody:
+    content:
+      application/x-www-form-urlencoded:
+        schema:
+          type: object
+          properties:
+            filter:
+              $ref: '../../schemas/properties/searchFilterProperty.yml'
+            namespaces:
+              $ref: '../../schemas/properties/namespacesProperty.yml'
+        encoding:
+          filter:
+            style: form
+            explode: false
+          namespaces:
+            style: form
+            explode: false
+        example:
+          filter: "and(like(definition,\"*test*\"))"
+          namespaces: "org.eclipse.ditto,foo.bar"

--- a/documentation/src/main/resources/openapi/sources/paths/search/things.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/search/things.yml
@@ -106,3 +106,88 @@ get:
         application/json:
           schema:
             $ref: '../../schemas/errors/advancedError.yml'
+post:
+  summary: Search for things
+  description: |-
+    This resource can be used to search for things.
+
+    * The parameter `filter` is not mandatory. If it is not set, the
+      result contains all things which the logged in user is allowed to read.
+
+    * The search is case sensitive. In case you don't know how exactly the
+      spelling of value of the namespace, name, attribute, feature etc. is, use the *like*
+      notation instead of *eq* for filtering.
+
+    * The resource supports sorting and paging. If paging is not explicitly
+      specified by means of the `size` option, a default count of `25`
+      documents is returned.
+
+    * The internal search index is "eventually consistent".  Consistency with the latest
+      thing updates should recover within milliseconds.
+  tags:
+    - Things-Search
+  responses:
+    '200':
+      description: An array of the matching things.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/search/searchResultThings.yml'
+    '400':
+      description: |-
+        The request could not be completed. A provided parameter is in a
+        wrong format.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '401':
+      description: The request could not be completed due to missing authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '403':
+      description: The request could not be completed due to an invalid authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '504':
+      description: The request ran out of time to execute on the the back-end. Optimize your query and try again.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+  requestBody:
+    content:
+      application/x-www-form-urlencoded:
+        schema:
+          type: object
+          properties:
+            filter:
+              $ref: '../../schemas/properties/searchFilterProperty.yml'
+            namespaces:
+              $ref: '../../schemas/properties/namespacesProperty.yml'
+            fields:
+              $ref: '../../schemas/properties/thingFieldsProperty.yml'
+            option:
+              $ref: '../../schemas/properties/optionProperty.yml'
+        encoding:
+          filter:
+            style: form
+            explode: false
+          namespaces:
+            style: form
+            explode: false
+          fields:
+            style: form
+            explode: false
+          option:
+            style: form
+            explode: false
+        example:
+          filter: "and(like(definition,\"*test*\"))"
+          namespaces: "org.eclipse.ditto,foo.bar"
+          fields: "attributes/model,attributes/location"
+          option: "limit(0,5)"

--- a/documentation/src/main/resources/openapi/sources/schemas/properties/namespacesProperty.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/properties/namespacesProperty.yml
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#namespaces:
+description: |-
+    A comma-separated list of namespaces. This list is used to limit the query to things in the given namespaces
+    only.
+  
+  
+    #### Examples:
+  
+    * `?namespaces=com.example.namespace`
+  
+    * `?namespaces=com.example.namespace1,com.example.namespace2`
+type: string

--- a/documentation/src/main/resources/openapi/sources/schemas/properties/optionProperty.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/properties/optionProperty.yml
@@ -1,0 +1,46 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+description: |-
+  Possible values for the parameter:
+  
+  #### Sort operations
+  
+  * ```sort([+|-]{property})```
+  * ```sort([+|-]{property},[+|-]{property},...)```
+  
+  #### Paging operations
+  
+  * ```size({page-size})```  Maximum allowed page size is `200`. Default page size is `25`.
+  * ```cursor({cursor-id})```  Start the search from the cursor location. Specify the cursor ID without
+  quotation marks. Cursor IDs are given in search responses and mark the position after the last entry of
+  the previous search. The meaning of cursor IDs is unspecified and may change without notice.
+  
+  The paging option `limit({offset},{count})` is deprecated.
+  It may result in slow queries or timeouts and will be removed eventually.
+  
+  #### Examples:
+  
+  * ```sort(+thingId)```
+  * ```sort(-attributes/manufacturer)```
+  * ```sort(+thingId,-attributes/manufacturer)```
+  * ```size(10)``` return 10 results
+  * ```cursor(LOREMIPSUM)```  return results after the position of the cursor `LOREMIPSUM`.
+  
+  #### Combine:
+  
+  If you need to specify multiple options, when using the swagger UI just write each option in a new line.
+  When using the plain REST API programmatically,
+  you will need to separate the options using a comma (,) character.
+  
+  ```size(200),cursor(LOREMIPSUM)```
+  
+  The deprecated paging option `limit` may not be combined with the other paging options `size` and `cursor`.
+type: string

--- a/documentation/src/main/resources/openapi/sources/schemas/properties/searchFilterProperty.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/properties/searchFilterProperty.yml
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#filter:
+description: |-
+  
+    #### Filter predicates:
+  
+    * ```eq({property},{value})```  (i.e. equal to the given value)
+  
+    * ```ne({property},{value})```  (i.e. not equal to the given value)
+  
+    * ```gt({property},{value})```  (i.e. greater than the given value)
+  
+    * ```ge({property},{value})```  (i.e. equal to the given value or greater than it)
+  
+    * ```lt({property},{value})```  (i.e. lower than the given value or equal to it)
+  
+    * ```le({property},{value})```  (i.e. lower than the given value)
+  
+    * ```in({property},{value},{value},...)```  (i.e. contains at least one of the values listed)
+  
+    * ```like({property},{value})```  (i.e. contains values similar to the expressions listed)
+  
+    * ```ilike({property},{value})```  (i.e. contains values similar and case insensitive to the expressions listed)
+  
+    * ```exists({property})```  (i.e. all things in which the given path exists)
+  
+  
+    Note: When using filter operations, only things with the specified properties are returned.
+    For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
+    the `owner` attribute.
+  
+  
+    #### Logical operations:
+  
+  
+    * ```and({query},{query},...)```
+  
+    * ```or({query},{query},...)```
+  
+    * ```not({query})```
+  
+  
+    #### Examples:
+  
+    * ```eq(attributes/location,"kitchen")```
+  
+    * ```ge(thingId,"myThing1")```
+  
+    * ```gt(_created,"2020-08-05T12:17")```
+  
+    * ```exists(features/featureId)```
+  
+    * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
+  
+    * ```or(eq(attributes/location,"kitchen"),eq(attributes/location,"living-room"))```
+  
+    * ```like(attributes/key1,"known-chars-at-start*")```
+  
+    * ```like(attributes/key1,"*known-chars-at-end")```
+  
+    * ```like(attributes/key1,"*known-chars-in-between*")```
+  
+    * ```like(attributes/key1,"just-som?-char?-unkn?wn")```
+  
+    The `like` filters with the wildcard `*` at the beginning can slow down your search request.
+type: string

--- a/documentation/src/main/resources/openapi/sources/schemas/properties/thingFieldsProperty.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/properties/thingFieldsProperty.yml
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+description: |-
+  Contains a comma-separated list of fields to be included in the returned
+  JSON. attributes can be selected in the same manner.
+
+  #### Selectable fields
+
+  * `thingId`
+  * `policyId`
+  * `definition`
+  * `attributes`
+
+     Supports selecting arbitrary sub-fields by using a comma-separated list:
+      * several attribute paths can be passed as a comma-separated list of JSON pointers (RFC-6901)
+
+        For example:
+          * `?fields=attributes/model` would select only `model` attribute value (if present)
+          * `?fields=attributes/model,attributes/location` would select only `model` and
+             `location` attribute values (if present)
+
+    Supports selecting arbitrary sub-fields of objects by wrapping sub-fields inside parentheses `( )`:
+      * a comma-separated list of sub-fields (a sub-field is a JSON pointer (RFC-6901)
+        separated with `/`) to select
+
+      * sub-selectors can be used to request only specific sub-fields by placing expressions
+        in parentheses `( )` after a selected subfield
+
+        For example:
+         * `?fields=attributes(model,location)` would select only `model`
+            and `location` attribute values (if present)
+         * `?fields=attributes(coffeemaker/serialno)` would select the `serialno` value
+            inside the `coffeemaker` object
+         * `?fields=attributes/address/postal(city,street)` would select the `city` and
+            `street` values inside the `postal` object inside the `address` object
+
+  * `features`
+
+    Supports selecting arbitrary fields in features similar to `attributes` (see also features documentation for more details)
+
+  * `_namespace`
+
+    Specifically selects the namespace also contained in the `thingId`
+
+  * `_revision`
+
+    Specifically selects the revision of the thing. The revision is a counter, which is incremented on each modification of a thing.
+
+  * `_created`
+
+    Specifically selects the created timestamp of the thing in ISO-8601 UTC format. The timestamp is set on creation of a thing.
+
+  * `_modified`
+
+    Specifically selects the modified timestamp of the thing in ISO-8601 UTC format. The timestamp is set on each modification of a thing.
+
+  * `_metadata`
+
+    Specifically selects the Metadata of the thing. The content is a JSON object having the Thing's JSON structure with the difference that the JSON leaves of the Thing are JSON objects containing the metadata.
+
+  * `_policy`
+
+    Specifically selects the content of the policy associated to the thing. (By default, only the policyId is returned.)
+
+  #### Examples
+
+  * `?fields=thingId,attributes,features`
+  * `?fields=attributes(model,manufacturer),features`
+type: string

--- a/documentation/src/main/resources/openapi/sources/schemas/search/searchThingsForm.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/search/searchThingsForm.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+properties:
+  searchFilter:
+    type: string
+    description: The search filter parameter
+  namespacesFilter:
+    type: string
+    description: The namespaces filter parameter
+  thingFieldsQueryParam:
+    type: string
+    description: The thing fields query parameter
+  timeoutParam:
+    type: integer
+    description: The timeout parameter in seconds

--- a/documentation/src/main/resources/pages/ditto/httpapi-search.md
+++ b/documentation/src/main/resources/pages/ditto/httpapi-search.md
@@ -11,8 +11,10 @@ The [search aspect](basic-search.html) of Ditto can be accessed via an HTTP API.
     [Search resources](http-api-doc.html?urls.primaryName=api2#/Search)." %}
 
 The concepts of the [RQL expression](basic-rql.html#rql-filter), [RQL sorting](basic-rql.html#rql-sorting) and 
-[RQL paging](basic-search.html#rql-paging-deprecated) are mapped to HTTP as query parameters which are added to 
-`GET` requests to the search endpoint:
+[RQL paging](basic-search.html#rql-paging-deprecated) are mapped to HTTP as
+
+* query parameters which are added to `GET` requests to the search endpoint;
+* a x-www-form-urlencoded body which is added to `POST` requests to the search endpoint.
 
 ```
 http://localhost:8080/api/2/search/things
@@ -23,8 +25,8 @@ If the `filter` parameter is omitted, the result contains all `Things` the authe
 
 Optionally a `namespaces` parameter can be added to search only in the given namespaces.  
 
-
-## Query parameters
+## GET
+### Query parameters
 
 In order to define for which `Things` to search, the `filter` query parameter has to be added.<br/>
 In order to change the sorting and limit the result (also to do paging), the `option` parameter has to be added.
@@ -58,7 +60,7 @@ Example which only returns Things with the given namespaces prefix:
 GET .../search/things?namespaces=org.eclipse.ditto,foo.bar
 ```
 
-## Search count
+### Search count
 Search counts can be made against this endpoint:
 
 ```
@@ -68,4 +70,55 @@ http://localhost:8080/api/2/search/things/count
 Complex example:
 ```
 GET .../search/things/count?filter=eq(attributes/location,"living-room")
+```
+
+## POST
+### x-www-form-urlencoded
+
+In order to define for which `Things` to search, the key `filter` has to be used.<br/>
+In order to change the sorting and limit the result (also to do paging), the key `option` has to be used.
+Default values of each option is documented [here](basic-search.html#sorting-and-paging-options).
+
+Complex example:
+```
+POST .../search/things
+body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29&namespaces=org.eclipse.ditto%2Cfoo.bar&option=sort%28%2BthingId%29%2Climit%280%2C5%29
+```
+
+Another Complex example with the `namespaces` parameter:
+```
+POST .../search/things
+body: filter=filter=eq%28attributes%2Flocation%2C%22living-room%22%29&namespaces=org.eclipse.ditto%2Cfoo.bar
+```
+
+The HTTP search API can also profit from the [partial request](httpapi-concepts.html#partial-requests) concept
+of the API:<br/>
+Additionally to a `filter` and `options`, the key `fields` may be specified in order to select which data
+of the result set to retrieve.
+
+Example which only returns `thingId` and the `manufacturer` attribute of the found Things:
+```
+POST .../search/things
+body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29&fields=thingId%2Cattributes%2Fmanufacturer
+```
+
+With the `namespaces` parameter, the result can be limited to the given namespaces.
+
+Example which only returns Things with the given namespaces prefix:
+```
+POST .../search/things
+body: namespaces=org.eclipse.ditto%2Cfoo.bar
+```
+
+### Search count
+Search counts can be made against this endpoint:
+
+```
+http://localhost:8080/api/2/search/things/count
+```
+
+Complex example:
+```
+POST .../search/things/count
+body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29
 ```

--- a/documentation/src/main/resources/pages/ditto/httpapi-search.md
+++ b/documentation/src/main/resources/pages/ditto/httpapi-search.md
@@ -28,7 +28,7 @@ Optionally a `namespaces` parameter can be added to search only in the given nam
 ## GET
 ### Query parameters
 
-In order to define for which `Things` to search, the `filter` query parameter has to be added.<br/>
+In order to define for which `Things` to search, the `filter` query parameter has to be added.  
 In order to change the sorting and limit the result (also to do paging), the `option` parameter has to be added.
 Default values of each option is documented [here](basic-search.html#sorting-and-paging-options).
 
@@ -44,7 +44,7 @@ GET .../search/things?filter=eq(attributes/location,"living-room")&namespaces=or
 ```
 
 The HTTP search API can also profit from the [partial request](httpapi-concepts.html#partial-requests) concept 
-of the API:<br/>
+of the API:  
 Additionally to a `filter` and `options`, a `fields` parameter may be specified in order to select which data 
 of the result set to retrieve.
 
@@ -75,31 +75,31 @@ GET .../search/things/count?filter=eq(attributes/location,"living-room")
 ## POST
 ### x-www-form-urlencoded
 
-In order to define for which `Things` to search, the key `filter` has to be used.<br/>
+In order to define for which `Things` to search, the key `filter` has to be used.  
 In order to change the sorting and limit the result (also to do paging), the key `option` has to be used.
 Default values of each option is documented [here](basic-search.html#sorting-and-paging-options).
 
 Complex example:
 ```
 POST .../search/things
-body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29&namespaces=org.eclipse.ditto%2Cfoo.bar&option=sort%28%2BthingId%29%2Climit%280%2C5%29
+body: filter=eq(attributes/location,"living-room")&namespaces=org.eclipse.ditto,foo.bar&option=sort(+thingId),limit(0,5)
 ```
 
 Another Complex example with the `namespaces` parameter:
 ```
 POST .../search/things
-body: filter=filter=eq%28attributes%2Flocation%2C%22living-room%22%29&namespaces=org.eclipse.ditto%2Cfoo.bar
+body: filter=eq(attributes/location,"living-room")&namespaces=org.eclipse.ditto,foo.bar
 ```
 
 The HTTP search API can also profit from the [partial request](httpapi-concepts.html#partial-requests) concept
-of the API:<br/>
+of the API:  
 Additionally to a `filter` and `options`, the key `fields` may be specified in order to select which data
 of the result set to retrieve.
 
 Example which only returns `thingId` and the `manufacturer` attribute of the found Things:
 ```
 POST .../search/things
-body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29&fields=thingId%2Cattributes%2Fmanufacturer
+body: filter=eq(attributes/location,"living-room")&fields=thingId,attributes/manufacturer
 ```
 
 With the `namespaces` parameter, the result can be limited to the given namespaces.
@@ -107,7 +107,7 @@ With the `namespaces` parameter, the result can be limited to the given namespac
 Example which only returns Things with the given namespaces prefix:
 ```
 POST .../search/things
-body: namespaces=org.eclipse.ditto%2Cfoo.bar
+body: namespaces=org.eclipse.ditto,foo.bar
 ```
 
 ### Search count
@@ -120,5 +120,5 @@ http://localhost:8080/api/2/search/things/count
 Complex example:
 ```
 POST .../search/things/count
-body: filter=eq%28attributes%2Flocation%2C%22living-room%22%29
+body: filter=eq(attributes/location,"living-room")
 ```

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -303,13 +304,12 @@ public abstract class AbstractRoute extends AllDirectives {
     protected Route ensureMediaTypeFormUrlEncodedThenExtractData(
             final RequestContext ctx,
             final DittoHeaders dittoHeaders,
-            final java.util.function.Function<Source<ByteString, Object>, Route> inner
+            final java.util.function.Function<Map<String, List<String>>, Route> inner
     ) {
-        return ContentTypeValidationDirective.ensureValidContentType(Set.of(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED.toString()), ctx, dittoHeaders,
-                () -> {
-                    final var res = extractDataBytes(inner);
-                    return res;
-                });
+        return ContentTypeValidationDirective.ensureValidContentType(
+                Set.of(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED.toString()), ctx, dittoHeaders,
+                () -> formFieldMultiMap(inner)
+        );
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
@@ -170,15 +170,15 @@ public abstract class AbstractRoute extends AllDirectives {
      * @param ctx the request context.
      * @param dittoHeaders the extracted Ditto headers.
      * @param payloadSource source of the request body.
-     * @param requestJsonToCommandFunction function converting a string to a command.
+     * @param requestStringToCommandFunction function converting a string to a command.
      * @return the request handling route.
      */
     public Route handlePerRequest(final RequestContext ctx,
             final DittoHeaders dittoHeaders,
             final Source<ByteString, ?> payloadSource,
-            final Function<String, Command<?>> requestJsonToCommandFunction) {
+            final Function<String, Command<?>> requestStringToCommandFunction) {
 
-        return handlePerRequest(ctx, dittoHeaders, payloadSource, requestJsonToCommandFunction, null);
+        return handlePerRequest(ctx, dittoHeaders, payloadSource, requestStringToCommandFunction, null);
     }
 
     protected Route handlePerRequest(final RequestContext ctx, final Command<?> command) {
@@ -195,13 +195,13 @@ public abstract class AbstractRoute extends AllDirectives {
     protected Route handlePerRequest(final RequestContext ctx,
             final DittoHeaders dittoHeaders,
             final Source<ByteString, ?> payloadSource,
-            final Function<String, Command<?>> requestJsonToCommandFunction,
+            final Function<String, Command<?>> requestStringToCommandFunction,
             @Nullable final BiFunction<JsonValue, HttpResponse, HttpResponse> responseTransformFunction) {
 
         return withCustomRequestTimeout(dittoHeaders.getTimeout().orElse(null),
                 this::validateCommandTimeout,
                 timeout -> doHandlePerRequest(ctx, dittoHeaders.toBuilder().timeout(timeout).build(), payloadSource,
-                        requestJsonToCommandFunction, responseTransformFunction));
+                        requestStringToCommandFunction, responseTransformFunction));
     }
 
     protected <M> M runWithSupervisionStrategy(final RunnableGraph<M> graph) {
@@ -211,7 +211,7 @@ public abstract class AbstractRoute extends AllDirectives {
     private Route doHandlePerRequest(final RequestContext ctx,
             final DittoHeaders dittoHeaders,
             final Source<ByteString, ?> payloadSource,
-            final Function<String, Command<?>> requestJsonToCommandFunction,
+            final Function<String, Command<?>> requestStringToCommandFunction,
             @Nullable final BiFunction<JsonValue, HttpResponse, HttpResponse> responseValueTransformFunction) {
 
         final CompletableFuture<HttpResponse> httpResponseFuture = new CompletableFuture<>();
@@ -222,7 +222,7 @@ public abstract class AbstractRoute extends AllDirectives {
                 .map(x -> {
                     try {
                         // DON'T replace this try-catch by .recover: The supervising strategy is called before recovery!
-                        final Command<?> command = requestJsonToCommandFunction.apply(x);
+                        final Command<?> command = requestStringToCommandFunction.apply(x);
                         final JsonSchemaVersion schemaVersion =
                                 dittoHeaders.getSchemaVersion().orElse(command.getImplementedSchemaVersion());
                         return command.implementsSchemaVersion(schemaVersion) ? command
@@ -298,6 +298,18 @@ public abstract class AbstractRoute extends AllDirectives {
 
         final var actorSystem = routeBaseProperties.getActorSystem();
         return actorSystem.actorOf(props);
+    }
+
+    protected Route ensureMediaTypeFormUrlEncodedThenExtractData(
+            final RequestContext ctx,
+            final DittoHeaders dittoHeaders,
+            final java.util.function.Function<Source<ByteString, Object>, Route> inner
+    ) {
+        return ContentTypeValidationDirective.ensureValidContentType(Set.of(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED.toString()), ctx, dittoHeaders,
+                () -> {
+                    final var res = extractDataBytes(inner);
+                    return res;
+                });
     }
 
     /**

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRouteTest.java
@@ -12,19 +12,22 @@
  */
 package org.eclipse.ditto.gateway.service.endpoints.routes.thingsearch;
 
-import akka.http.javadsl.model.*;
-import akka.http.javadsl.server.Route;
-import akka.http.javadsl.testkit.TestRoute;
-import akka.japi.Pair;
+import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
+
+import java.util.List;
+
 import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
 import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
+import akka.http.javadsl.model.FormData;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.TestRoute;
+import akka.japi.Pair;
 
 /**
  * Builder for creating Akka HTTP routes for {@code /search/things}.
@@ -55,7 +58,7 @@ public final class ThingSearchRouteTest extends EndpointTestBase {
                 .withEntity(formData.toEntity()));
 
         result.assertStatusCode(StatusCodes.OK);
-        result.assertEntity("{\"type\":\"thing-search.commands:queryThings\",\"filter\":\"and(and%28like%28definition%2C%22%2Atest%2A%22%29%29)\",\"options\":[\"sort%28%2BthingId%29\",\"limit%280%2C5%29\"],\"namespaces\":[\"org.eclipse.ditto%2Cfoo.bar\"]}");
+        result.assertEntity("{\"type\":\"thing-search.commands:queryThings\",\"filter\":\"and(and(like(definition,\\\"*test*\\\")))\",\"options\":[\"limit(0\",\"5)\",\"sort(+thingId)\"],\"namespaces\":[\"foo.bar\",\"org.eclipse.ditto\"]}");
     }
 
     @Test
@@ -90,7 +93,7 @@ public final class ThingSearchRouteTest extends EndpointTestBase {
         assertThat(JsonObject.of(result.entityString()))
                 .contains(
                         JsonKey.of("filter"),
-                        "and(and%28like%28definition%2C%22%2Atest%2A%22%29%29)"
+                        "and(and(like(definition,\"*test*\")))"
                 );
     }
 

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRouteTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.endpoints.routes.thingsearch;
+
+import akka.http.javadsl.model.*;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.TestRoute;
+import akka.japi.Pair;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
+import org.eclipse.ditto.json.JsonKey;
+import org.eclipse.ditto.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
+
+/**
+ * Builder for creating Akka HTTP routes for {@code /search/things}.
+ */
+public final class ThingSearchRouteTest extends EndpointTestBase {
+
+    private ThingSearchRoute thingsSearchRoute;
+    private TestRoute underTest;
+
+
+    @Before
+    public void setUp() {
+        thingsSearchRoute = new ThingSearchRoute(routeBaseProperties);
+        final Route route = extractRequestContext(ctx -> thingsSearchRoute.buildSearchRoute(ctx, dittoHeaders));
+        underTest = testRoute(handleExceptions(() -> route));
+    }
+
+    @Test
+    public void postSearchThingsShouldGetParametersFromBody() {
+        final var formData = FormData.create(
+                List.of(
+                    new Pair<>("filter", "and(like(definition,\"*test*\"))"),
+                    new Pair<>("option", "sort(+thingId)"),
+                    new Pair<>("option","limit(0,5)"),
+                    new Pair<>("namespaces","org.eclipse.ditto,foo.bar")
+                ));
+        final var result = underTest.run(HttpRequest.POST("/search/things")
+                .withEntity(formData.toEntity()));
+
+        result.assertStatusCode(StatusCodes.OK);
+        result.assertEntity("{\"type\":\"thing-search.commands:queryThings\",\"filter\":\"and(and%28like%28definition%2C%22%2Atest%2A%22%29%29)\",\"options\":[\"sort%28%2BthingId%29\",\"limit%280%2C5%29\"],\"namespaces\":[\"org.eclipse.ditto%2Cfoo.bar\"]}");
+    }
+
+    @Test
+    public void searchThingsShouldGetFilter() {
+        final var form = "and(and(like(definition,\"*test*\")))";
+
+        final var result = underTest.run(
+                HttpRequest.GET("/search/things?filter=and(like(definition,\"*test*\"))&option=sort(+thingId)&option=limit(0,5)&namespaces=org.eclipse.ditto,foo.bar"));
+
+        result.assertStatusCode(StatusCodes.OK);
+
+        assertThat(JsonObject.of(result.entityString()))
+                .contains(
+                        JsonKey.of("filter"),
+                        form
+                );
+    }
+
+    @Test
+    public void countThingsShouldGetFilterFromBody() {
+        final var formData = FormData.create(
+                List.of(
+                        new Pair<>("filter", "and(like(definition,\"*test*\"))"),
+                        new Pair<>("option", "sort(+thingId)"),
+                        new Pair<>("option","limit(0,5)"),
+                        new Pair<>("namespaces","org.eclipse.ditto,foo.bar")
+                ));
+        final var result = underTest.run(HttpRequest.POST("/search/things/count")
+                .withEntity(formData.toEntity()));
+
+        result.assertStatusCode(StatusCodes.OK);
+        assertThat(JsonObject.of(result.entityString()))
+                .contains(
+                        JsonKey.of("filter"),
+                        "and(and%28like%28definition%2C%22%2Atest%2A%22%29%29)"
+                );
+    }
+
+    @Test
+    public void countThingsShouldAssertBadRequest() {
+        final var result = underTest.run(HttpRequest.POST("/search/things/count"));
+        result.assertStatusCode(StatusCodes.UNSUPPORTED_MEDIA_TYPE);
+    }
+}


### PR DESCRIPTION
Additional POST method accepting the search filter as payload. Workaround for longer RQL filters until QUERY is possible to implement.