### PR TITLE
fix providing Ditto Adaptable information in the "_context" of an SSE event

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/starter/GatewayRootActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/starter/GatewayRootActor.java
@@ -255,10 +255,10 @@ public final class GatewayRootActor extends DittoRootActor {
                 .devopsRoute(new DevOpsRoute(routeBaseProperties, devopsAuthenticationDirective))
                 .policiesRoute(new PoliciesRoute(routeBaseProperties,
                         OAuthTokenIntegrationSubjectIdFactory.of(authConfig.getOAuthConfig())))
-                .sseThingsRoute(
-                        ThingsSseRouteBuilder.getInstance(actorSystem, streamingActor, streamingConfig, pubSubMediator)
-                                .withProxyActor(proxyActor)
-                                .withSignalEnrichmentProvider(signalEnrichmentProvider))
+                .sseThingsRoute(ThingsSseRouteBuilder
+                        .getInstance(actorSystem, streamingActor, streamingConfig, pubSubMediator, headerTranslator)
+                        .withProxyActor(proxyActor)
+                        .withSignalEnrichmentProvider(signalEnrichmentProvider))
                 .thingsRoute(new ThingsRoute(routeBaseProperties,
                         gatewayConfig.getMessageConfig(),
                         gatewayConfig.getClaimMessageConfig()))

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRouteTest.java
@@ -159,7 +159,7 @@ public final class RootRouteTest extends EndpointTestBase {
                 .sseThingsRoute(ThingsSseRouteBuilder.getInstance(routeBaseProperties.getActorSystem(),
                         routeBaseProperties.getProxyActor(),
                         streamingConfig,
-                        routeBaseProperties.getProxyActor()))
+                        routeBaseProperties.getProxyActor(), httpHeaderTranslator))
                 .thingsRoute(new ThingsRoute(routeBaseProperties, messageConfig, claimMessageConfig))
                 .thingSearchRoute(new ThingSearchRoute(routeBaseProperties))
                 .whoamiRoute(new WhoamiRoute(routeBaseProperties))

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
@@ -26,6 +26,7 @@ import org.assertj.core.util.Lists;
 import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
 import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.translator.HeaderTranslator;
 import org.eclipse.ditto.gateway.api.GatewayServiceUnavailableException;
 import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
 import org.eclipse.ditto.gateway.service.streaming.actors.SessionedJsonifiable;
@@ -101,7 +102,8 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
                 () -> CompletableFuture.completedFuture(dittoHeaders);
 
         final var sseRouteBuilder =
-                ThingsSseRouteBuilder.getInstance(actorSystem, streamingActor.ref(), streamingConfig, proxyActor.ref());
+                ThingsSseRouteBuilder.getInstance(actorSystem, streamingActor.ref(), streamingConfig, proxyActor.ref(),
+                        HeaderTranslator.empty());
         sseRouteBuilder.withProxyActor(proxyActor.ref());
         final Route sseRoute = extractRequestContext(ctx -> sseRouteBuilder.build(ctx, dittoHeadersSupplier));
         underTest = testRoute(sseRoute);


### PR DESCRIPTION
Previously, the optional `_context` of a SSE subscription only contained the `headers`.

For the `NormalizedMessageMapper` of connectivity, however, also additional information from the Ditto Adpatable is provided, like:
* topic
* path

This PR adds this information as well for the SSE `_context` and fixes that the `headers` included Ditto internal headers which should not be exposed.