### PR TITLE
reduce Kamon startup warnings and logs

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.4.0  # chart version is effectively set by release-job
+version: 3.4.1  # chart version is effectively set by release-job
 appVersion: 3.4.0-M1
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- end }}
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
+              value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ tpl .Values.global.tracing.otelExporterOtlpEndpoint . }}"
             - name: DITTO_TRACING_SAMPLER

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -89,6 +89,8 @@ spec:
             {{- end }}
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
+              value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ tpl .Values.global.tracing.otelExporterOtlpEndpoint . }}"
             - name: DITTO_TRACING_SAMPLER

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- end }}
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
+              value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ tpl .Values.global.tracing.otelExporterOtlpEndpoint . }}"
             - name: DITTO_TRACING_SAMPLER

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- end }}
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
+              value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ tpl .Values.global.tracing.otelExporterOtlpEndpoint . }}"
             - name: DITTO_TRACING_SAMPLER

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -88,6 +88,8 @@ spec:
             {{- end }}
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
+              value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ tpl .Values.global.tracing.otelExporterOtlpEndpoint . }}"
             - name: DITTO_TRACING_SAMPLER

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -139,6 +139,8 @@ global:
   tracing:
     # enabled whether tracing (via OpenTelemetry) is enabled
     enabled: false
+    # otelTraceReporterEnabled whether reporting traces via the OLTP endpoint should be activated
+    otelTraceReporterEnabled: false
     # otelExporterOtlpEndpoint the OTLP endpoint to report traces to
     otelExporterOtlpEndpoint: "http://localhost:4317"
     # sampler the tracing sampler to use

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -431,12 +431,13 @@ processed and the tracing data is exported in [OpenTelemetry](https://openteleme
 kamon-opentelemetry library.
 
 Adjust the following environment variables to configure the Ditto services to produce traces:
-* `DITTO_TRACING_ENABLED`: determines whether tracing is enabled (default:`false`) 
+* `DITTO_TRACING_ENABLED`: determines whether tracing is enabled (default: `false`) 
 * `DITTO_TRACING_SAMPLER`: defines the used sampler
   * `always`: report all traces 
   * `never`:  don't report any trace (default)
   * `random`: randomly decide using the probability defined in the `DITTO_TRACING_RANDOM_SAMPLER_PROBABILITY` environment variable
   * `adaptive`: keeps dynamic samplers for each operation while trying to achieve a set throughput goal (`DITTO_TRACING_ADAPTIVE_SAMPLER_THROUGHPUT`) 
+* `DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED`: whether reporting traces via the OLTP endpoint should be activated (default: `false`)
 * `OTEL_EXPORTER_OTLP_ENDPOINT`: the OTLP endpoint where to report the gathered traces (default: `http://localhost:4317`)
 
 ## DevOps commands

--- a/internal/utils/config/src/main/resources/ditto-kamon.conf
+++ b/internal/utils/config/src/main/resources/ditto-kamon.conf
@@ -1,7 +1,10 @@
 # To be included in kamon.conf of all services.
 
 kamon {
-  show-aspectj-missing-warning = false
+  init {
+    hide-banner = yes
+    attach-instrumentation = no
+  }
 
   metric {
     tick-interval = 10s
@@ -68,6 +71,9 @@ kamon {
     # otherwise we cannot run with OpenJDK Java Docker Images
     process-metrics.enabled = no
     host-metrics.enabled = no
+    otel-trace-reporter.enabled = no
+    otel-trace-reporter.enabled = ${?DITTO_TRACING_ENABLED}
+    otel-trace-reporter.enabled = ${?DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED}
   }
 
   trace {


### PR DESCRIPTION
* made loading of "otel-trace-reporter" configurable and by default, don't load it
* introduce new env var `DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED` which can in addition to `DITTO_TRACING_ENABLED` be used to just switch off OTEL reporting of traces