### PR TITLE
fix(helm): fix missing whitespace in JAVA_TOOL_OPTIONS

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.8  # chart version is effectively set by release-job
+version: 3.3.9  # chart version is effectively set by release-job
 appVersion: nightly
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -126,7 +126,7 @@ spec:
                 -XX:InitialRAMPercentage={{ .Values.connectivity.jvm.heapRamPercentage }}
                 -XX:MaxGCPauseMillis={{ .Values.connectivity.jvm.maxGcPauseMillis }}
                 {{ .Values.connectivity.additionalJvmOptions }}
-                {{- .Values.global.pekkoOptions }}
+                {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
                 {{- end }}

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -127,7 +127,7 @@ spec:
                 -XX:InitialRAMPercentage={{ .Values.gateway.jvm.heapRamPercentage }}
                 -XX:MaxGCPauseMillis={{ .Values.gateway.jvm.maxGcPauseMillis }}
                 {{ .Values.gateway.additionalJvmOptions }}
-                {{- .Values.global.pekkoOptions }}
+                {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
                 {{- end }}

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -126,7 +126,7 @@ spec:
                 -XX:InitialRAMPercentage={{ .Values.things.jvm.heapRamPercentage }}
                 -XX:MaxGCPauseMillis={{ .Values.things.jvm.maxGcPauseMillis }}
                 {{ .Values.things.additionalJvmOptions }}
-                {{- .Values.global.pekkoOptions }}
+                {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
                 {{- end }}

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -126,7 +126,7 @@ spec:
                 -XX:InitialRAMPercentage={{ .Values.thingsSearch.jvm.heapRamPercentage }}
                 -XX:MaxGCPauseMillis={{ .Values.thingsSearch.jvm.maxGcPauseMillis }}
                 {{ .Values.thingsSearch.additionalJvmOptions }}
-                {{- .Values.global.pekkoOptions }}
+                {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
                 {{- end }}


### PR DESCRIPTION
In the JAVA_TOOL_OPTIONS environment variable, the different values get put together without any (white)space.
This could lead to some options not being processed by the JVM.

This PR fixes this by removing the "trim whitespace" character from the affected template.