### PR TITLE
Allow BASIC authentication for devops/status users while using Helm deployment and Ingress Controller 

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,8 +16,8 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.3.7  # chart version is effectively set by release-job
-appVersion: 3.3.7
+version: 3.3.8  # chart version is effectively set by release-job
+appVersion: nightly
 keywords:
   - iot-chart
   - digital-twin

--- a/deployment/helm/ditto/templates/nginx-ingress-devops.yaml
+++ b/deployment/helm/ditto/templates/nginx-ingress-devops.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ditto.fullname" . -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-devops
+  labels:
+    app.kubernetes.io/name: {{ include "ditto.name" . }}-nginx
+{{ include "ditto.labels" . | indent 4 }}
+  annotations:
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.devops.annotations }}
+  {{- with .Values.ingress.devops.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  {{- with .Values.ingress.api.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}    
+  {{- end }}
+
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  defaultBackend:
+    service:
+      name: {{ $fullName }}-{{ .Values.ingress.defaultBackendSuffix }}
+      port:
+        name: http
+{{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          {{- range .Values.ingress.devops.paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- else }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              service:
+                name: {{ $fullName }}-{{ .backendSuffix }}
+                port:
+                  name: http
+          {{- end }}
+{{- end }}

--- a/deployment/helm/ditto/templates/nginx-ingress.yaml
+++ b/deployment/helm/ditto/templates/nginx-ingress.yaml
@@ -646,7 +646,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["sleep", "95"]
+              command: ["sleep", "{{ .Values.ingress.controller.preStopWait }}"]
         env:
         - name: POD_NAME
           valueFrom:

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -206,6 +206,10 @@ ingress:
     #  of its containers crashing, for it to be considered available
     #  ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds
     minReadySeconds: 10
+    # as NGINX Ingress Controller on its pod shutdown tends to interrupt connections, we need to include 
+    # some wait time so that existing connections are fully handled before the pod is really shut down. 
+    # ref: https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8
+    preStopWait: 15
     # specify how many old ReplicaSets for ingress controller deployment will be retained
     # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
     revisionHistoryLimit: 5

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -206,8 +206,8 @@ ingress:
     #  of its containers crashing, for it to be considered available
     #  ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds
     minReadySeconds: 10
-    # as NGINX Ingress Controller on its pod shutdown tends to interrupt connections, we need to include 
-    # some wait time so that existing connections are fully handled before the pod is really shut down. 
+    # as NGINX Ingress Controller on its pod shutdown tends to interrupt connections, we need to include
+    # some wait time so that existing connections are fully handled before the pod is really shut down.
     # ref: https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8
     preStopWait: 15
     # specify how many old ReplicaSets for ingress controller deployment will be retained

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -218,7 +218,7 @@ ingress:
     # namespace for ingress controller, managed by helm, should not be created manually
     namespace: ingress-nginx
     # Ingress-NGINX version. Check Supported Versions table from https://github.com/kubernetes/ingress-nginx to match k8s version.
-    nginxIngressVersion: "v1.8.0"
+    nginxIngressVersion: "v1.9.0"
     # Nginx Version. Check Supported Versions table from https://github.com/kubernetes/ingress-nginx to match k8s version.
     nginxVersion: "1.21.6"
     # Pod topology spread constraints for nginx-ingress controller
@@ -243,21 +243,17 @@ ingress:
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header Host $host;
-  # api the /api, /devops, /status, /overall and /health Ingress configuration
+  # api the /api, /stats and /overall Ingress configuration
   api:
     # paths configures ingress paths
     paths:
-      - path: /api
-        backendSuffix: gateway
-      - path: /devops
-        backendSuffix: gateway
-      - path: /status
+      # negative lookahead, so we don't accept /api/2/connections, which is devops responsibility
+      - path: /api/2/(?!connections)
+        pathType: ImplementationSpecific
         backendSuffix: gateway
       - path: /stats
         backendSuffix: gateway
       - path: /overall
-        backendSuffix: gateway
-      - path: /health
         backendSuffix: gateway
     kubernetesAuthAnnotations: |
       nginx.ingress.kubernetes.io/auth-type: basic
@@ -361,8 +357,10 @@ ingress:
         pathType: Exact
         backendSuffix: nginx
       - path: /apidoc(/|$)(.*)
+        pathType: ImplementationSpecific
         backendSuffix: swaggerui
       - path: /ui(/|$)(.*)
+        pathType: ImplementationSpecific
         backendSuffix: dittoui
     # annotations defines k8s annotations to add to the Ingress
     annotations:
@@ -377,6 +375,21 @@ ingress:
         add_header "X-Content-Type-Options" "nosniff" always;
         add_header "X-Frame-Options" "SAMEORIGIN" always;
         add_header "X-XSS-Protection" "1; mode=block" always;
+  # devops the /devops, /api/2/connections, /status and /health commands Ingress configuration
+  devops:
+    # paths configures ingress paths
+    paths:
+      - path: /devops
+        backendSuffix: gateway
+      - path: /status
+        backendSuffix: gateway
+      - path: /health
+        backendSuffix: gateway
+      - path: /api/2/connections
+        backendSuffix: gateway
+    # annotations defines k8s annotations to add to the Ingress
+    # if undefined, api ingress annotations are reused
+    annotations:
   # tls configures the TLS for ingress
   tls: []
   #  - secretName: ditto-tls


### PR DESCRIPTION
At the moment all `/devops` and `/status` paths are routed through `api` Ingress resource. Since the introduction of BASIC auth for ditto user(s), `/devops` and `/status` paths could not be authenticated with devops/status users.

This PR introduces a new Ingress resource to control devops and status paths. The authorization header is simply forwarded to the gateway.

Another update is parameterizing preStop wait time on the IngressController. More info in the comments in the `values.yaml`.

Also Ingress Controller version is updated to 1.9.0. With this all regex-type paths are given `ImplementationSpecific` pathType instead of Prefix.