### PR TITLE
Allow spaces inside placeholder in target issued acknowledgement label

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/acks/AcknowledgementLabels.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/acks/AcknowledgementLabels.java
@@ -35,7 +35,7 @@ final class AcknowledgementLabels {
      * Ack labels starting with unresolved placeholders are also valid, e.g.: {@code {{connection:id}}:my-ack}.
      */
     public static final String ACK_LABEL_REGEX =
-            "(?<" + PLACEHOLDER_GROUP + ">\\{\\{\\w*[a-z]+:[a-z]+\\w*}}:)?[a-zA-Z0-9-_:]{3,165}";
+            "(?<" + PLACEHOLDER_GROUP + ">\\{\\{\\s*[a-z]+:[a-z]+\\s*}}:)?[a-zA-Z0-9-_:]{3,165}";
 
     private static final Pattern ACK_LABEL_PATTERN = Pattern.compile(ACK_LABEL_REGEX);
 

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/acks/AcknowledgementLabelsTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/acks/AcknowledgementLabelsTest.java
@@ -88,7 +88,11 @@ public final class AcknowledgementLabelsTest {
                     RegexValidationParameter.valid("___"),
                     RegexValidationParameter.valid("FOO-BAR"),
                     RegexValidationParameter.valid("0123456789"),
-                    RegexValidationParameter.valid("{{connection:id}}:foo")
+                    RegexValidationParameter.valid("{{connection:id}}:foo"),
+                    RegexValidationParameter.invalid("foo:{{connection:id}}"),
+                    RegexValidationParameter.valid("{{ connection:id }}:foo"),
+                    RegexValidationParameter.valid("{{  connection:id  }}:foo"),
+                    RegexValidationParameter.valid("{{ thing:id }}:foo")
             );
         }
 


### PR DESCRIPTION
Issued acknowledgement label for target must start with connection ID. This can be achieved by using `connection:id` placeholder. Usually placeholders allow using spaces inside of (right after opening and right before closing) curly brackets, for example, `{{ connection:id }}`. But validation does not allow spaces in placeholder in target issued acknowledgement label.