### PR TITLE
Enable configuration of size "limits" in Helm chart

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.6  # chart version is effectively set by release-job
+version: 3.3.8  # chart version is effectively set by release-job
 appVersion: 3.3.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -156,6 +156,20 @@ spec:
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
             {{- end }}
+            - name: REMOTE_MAX_FRAMESIZE
+              value: "{{ .Values.global.limits.akkaClusterMaxFramesize }}"
+            - name: LIMITS_THINGS_MAX_SIZE
+              value: "{{ .Values.global.limits.thingsMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_SIZE
+              value: "{{ .Values.global.limits.policiesMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_IMPORTS
+              value: "{{ .Values.global.limits.policiesMaxImports }}"
+            - name: LIMITS_MESSAGES_MAX_SIZE
+              value: "{{ .Values.global.limits.messagesMaxSize }}"
+            - name: LIMITS_MESSAGES_HEADERS_SIZE
+              value: "{{ .Values.global.limits.maxHeadersSize }}"
+            - name: LIMITS_MESSAGES_AUTH_SUBJECTS_COUNT
+              value: "{{ .Values.global.limits.maxAuthSubjectsCount }}"
             - name: AKKA_PERSISTENCE_MONGO_JOURNAL_WRITE_CONCERN
               value: "{{ .Values.connectivity.config.mongodb.journalWriteConcern }}"
             - name: AKKA_PERSISTENCE_MONGO_SNAPS_WRITE_CONCERN

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -153,6 +153,20 @@ spec:
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"
             {{- end }}
+            - name: REMOTE_MAX_FRAMESIZE
+              value: "{{ .Values.global.limits.akkaClusterMaxFramesize }}"
+            - name: LIMITS_THINGS_MAX_SIZE
+              value: "{{ .Values.global.limits.thingsMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_SIZE
+              value: "{{ .Values.global.limits.policiesMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_IMPORTS
+              value: "{{ .Values.global.limits.policiesMaxImports }}"
+            - name: LIMITS_MESSAGES_MAX_SIZE
+              value: "{{ .Values.global.limits.messagesMaxSize }}"
+            - name: LIMITS_MESSAGES_HEADERS_SIZE
+              value: "{{ .Values.global.limits.maxHeadersSize }}"
+            - name: LIMITS_MESSAGES_AUTH_SUBJECTS_COUNT
+              value: "{{ .Values.global.limits.maxAuthSubjectsCount }}"
             - name: ENABLE_PRE_AUTHENTICATION
               value: "{{ or .Values.gateway.config.authentication.enablePreAuthentication (not .Values.global.jwtOnly) }}"
             - name: DEVOPS_SECURED

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -174,6 +174,20 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: REMOTE_MAX_FRAMESIZE
+              value: "{{ .Values.global.limits.akkaClusterMaxFramesize }}"
+            - name: LIMITS_THINGS_MAX_SIZE
+              value: "{{ .Values.global.limits.thingsMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_SIZE
+              value: "{{ .Values.global.limits.policiesMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_IMPORTS
+              value: "{{ .Values.global.limits.policiesMaxImports }}"
+            - name: LIMITS_MESSAGES_MAX_SIZE
+              value: "{{ .Values.global.limits.messagesMaxSize }}"
+            - name: LIMITS_MESSAGES_HEADERS_SIZE
+              value: "{{ .Values.global.limits.maxHeadersSize }}"
+            - name: LIMITS_MESSAGES_AUTH_SUBJECTS_COUNT
+              value: "{{ .Values.global.limits.maxAuthSubjectsCount }}"
             - name: AKKA_PERSISTENCE_MONGO_JOURNAL_WRITE_CONCERN
               value: "{{ .Values.policies.config.mongodb.journalWriteConcern }}"
             - name: AKKA_PERSISTENCE_MONGO_SNAPS_WRITE_CONCERN
@@ -208,6 +222,8 @@ spec:
               value: "{{ .Values.policies.config.cleanup.timerThreshold }}"
             - name: CLEANUP_CREDITS_PER_BATCH
               value: "{{ .Values.policies.config.cleanup.creditsPerBatch }}"
+            - name: CLEANUP_DELETE_FINAL_DELETED_SNAPSHOT
+              value: "{{ .Values.policies.config.cleanup.deleteFinalDeletedSnapshot }}"
             - name: POLICIES_PERSISTENCE_PING_RATE_FREQUENCY
               value: "{{ .Values.policies.config.persistence.pingRate.frequency }}"
             - name: POLICIES_PERSISTENCE_PING_RATE_ENTITIES

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -175,6 +175,20 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: REMOTE_MAX_FRAMESIZE
+              value: "{{ .Values.global.limits.akkaClusterMaxFramesize }}"
+            - name: LIMITS_THINGS_MAX_SIZE
+              value: "{{ .Values.global.limits.thingsMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_SIZE
+              value: "{{ .Values.global.limits.policiesMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_IMPORTS
+              value: "{{ .Values.global.limits.policiesMaxImports }}"
+            - name: LIMITS_MESSAGES_MAX_SIZE
+              value: "{{ .Values.global.limits.messagesMaxSize }}"
+            - name: LIMITS_MESSAGES_HEADERS_SIZE
+              value: "{{ .Values.global.limits.maxHeadersSize }}"
+            - name: LIMITS_MESSAGES_AUTH_SUBJECTS_COUNT
+              value: "{{ .Values.global.limits.maxAuthSubjectsCount }}"
             - name: AKKA_PERSISTENCE_MONGO_JOURNAL_WRITE_CONCERN
               value: "{{ .Values.things.config.mongodb.journalWriteConcern }}"
             - name: AKKA_PERSISTENCE_MONGO_SNAPS_WRITE_CONCERN
