### PR TITLE
Add MQTT message expiry interval

### DIFF
--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/IllegalMessageExpiryIntervalSecondsException.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/IllegalMessageExpiryIntervalSecondsException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.model.mqtt;
+
+import javax.annotation.Nullable;
+
+/**
+ * This exception is thrown to indicate that the seconds of an MQTT
+ * message expiry interval is outside its allowed range.
+ */
+public final class IllegalMessageExpiryIntervalSecondsException extends Exception {
+
+    private static final long serialVersionUID = -566567001721859949L;
+
+    /**
+     * Constructs a {@code IllegalMessageExpiryIntervalSecondsException} for the specified detail message argument.
+     *
+     * @param detailMessage the detail message of the exception.
+     * @param cause the cause of the exception or {@code null} if unknown.
+     */
+    IllegalMessageExpiryIntervalSecondsException(final String detailMessage, @Nullable final Throwable cause) {
+        super(detailMessage, cause);
+    }
+
+}

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryInterval.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryInterval.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.Immutable;
  * The maximum seconds is {@value MAX_INTERVAL_SECONDS}.
  */
 @Immutable
-public class MessageExpiryInterval {
+public final class MessageExpiryInterval {
 
     public static final long MIN_INTERVAL_SECONDS = 1L;
 
@@ -36,6 +36,14 @@ public class MessageExpiryInterval {
         this.seconds = seconds;
     }
 
+    /**
+     * Returns an instance of {@code MessageExpiryInterval} for the specified interval.
+     *
+     * @param seconds the message expiry interval duration in seconds. The value must be between
+     * {@value #MIN_INTERVAL_SECONDS} and {@value #MAX_INTERVAL_SECONDS} (both inclusive).
+     * @return the MessageExpiryInterval for interval of {@code seconds}.
+     * @throws IllegalMessageExpiryIntervalSecondsException if the seconds is less than {@value MIN_INTERVAL_SECONDS} or greater than {@value #MAX_INTERVAL_SECONDS}.
+     */
     public static MessageExpiryInterval of(final long seconds)
             throws IllegalMessageExpiryIntervalSecondsException {
         if (seconds < MIN_INTERVAL_SECONDS || seconds > MAX_INTERVAL_SECONDS) {
@@ -50,10 +58,20 @@ public class MessageExpiryInterval {
         return new MessageExpiryInterval(seconds);
     }
 
+    /**
+     * Returns an instance of the empty {@code MessageExpiryInterval}.
+     *
+     * @return the empty message expiry interval.
+     */
     public static MessageExpiryInterval empty() {
         return new MessageExpiryInterval(null);
     }
 
+    /**
+     * Returns message expiry interval seconds.
+     *
+     * @return optional count of seconds in the interval.
+     */
     public OptionalLong getAsOptionalLong() {
         return seconds != null ?
                 OptionalLong.of(seconds) :

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryInterval.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryInterval.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.model.mqtt;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Representation of the MQTT 5 message expiry interval.
+ * The minimum seconds is {@value MIN_INTERVAL_SECONDS}.
+ * The maximum seconds is {@value MAX_INTERVAL_SECONDS}.
+ */
+@Immutable
+public class MessageExpiryInterval {
+
+    public static final long MIN_INTERVAL_SECONDS = 1L;
+
+    public static final long MAX_INTERVAL_SECONDS = 4_294_967_295L;
+
+    @Nullable private final Long seconds;
+
+    private MessageExpiryInterval(@Nullable final Long seconds) {
+        this.seconds = seconds;
+    }
+
+    public static MessageExpiryInterval of(final long seconds)
+            throws IllegalMessageExpiryIntervalSecondsException {
+        if (seconds < MIN_INTERVAL_SECONDS || seconds > MAX_INTERVAL_SECONDS) {
+            throw new IllegalMessageExpiryIntervalSecondsException(
+                    String.format("Expected message expiry interval seconds to be within [%d, %d] but it was <%d>.",
+                            MIN_INTERVAL_SECONDS,
+                            MAX_INTERVAL_SECONDS,
+                            seconds),
+                    null);
+        }
+
+        return new MessageExpiryInterval(seconds);
+    }
+
+    public static MessageExpiryInterval empty() {
+        return new MessageExpiryInterval(null);
+    }
+
+    public OptionalLong getAsOptionalLong() {
+        return seconds != null ?
+                OptionalLong.of(seconds) :
+                OptionalLong.empty();
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MessageExpiryInterval that = (MessageExpiryInterval) o;
+        return Objects.equals(seconds, that.seconds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(seconds);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "seconds=" + seconds +
+                "]";
+    }
+}

--- a/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryIntervalTest.java
+++ b/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/mqtt/MessageExpiryIntervalTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.model.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit test for {@link MessageExpiryInterval}.
+ */
+public final class MessageExpiryIntervalTest {
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(MessageExpiryInterval.class, areImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(MessageExpiryInterval.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void ofWithMaxValueReturnsExpected()
+            throws IllegalMessageExpiryIntervalSecondsException {
+        final MessageExpiryInterval underTest = MessageExpiryInterval.of(MessageExpiryInterval.MAX_INTERVAL_SECONDS);
+
+        assertThat(underTest.getAsOptionalLong()).hasValue(MessageExpiryInterval.MAX_INTERVAL_SECONDS);
+    }
+
+    @Test
+    public void ofWithNegativeOutOfBoundsValueThrowsException() {
+        final long negativeOutOfBoundsSeconds = MessageExpiryInterval.MIN_INTERVAL_SECONDS - 1;
+
+        assertThatExceptionOfType(IllegalMessageExpiryIntervalSecondsException.class)
+                .isThrownBy(() -> MessageExpiryInterval.of(negativeOutOfBoundsSeconds))
+                .withMessageEndingWith("but it was <%d>.", negativeOutOfBoundsSeconds)
+                .withNoCause();
+    }
+
+    @Test
+    public void ofWithPositiveOutOfBoundsValueThrowsException() {
+        final long positiveOutOfBoundsSeconds = MessageExpiryInterval.MAX_INTERVAL_SECONDS + 1;
+
+        assertThatExceptionOfType(IllegalMessageExpiryIntervalSecondsException.class)
+                .isThrownBy(() -> MessageExpiryInterval.of(positiveOutOfBoundsSeconds))
+                .withMessageEndingWith("but it was <%d>.", positiveOutOfBoundsSeconds)
+                .withNoCause();
+    }
+
+    @Test
+    public void emptyReturnsEmpty() {
+        final MessageExpiryInterval underTest = MessageExpiryInterval.empty();
+
+        assertThat(underTest.getAsOptionalLong()).isEmpty();
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3Validator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3Validator.java
@@ -34,6 +34,8 @@ import org.eclipse.ditto.placeholders.PlaceholderFactory;
 
 import org.apache.pekko.actor.ActorSystem;
 
+import com.hivemq.client.mqtt.MqttVersion;
+
 /**
  * Connection specification for Mqtt 3.1.1 protocol.
  */
@@ -150,12 +152,12 @@ public final class Mqtt3Validator extends AbstractMqttValidator {
     }
 
     private static void checkIfKeyIsAllowed(final String key, final DittoHeaders dittoHeaders) {
-        if (!MqttHeader.getHeaderNames().contains(key)) {
+        if (!MqttHeader.getHeaderNames(MqttVersion.MQTT_3_1_1).contains(key)) {
             final String message = String.format("The header '%s' is not allowed in MQTT 3.1.1 target header mapping.",
                     key);
             final String description = String.format(
                     "The following headers are allowed and are directly applied to the published MQTT message: %s",
-                    MqttHeader.getHeaderNames());
+                    MqttHeader.getHeaderNames(MqttVersion.MQTT_3_1_1));
             throw ConnectionConfigurationInvalidException
                     .newBuilder(message)
                     .description(description)
@@ -196,12 +198,12 @@ public final class Mqtt3Validator extends AbstractMqttValidator {
 
         @Override
         public List<String> getSupportedNames() {
-            return MqttHeader.getHeaderNames();
+            return MqttHeader.getHeaderNames(MqttVersion.MQTT_3_1_1);
         }
 
         @Override
         public boolean supports(final String name) {
-            return MqttHeader.getHeaderNames().contains(name);
+            return MqttHeader.getHeaderNames(MqttVersion.MQTT_3_1_1).contains(name);
         }
     }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttHeader.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttHeader.java
@@ -24,7 +24,8 @@ public enum MqttHeader {
 
     MQTT_TOPIC("mqtt.topic"),
     MQTT_QOS("mqtt.qos"),
-    MQTT_RETAIN("mqtt.retain");
+    MQTT_RETAIN("mqtt.retain"),
+    MQTT_MESSAGE_EXPIRY_INTERVAL("mqtt.message-expiry-interval");
 
     private final String name;
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttPublishToExternalMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttPublishToExternalMessageTransformer.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -158,6 +159,9 @@ final class MqttPublishToExternalMessageTransformer {
         result.put(MqttHeader.MQTT_QOS.getName(), getQosCodeAsString(genericMqttPublish));
         result.put(MqttHeader.MQTT_RETAIN.getName(), getIsRetainAsString(genericMqttPublish));
 
+        getMessageExpiryIntervalAsString(genericMqttPublish)
+                .ifPresent(messageExpiryInterval -> result.put(MqttHeader.MQTT_MESSAGE_EXPIRY_INTERVAL.getName(), messageExpiryInterval));
+
         genericMqttPublish.getCorrelationData()
                 .map(ByteBufferUtils::toUtf8String)
                 .ifPresent(correlationId -> result.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), correlationId));
@@ -186,6 +190,13 @@ final class MqttPublishToExternalMessageTransformer {
 
     private static String getIsRetainAsString(final GenericMqttPublish genericMqttPublish) {
         return String.valueOf(genericMqttPublish.isRetain());
+    }
+
+    private static Optional<String> getMessageExpiryIntervalAsString(final GenericMqttPublish genericMqttPublish) {
+        final var messageExpiryInterval = genericMqttPublish.getMessageExpiryInterval().getAsOptionalLong();
+        return messageExpiryInterval.isPresent() ?
+                Optional.of(String.valueOf(messageExpiryInterval.getAsLong())) :
+                Optional.empty();
     }
 
     private ExternalMessage getExternalMessage(final GenericMqttPublish genericMqttPublish,

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/message/publish/GenericMqttPublish.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/message/publish/GenericMqttPublish.java
@@ -112,6 +112,11 @@ public abstract class GenericMqttPublish {
      */
     public abstract boolean isRetain();
 
+    /**
+     * Returns expiry interval for this Publish message.
+     *
+     * @return message expiry interval.
+     */
     public abstract MessageExpiryInterval getMessageExpiryInterval();
 
     public abstract Optional<ByteBuffer> getCorrelationData();
@@ -238,6 +243,12 @@ public abstract class GenericMqttPublish {
             return this;
         }
 
+        /**
+         * Sets message expiry interval.
+         *
+         * @param messageExpiryInterval expiry interval of the Publish
+         * @return this Builder instance for method chaining.
+         */
         public Builder messageExpiryInterval(final MessageExpiryInterval messageExpiryInterval) {
             this.messageExpiryInterval = messageExpiryInterval;
             return this;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/message/publish/GenericMqttPublish.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/message/publish/GenericMqttPublish.java
@@ -17,6 +17,7 @@ import java.text.MessageFormat;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -27,6 +28,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.common.CharsetDeterminer;
 import org.eclipse.ditto.base.model.common.ConditionChecker;
+import org.eclipse.ditto.connectivity.model.mqtt.IllegalMessageExpiryIntervalSecondsException;
+import org.eclipse.ditto.connectivity.model.mqtt.MessageExpiryInterval;
 
 import com.hivemq.client.mqtt.MqttVersion;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
@@ -109,6 +112,8 @@ public abstract class GenericMqttPublish {
      */
     public abstract boolean isRetain();
 
+    public abstract MessageExpiryInterval getMessageExpiryInterval();
+
     public abstract Optional<ByteBuffer> getCorrelationData();
 
     public abstract Optional<MqttTopic> getResponseTopic();
@@ -169,9 +174,16 @@ public abstract class GenericMqttPublish {
     public abstract Mqtt5Publish getAsMqtt5Publish();
 
     private static Mqtt5Publish getAsMqtt5Publish(final GenericMqttPublish genericMqttPublish) {
-        return Mqtt5Publish.builder()
+        var builder = Mqtt5Publish.builder()
                 .topic(genericMqttPublish.getTopic())
-                .qos(genericMqttPublish.getQos())
+                .qos(genericMqttPublish.getQos());
+
+        final var messageExpiryInterval = genericMqttPublish.getMessageExpiryInterval().getAsOptionalLong();
+        if (messageExpiryInterval.isPresent()) {
+            builder = builder.messageExpiryInterval(messageExpiryInterval.getAsLong());
+        }
+
+        return builder
                 .retain(genericMqttPublish.isRetain())
                 .payload(genericMqttPublish.getPayload().orElse(null))
                 .correlationData(genericMqttPublish.getCorrelationData().orElse(null))
@@ -196,6 +208,7 @@ public abstract class GenericMqttPublish {
         private final MqttTopic mqttTopic;
         private final MqttQos mqttQos;
         private boolean retain;
+        private MessageExpiryInterval messageExpiryInterval;
         @Nullable private ByteBuffer payload;
         @Nullable private ByteBuffer correlationData;
         @Nullable private MqttTopic responseTopic;
@@ -206,6 +219,7 @@ public abstract class GenericMqttPublish {
             this.mqttTopic = ConditionChecker.checkNotNull(mqttTopic, "mqttTopic");
             this.mqttQos = ConditionChecker.checkNotNull(mqttQos, "mqttQos");
             retain = false;
+            messageExpiryInterval = MessageExpiryInterval.empty();
             payload = null;
             correlationData = null;
             responseTopic = null;
@@ -221,6 +235,11 @@ public abstract class GenericMqttPublish {
          */
         public Builder retain(final boolean retain) {
             this.retain = retain;
+            return this;
+        }
+
+        public Builder messageExpiryInterval(final MessageExpiryInterval messageExpiryInterval) {
+            this.messageExpiryInterval = messageExpiryInterval;
             return this;
         }
 
@@ -275,6 +294,7 @@ public abstract class GenericMqttPublish {
         private final MqttTopic mqttTopic;
         private final MqttQos mqttQos;
         private final boolean retain;
+        private final MessageExpiryInterval messageExpiryInterval;
         @Nullable private final ByteBuffer payload;
         @Nullable private final ByteBuffer correlationData;
         @Nullable private final MqttTopic responseTopic;
@@ -285,6 +305,7 @@ public abstract class GenericMqttPublish {
             mqttTopic = builder.mqttTopic;
             mqttQos = builder.mqttQos;
             retain = builder.retain;
+            messageExpiryInterval = builder.messageExpiryInterval;
             payload = builder.payload;
             correlationData = builder.correlationData;
             responseTopic = builder.responseTopic;
@@ -305,6 +326,11 @@ public abstract class GenericMqttPublish {
         @Override
         public boolean isRetain() {
             return retain;
+        }
+
+        @Override
+        public MessageExpiryInterval getMessageExpiryInterval() {
+            return messageExpiryInterval;
         }
 
         @Override
@@ -368,6 +394,7 @@ public abstract class GenericMqttPublish {
             return Objects.equals(mqttTopic, that.mqttTopic) &&
                     mqttQos == that.mqttQos &&
                     retain == that.retain &&
+                    Objects.equals(messageExpiryInterval, that.messageExpiryInterval) &&
                     Objects.equals(payload, that.payload) &&
                     Objects.equals(correlationData, that.correlationData) &&
                     Objects.equals(responseTopic, that.responseTopic) &&
@@ -380,6 +407,7 @@ public abstract class GenericMqttPublish {
             return Objects.hash(mqttTopic,
                     mqttQos,
                     retain,
+                    messageExpiryInterval,
                     payload,
                     correlationData,
                     responseTopic,
@@ -393,6 +421,7 @@ public abstract class GenericMqttPublish {
                     "mqttTopic=" + mqttTopic +
                     ", mqttQos=" + mqttQos +
                     ", retain=" + retain +
+                    ", messageExpiryInterval=" + messageExpiryInterval +
                     ", payload=" + getPayloadAsHumanReadable().orElse(null) +
                     ", correlationData=" + correlationData +
                     ", responseTopic=" + responseTopic +
@@ -424,6 +453,11 @@ public abstract class GenericMqttPublish {
         @Override
         public boolean isRetain() {
             return mqtt3Publish.isRetain();
+        }
+
+        @Override
+        public MessageExpiryInterval getMessageExpiryInterval() {
+            return MessageExpiryInterval.empty();
         }
 
         @Override
@@ -523,6 +557,20 @@ public abstract class GenericMqttPublish {
         @Override
         public boolean isRetain() {
             return mqtt5Publish.isRetain();
+        }
+
+        @Override
+        public MessageExpiryInterval getMessageExpiryInterval() {
+            final var messageExpiryInterval = mqtt5Publish.getMessageExpiryInterval();
+            try {
+                return messageExpiryInterval.isPresent() ?
+                        MessageExpiryInterval.of(messageExpiryInterval.getAsLong()) :
+                        MessageExpiryInterval.empty();
+            } catch (IllegalMessageExpiryIntervalSecondsException e) {
+                // If we received message, assume message broker knows that it's correct, so don't drop it.
+                // But as we can't handle such values, fall back to empty message expiry interval.
+                return MessageExpiryInterval.empty();
+            }
         }
 
         @Override

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3ValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3ValidatorTest.java
@@ -256,6 +256,14 @@ public final class Mqtt3ValidatorTest extends AbstractMqttValidatorTest {
     }
 
     @Test
+    public void testInvalidSourceMappingValueIfMqtt5HeaderIsUsed() {
+        final HeaderMapping invalidHeaderMapping = ConnectivityModelFactory.newHeaderMapping(Map.of(
+                "timeout", "{{ header:mqtt.message-expiry-interval }}"
+        ));
+        testSourceMapping(invalidHeaderMapping, "header:mqtt.message-expiry-interval");
+    }
+
+    @Test
     public void testValidSourceMappingKeys() {
         final HeaderMapping validHeaderMapping = ConnectivityModelFactory.newHeaderMapping(Map.of(
                 "mqtt.topic", "{{ header:mqtt.topic }}",

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttHeaderTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttHeaderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.mqtt;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.hivemq.client.mqtt.MqttVersion;
+
+import java.util.List;
+
+/**
+ * Unit test for {@link MqttHeader}
+ */
+public class MqttHeaderTest {
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Test
+    public void getHeaderNamesReturnsExpectedHeadersForMqtt3() {
+        final var expected = List.of(
+                MqttHeader.MQTT_TOPIC.getName(),
+                MqttHeader.MQTT_QOS.getName(),
+                MqttHeader.MQTT_RETAIN.getName());
+        final var actual = MqttHeader.getHeaderNames(MqttVersion.MQTT_3_1_1);
+
+        softly.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    public void getHeaderNamesReturnsExpectedHeadersForMqtt5() {
+        final var expected = List.of(
+                MqttHeader.MQTT_TOPIC.getName(),
+                MqttHeader.MQTT_QOS.getName(),
+                MqttHeader.MQTT_RETAIN.getName(),
+                MqttHeader.MQTT_MESSAGE_EXPIRY_INTERVAL.getName());
+        final var actual = MqttHeader.getHeaderNames(MqttVersion.MQTT_5_0);
+
+        softly.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MqttClientActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MqttClientActorTest.java
@@ -94,6 +94,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.hivemq.client.mqtt.MqttVersion;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopic;
 import com.typesafe.config.ConfigFactory;
@@ -289,7 +290,7 @@ public final class MqttClientActorTest extends AbstractBaseClientActorTest {
         testKit.expectNoMessage();
         final var modifyThing = commandForwarder.expectMsgClass(ModifyThing.class);
         assertThat(modifyThing.getDittoHeaders())
-                .doesNotContainKeys(MqttHeader.getHeaderNames().toArray(String[]::new));
+                .doesNotContainKeys(MqttHeader.getHeaderNames(MqttVersion.MQTT_5_0).toArray(String[]::new));
 
         underTest.tell(RetrieveConnectionMetrics.of(CONNECTION_ID, dittoHeadersWithCorrelationId), testKit.getRef());
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttPublishToExternalMessageTransformerTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttPublishToExternalMessageTransformerTest.java
@@ -79,6 +79,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
     private static final MqttTopic MQTT_TOPIC = MqttTopic.of("source/my-connection");
     private static final MqttQos MQTT_QOS = MqttQos.AT_LEAST_ONCE;
     private static final boolean RETAIN = true;
+    private static final Long MESSAGE_EXPIRY_INTERVAL = 10L;
     private static final String CORRELATION_ID = String.valueOf(UUID.randomUUID());
     private static final MqttTopic RESPONSE_TOPIC = MqttTopic.of("my-response-topic");
     private static final String CONTENT_TYPE = "application/json";
@@ -153,6 +154,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                 .topic(MQTT_TOPIC)
                 .qos(MQTT_QOS)
                 .retain(RETAIN)
+                .messageExpiryInterval(MESSAGE_EXPIRY_INTERVAL)
                 .correlationData(ByteBufferUtils.fromUtf8String(CORRELATION_ID))
                 .responseTopic(RESPONSE_TOPIC)
                 .contentType(CONTENT_TYPE)
@@ -168,6 +170,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                                         Map.entry(MqttHeader.MQTT_TOPIC.getName(), MQTT_TOPIC.toString()),
                                         Map.entry(MqttHeader.MQTT_QOS.getName(), String.valueOf(MQTT_QOS.getCode())),
                                         Map.entry(MqttHeader.MQTT_RETAIN.getName(), String.valueOf(RETAIN)),
+                                        Map.entry(MqttHeader.MQTT_MESSAGE_EXPIRY_INTERVAL.getName(), String.valueOf(MESSAGE_EXPIRY_INTERVAL)),
                                         Map.entry(DittoHeaderDefinition.CORRELATION_ID.getKey(), CORRELATION_ID),
                                         Map.entry(DittoHeaderDefinition.REPLY_TO.getKey(), RESPONSE_TOPIC.toString()),
                                         Map.entry(DittoHeaderDefinition.CONTENT_TYPE.getKey(), CONTENT_TYPE)
@@ -196,6 +199,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                 .topic(MQTT_TOPIC)
                 .qos(MQTT_QOS)
                 .retain(RETAIN)
+                .messageExpiryInterval(MESSAGE_EXPIRY_INTERVAL)
                 .correlationData(ByteBufferUtils.fromUtf8String(CORRELATION_ID))
                 .responseTopic(RESPONSE_TOPIC)
                 .contentType(CONTENT_TYPE)
@@ -211,6 +215,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                                         Map.entry(MqttHeader.MQTT_TOPIC.getName(), MQTT_TOPIC.toString()),
                                         Map.entry(MqttHeader.MQTT_QOS.getName(), String.valueOf(MQTT_QOS.getCode())),
                                         Map.entry(MqttHeader.MQTT_RETAIN.getName(), String.valueOf(RETAIN)),
+                                        Map.entry(MqttHeader.MQTT_MESSAGE_EXPIRY_INTERVAL.getName(), String.valueOf(MESSAGE_EXPIRY_INTERVAL)),
                                         Map.entry(DittoHeaderDefinition.CORRELATION_ID.getKey(), CORRELATION_ID),
                                         Map.entry(DittoHeaderDefinition.REPLY_TO.getKey(), RESPONSE_TOPIC.toString()),
                                         Map.entry(DittoHeaderDefinition.CONTENT_TYPE.getKey(), CONTENT_TYPE)
@@ -235,6 +240,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                         Map.entry(MqttHeader.MQTT_TOPIC.getName(), MQTT_TOPIC.toString()),
                         Map.entry(MqttHeader.MQTT_QOS.getName(), String.valueOf(MQTT_QOS.getCode())),
                         Map.entry(MqttHeader.MQTT_RETAIN.getName(), String.valueOf(RETAIN)),
+                        Map.entry(MqttHeader.MQTT_MESSAGE_EXPIRY_INTERVAL.getName(), String.valueOf(MESSAGE_EXPIRY_INTERVAL)),
                         Map.entry(DittoHeaderDefinition.CORRELATION_ID.getKey(), CORRELATION_ID),
                         Map.entry(DittoHeaderDefinition.REPLY_TO.getKey(), RESPONSE_TOPIC.toString()),
                         Map.entry(DittoHeaderDefinition.CONTENT_TYPE.getKey(), CONTENT_TYPE)
@@ -252,6 +258,7 @@ public final class MqttPublishToExternalMessageTransformerTest {
                 .topic(MQTT_TOPIC)
                 .qos(MQTT_QOS)
                 .retain(RETAIN)
+                .messageExpiryInterval(MESSAGE_EXPIRY_INTERVAL)
                 .correlationData(ByteBufferUtils.fromUtf8String(CORRELATION_ID))
                 .responseTopic(RESPONSE_TOPIC)
                 .contentType(CONTENT_TYPE)

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
@@ -25,6 +25,7 @@ Supported MQTT 5 properties, which are interpreted in a specific way are:
 * `8 (0x08) Response Topic`: The MQTT topic a requests response is expected in.
   If a command sets the header `reply-to`, then its response is published at the topic equal to the header value.
 * `3 (0x03) Content Type`: The UTF-8 encoded string representation of the payloads content MIME type.
+* `2 (0x02) Message Expiry Interval`: Lifetime of the message in seconds.
 
 ## Specific connection configuration
 
@@ -64,6 +65,7 @@ In addition, Ditto extracts the following headers from each consumed message:
 * `mqtt.topic`: contains the MQTT topic on which a message was received 
 * `mqtt.qos`: contains the MQTT QoS value of a received message
 * `mqtt.retain`: contains the MQTT retain flag of a received message
+* `mqtt.message-expiry-interval`: contains the MQTT 5 message expiry interval of a received message
 * `correlation-id`: contains the MQTT 5 "correlation data" value
 * `reply-to`: contains the MQTT 5 "response topic" value
 * `content-type`: contains the MQTT 5 "content type" value
@@ -156,6 +158,7 @@ The following headers have a special meaning in that the values are applied dire
 * `mqtt.topic`: overwrites the topic configured for the target 
 * `mqtt.qos`: overwrites the qos level configured in the target 
 * `mqtt.retain`: controls whether the MQTT retain flag is set on the published message  
+* `mqtt.message-expiry-interval`: sets MQTT 5 message expiry interval of the published message  
 
 #### Target acknowledgement handling
 


### PR DESCRIPTION
Resolves #1729

Please, be patient. As I'm C# developer, I assume, there are moments done in non-Java way. If you find some names or language constructs that feel strange or non-Java-like, I'd be grateful if you point them out to me.

My concerns are:

1. In class `ExternalMessageToMqttPublishTransformerTest` constant `RETAIN_FALL_BACK` was not used. It might have been used in method:

    ```java
    @Test
    public void transformExternalMessageWithoutRetainValueInHeadersFallsBackToFalse() {
        Mockito.when(externalMessage.getHeaders()).thenReturn(DittoHeaders.empty());
    
        assertThat(ExternalMessageToMqttPublishTransformer.transform(externalMessage, mqttPublishTarget))
                .isEqualTo(TransformationSuccess.of(externalMessage,
                        GenericMqttPublish.builder(MQTT_TOPIC_FALL_BACK, MQTT_QOS_FALL_BACK)
                                .retain(false)
                                .build()));
    }
    ```

    I believe, as long as the method is named as "*FallsBackToFalse" it's ok to use false instead of class constant.
2. I'm not sure about implementation of class `MessageExpiryInterval`, especially about method `getAsOptionalLong`. I was choosing between `Optional<Long>` and `OptionalLong`. I chose `OptionalLong` because it doesn't do boxing and it has only 2 states - does or doesn't have value, whereas `Optional<Long>` allows 3 states - doesn't have value, has `null` value and has not-`null` value.
3. Header name `mqtt.message-expiry-interval` seems a bit long. I thought about `mqtt.expiry` but decided to stick with MQTT 5 name.
4. In class `GenericMqttPublish` I didn't know what to do when we got message from broker with invalid message expiry interval. I decided to not throw any exception and just fall back to no message expiry interval. Probably, need to log something here. Throwing exception doesn't seem to be an option here, cause it'll be needed to be added to signatures of whole call tree of this method.
5. I added MQTT version to enum MqttHeader. Not sure if adding this kind of info to enum is OK in general.
6. I consider adding message expiry interval to last will message as out-of-scope.