@@ -209,6 +223,8 @@ spec:
               value: "{{ .Values.things.config.cleanup.timerThreshold }}"
             - name: CLEANUP_CREDITS_PER_BATCH
               value: "{{ .Values.things.config.cleanup.creditsPerBatch }}"
+            - name: CLEANUP_DELETE_FINAL_DELETED_SNAPSHOT
+              value: "{{ .Values.things.config.cleanup.deleteFinalDeletedSnapshot }}"
             - name: THING_SNAPSHOT_INTERVAL
               value: "{{ .Values.things.config.persistence.snapshots.interval }}"
             - name: THING_SNAPSHOT_THRESHOLD

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -153,6 +153,20 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: REMOTE_MAX_FRAMESIZE
+              value: "{{ .Values.global.limits.akkaClusterMaxFramesize }}"
+            - name: LIMITS_THINGS_MAX_SIZE
+              value: "{{ .Values.global.limits.thingsMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_SIZE
+              value: "{{ .Values.global.limits.policiesMaxSize }}"
+            - name: LIMITS_POLICIES_MAX_IMPORTS
+              value: "{{ .Values.global.limits.policiesMaxImports }}"
+            - name: LIMITS_MESSAGES_MAX_SIZE
+              value: "{{ .Values.global.limits.messagesMaxSize }}"
+            - name: LIMITS_MESSAGES_HEADERS_SIZE
+              value: "{{ .Values.global.limits.maxHeadersSize }}"
+            - name: LIMITS_MESSAGES_AUTH_SUBJECTS_COUNT
+              value: "{{ .Values.global.limits.maxAuthSubjectsCount }}"
             - name: MONGO_DB_READ_PREFERENCE
               value: "{{ .Values.thingsSearch.config.mongodb.searchReadPreference }}"
             - name: QUERY_PERSISTENCE_MONGO_DB_READ_CONCERN

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -52,6 +52,22 @@ global:
     downingStableAfter: 15s
     # downAllWhenUnstable is a configuration of the Akka SBR (split brain resolver)
     downAllWhenUnstable: "on"
+  # limits contains information about limit configuration, e.g. towards max. entity and payload sizes
+  limits:
+    # akkaClusterMaxFramesize the maximum serialized message size in the cluster, including header data, default: 256 KiB
+    akkaClusterMaxFramesize: 256k
+    # thingsMaxSize the maximum possible size of "Thing" entities, default: 100k
+    thingsMaxSize: 100k
+    # policiesMaxSize the maximum possible size of "Policy" entities, default: 100k
+    policiesMaxSize: 100k
+    # policiesMaxImports the maximum possible number of allowed imports a Policy can have
+    policiesMaxImports: 10
+    # messagesMaxSize the maximum possible size of "Messages" (their payload), default: 250k
+    messagesMaxSize: 250k
+    # maxHeadersSize the maximum possible size of Ditto headers (e.g. all HTTP headers are mapped to Ditto headers), default: 5k
+    maxHeadersSize: 5k
+    # maxAuthSubjectsCount the maximum possible number of authorization subjects in Ditto headers, default: 100
+    maxAuthSubjectsCount: 100
   # basicAuthUsers configures (as a map) several user/password combinations which the nginx of the Ditto chart will authenticate
   basicAuthUsers: {}
   # ditto:
@@ -533,6 +549,12 @@ policies:
       timerThreshold: 100ms
       # creditsPerBatch configures how many "cleanup credits" should be generated per "interval" as long as the
       creditsPerBatch: 5
+      # deleteFinalDeletedSnapshot configures whether for a deleted entity, the final snapshot (containing the
+      #  "deleted" information) should be deleted or not.
+      #  If the final snapshot is not deleted, re-creating the entity will cause that the recreated entity starts with
+      #  a revision number 1 higher than the previously deleted entity. If the final snapshot is deleted as well,
+      #  recreation of an entity with the same ID will lead to revisionNumber=1 after its recreation.
+      deleteFinalDeletedSnapshot: true
     # persistence holds configuration regarding (akka) persistence of policies (event journal and snapshots)
     persistence:
       # activityCheckInterval configures to keep policies for that amount of time in memory when no other use did happen:
@@ -727,6 +749,12 @@ things:
       timerThreshold: 100ms
       # creditsPerBatch configures how many "cleanup credits" should be generated per "interval" as long as the
       creditsPerBatch: 5
+      # deleteFinalDeletedSnapshot configures whether for a deleted entity, the final snapshot (containing the
+      #  "deleted" information) should be deleted or not.
+      #  If the final snapshot is not deleted, re-creating the entity will cause that the recreated entity starts with
+      #  a revision number 1 higher than the previously deleted entity. If the final snapshot is deleted as well,
+      #  recreation of an entity with the same ID will lead to revisionNumber=1 after its recreation.
+      deleteFinalDeletedSnapshot: true
     # persistence holds configuration regarding (akka) persistence of things (event journal and snapshots)
     persistence:
       # activityCheckInterval configures to keep things for that amount of time in memory when no other use did happen


### PR DESCRIPTION
This PR exposes the configuration of limits like "thing size, policy size, message size" to Helm values.