### PR TITLE
several small Ditto UI improvements

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/NormalizedMessageMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/NormalizedMessageMapper.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.contenttype.ContentType;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
@@ -42,8 +43,6 @@ import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 
 import com.typesafe.config.Config;
-
-import org.apache.pekko.actor.ActorSystem;
 
 /**
  * A message mapper implementation for normalized changes.
@@ -181,6 +180,7 @@ public final class NormalizedMessageMapper extends AbstractMessageMapper {
         // add fields of an event protocol message excluding "value" and "status"
         builder.set(JsonifiableAdaptable.JsonFields.TOPIC, adaptable.getTopicPath().getPath());
         builder.set(Payload.JsonFields.PATH, payload.getPath().toString());
+        builder.set(Payload.JsonFields.VALUE, adaptable.getPayload().getValue().orElse(JsonValue.nullLiteral()));
         payload.getFields().ifPresent(fields -> builder.set(Payload.JsonFields.FIELDS, fields.toString()));
         builder.set(JsonifiableAdaptable.JsonFields.HEADERS, dittoHeadersToJson(dittoHeaders));
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/mapping/NormalizedMessageMapperTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/mapping/NormalizedMessageMapperTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Instant;
 import java.util.Map;
 
+import org.apache.pekko.actor.ActorSystem;
 import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.Signal;
@@ -46,7 +47,6 @@ import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
-import org.eclipse.ditto.things.model.ThingDefinition;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteThing;
@@ -66,8 +66,6 @@ import org.mockito.Mockito;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
-import org.apache.pekko.actor.ActorSystem;
 
 /**
  * Tests {@link NormalizedMessageMapper}.
@@ -133,6 +131,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/created/things/twin/events/created\",\n" +
                         "    \"path\": \"/\",\n" +
+                        "    \"value\":{\"thingId\":\"thing:created\",\"policyId\":\"thing:created\",\"attributes\":{\"x\":5},\"features\":{\"feature\":{\"properties\":{\"y\":6}}}},\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/json\"\n" +
@@ -174,6 +173,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/merged/things/twin/events/merged\",\n" +
                         "    \"path\": \"/\",\n" +
+                        "    \"value\":{\"thingId\":\"thing:merged\",\"attributes\":{\"x\":5},\"features\":{\"feature\":{\"properties\":{\"y\":6}}}},\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/merge-patch+json\"\n" +
@@ -218,6 +218,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/merged/things/twin/events/merged\",\n" +
                         "    \"path\": \"/\",\n" +
+                        "    \"value\":{\"thingId\":\"thing:merged\",\"attributes\":{\"x\":5},\"features\":{\"feature\":{\"properties\":{\"y\":6}}}},\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/merge-patch+json\"\n" +
@@ -251,6 +252,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/merged/things/twin/events/merged\",\n" +
                         "    \"path\": \"/\",\n" +
+                        "    \"value\":{\"thingId\":\"thing:merged\"},\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/merge-patch+json\"\n" +
@@ -309,6 +311,7 @@ public final class NormalizedMessageMapperTest {
                 .set("_context", JsonObject.newBuilder()
                         .set("topic", "the.namespace/the-thing-id/things/twin/events/merged")
                         .set("path", "/features/transmission")
+                        .set("value", JsonFactory.readFrom("{\"properties\":{\"cur_speed\":80}}"))
                         .set("headers", JsonObject.newBuilder()
                                 .set("response-required", "false")
                                 .set("content-type", "application/merge-patch+json")
@@ -345,6 +348,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/id/things/twin/events/modified\",\n" +
                         "    \"path\": \"/features/featureId/properties/the/quick/brown/fox/jumps/over/the/lazy/dog\",\n" +
+                        "    \"value\":9,\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/json\"\n" +

--- a/documentation/src/main/resources/_posts/2023-10-16-release-announcement-340.md
+++ b/documentation/src/main/resources/_posts/2023-10-16-release-announcement-340.md
@@ -1,7 +1,7 @@
 ---
 title: "Announcing Eclipse Ditto Release 3.4.0"
 published: true
-permalink: 2023-10-12-release-announcement-340.html
+permalink: 2023-10-16-release-announcement-340.html
 layout: post
 author: thomas_jaeckle
 tags: [blog]
@@ -36,23 +36,29 @@ Eclipse Ditto 3.4.0 focuses on the following areas:
 * Addition of a **new placeholder** to use **in connections** to use **payload of the thing JSON** e.g. in headers or addresses
 * New **placeholder functions** for **joining** multiple elements into a single string and doing **URL-encoding and -decoding**
 * Configure **MQTT message expiry interval for published messages** via a header
+* UI enhancements:
+  * Adding sending messages to Things
+  * Made UI (at least navigation bar) responsive for small screen sizes
+  * Increase size of JSON editors in "edit" mode
 
 The following non-functional work is also included:
 
 * **Swapping the [Akka toolkit](https://akka.io)** (because of its switch of license to [BSL License](https://www.lightbend.com/akka/license-faq) after Akka v2.6.x)
   **with its fork [Apache Pekko](https://pekko.apache.org/)** which remains Apache 2.0 licensed.
-* Support for using AWS DocumentDB as a replacement for MongoDB
-* Improve logging by adding the W3C traceparent header as MDC field to logs
+* Support for using **AWS DocumentDB** as a replacement for MongoDB
+* Improve logging by adding the **W3C Trace Context** `traceparent` header as MDC field to logs
 * Adjust handling of special MQTT headers in MQTT 5
 * Optimize docker files
 * Migration of Ditto UI to TypeScript
-* There now is an official [Eclipse Ditto Benchmark](2023-10-09-ditto-benchmark.html) which shows how Ditto is able
+* There now is an official **[Eclipse Ditto Benchmark](2023-10-09-ditto-benchmark.html)** which shows how Ditto is able
   to scale horizontally and provides some tuning tips
-* Addition of a benchmark tooling to run own Ditto benchmarks
+* Addition of a **benchmark tooling** to run own Ditto benchmarks
 
 The following notable fixes are included:
 
 * Fixed that failed retrieval of a policy (e.g. after policy change) leads to search index being "emptied out"
+* Fixed that putting metadata when updating a single scalar value did not work
+* UI fix, fixing that patching a thing will null values did not reflect that change in the UI
 
 Please have a look at the [3.4.0 release notes](release_notes_340.html) for a more detailed information on the release.
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
@@ -129,6 +129,7 @@ would result in the following normalized JSON representation:
   "_context": {
     "topic": "thing/id/things/twin/events/modified",
     "path": "/features/sensors/properties/temperature/indoor/value",
+    "value": 42,
     "headers": {
       "content-type": "application/json"
     }

--- a/documentation/src/main/resources/pages/ditto/httpapi-sse.md
+++ b/documentation/src/main/resources/pages/ditto/httpapi-sse.md
@@ -96,6 +96,27 @@ An example without filtering would look like this:
 http://localhost:8080/api/2/things?fields=thingId,attributes&extraFields=attributes
 ```
 
+##### Enriching `_context`
+
+One special field which can be enriched for the SSE is the `_context` field.  
+As the SSE format returns a "normalized" view in form of the [thing JSON]( basic-thing.html#model-specification) 
+of change events, some "context" of the event gets lost, e.g. on which `path` the event was issued or whether is was 
+a "merged" or "modified" event.
+
+To obtain this kind of context information, select the `_context` field as `extraFields`, e.g.:
+```
+http://localhost:8080/api/2/things?fields=thingId,attributes&extraFields=attributes,_context
+```
+
+The `_context` will contain:
+* `topic`: the [Ditto Protocol topic](protocol-specification.html#topic)
+* `path`: the [Ditto Protocol path](protocol-specification.html#path)
+* `value`: the [Ditto Protocol value](protocol-specification.html#value)
+* `headers`: the [Ditto Protocol headers](protocol-specification.html#headers)
+
+It is also possible to select only specific context information, e.g.: `extraFields=_context/topic,_context/path,_context/value`
+in order to exclude the `headers`.
+
 #### Filtering by namespaces
 
 As described in [change notifications](basic-changenotifications.html#by-namespaces), it is possible to subscribe only

--- a/documentation/src/main/resources/pages/ditto/release_notes_340.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_340.md
@@ -23,23 +23,29 @@ Eclipse Ditto 3.4.0 focuses on the following areas:
 * Addition of a **new placeholder** to use **in connections** to use **payload of the thing JSON** e.g. in headers or addresses
 * New **placeholder functions** for **joining** multiple elements into a single string and doing **URL-encoding and -decoding**
 * Configure **MQTT message expiry interval for published messages** via a header
+* UI enhancements:
+  * Adding sending messages to Things
+  * Made UI (at least navigation bar) responsive for small screen sizes
+  * Increase size of JSON editors in "edit" mode
 
 The following non-functional work is also included:
 
 * **Swapping the [Akka toolkit](https://akka.io)** (because of its switch of license to [BSL License](https://www.lightbend.com/akka/license-faq) after Akka v2.6.x)
   **with its fork [Apache Pekko](https://pekko.apache.org/)** which remains Apache 2.0 licensed.
-* Support for using AWS DocumentDB as a replacement for MongoDB
-* Improve logging by adding the W3C traceparent header as MDC field to logs
+* Support for using **AWS DocumentDB** as a replacement for MongoDB
+* Improve logging by adding the **W3C Trace Context** `traceparent` header as MDC field to logs
 * Adjust handling of special MQTT headers in MQTT 5
 * Optimize docker files
 * Migration of Ditto UI to TypeScript
-* There now is an official [Eclipse Ditto Benchmark](2023-10-09-ditto-benchmark.html) which shows how Ditto is able
+* There now is an official **[Eclipse Ditto Benchmark](2023-10-09-ditto-benchmark.html)** which shows how Ditto is able
   to scale horizontally and provides some tuning tips
-* Addition of a benchmark tooling to run own Ditto benchmarks
+* Addition of a **benchmark tooling** to run own Ditto benchmarks
 
 The following notable fixes are included:
 
 * Fixed that failed retrieval of a policy (e.g. after policy change) leads to search index being "emptied out"
+* Fixed that putting metadata when updating a single scalar value did not work
+* UI fix, fixing that patching a thing will null values did not reflect that change in the UI
 
 ### New features
 
@@ -82,6 +88,19 @@ Resolving issue [#1729](https://github.com/eclipse-ditto/ditto/issues/1729), a f
 header `mqtt.message-expiry-interval` as part of a [MQTT5 target header mapping](connectivity-protocol-bindings-mqtt5.html#target-header-mapping),
 dynamically influencing the MQTT message expiry interval, e.g. as part of a payload mapper for certain to-be-published 
 messages, or as a header mapping for all published messages.
+
+#### Enhancements in Ditto explorer UI
+
+The UI was mainly enhanced with new features in a single PR, [#1773](https://github.com/eclipse-ditto/ditto/pull/1773).  
+In detail, the following improvements and fixes were added:  
+* add a tab "Message to Thing" to send thing messages
+* add a loading spinner to the "Send" (message) button and deactivate it while sending
+* update a complete Thing using "PATCH" and with the new 3.4.0 header "if-equal: skip-minimizing-merge"
+* only send eTag if it could be retrieved when updating complete thing
+* added missing `ilike` predicate to the search slot
+* made UI more responsive for small screens
+* prevent browser for doing autocomplete in the "search" input field
+* increase size of the "Things" JSON editor - keep sizes and position of other JSON editors as they were
 
 
 ### Changes
@@ -142,6 +161,16 @@ to TypeScript, introducing `npm` to build the UI.
 A bug [#1703](https://github.com/eclipse-ditto/ditto/issues/1703) was fixed, where the search index for things which 
 could not fetch an updated policy via a cache-loader, was basically dropped.  
 This could e.g. happen if a single policy is used by a lot of things and this was updated.
+
+#### Fixed that putting metadata when updating a single scalar value did not work
+
+The reported bug [#1631](https://github.com/eclipse-ditto/ditto/issues/1631), where the header `put-metadata` did not 
+have an effect when updating a single scalar value, was fixed.
+
+#### UI fix, fixing that patching a thing will null values did not reflect that change in the UI
+
+The reported bug [#1712](https://github.com/eclipse-ditto/ditto/issues/1712) was fixed, the UI now correctly updates
+when e.g. something was removed from a thing by a merge/patch update, using a `null` value.
 
 ### Helm Chart
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -786,6 +786,7 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
         objectBuilder.set(CONTEXT, JsonObject.newBuilder()
                 .set(JsonifiableAdaptable.JsonFields.TOPIC, adaptable.getTopicPath().getPath())
                 .set(Payload.JsonFields.PATH, adaptable.getPayload().getPath().toString())
+                .set(Payload.JsonFields.VALUE, adaptable.getPayload().getValue().orElse(JsonValue.nullLiteral()))
                 .set(JsonifiableAdaptable.JsonFields.HEADERS, dittoHeadersToJson(thingEvent.getDittoHeaders()))
                 .build()
         );

--- a/ui/index.html
+++ b/ui/index.html
@@ -37,17 +37,22 @@
 </head>
 
 <body>
-    <nav class="navbar fixed-top navbar-expand-sm flex-sm-nowrap bg-info navbar-dark">
+    <nav class="navbar sticky-top navbar-expand-lg bg-info navbar-dark center">
         <div class="container-fluid">
-            <a class="navbar-brand"><img
-                    src="https://raw.githubusercontent.com/eclipse/ditto/master/documentation/src/main/resources/images/ditto_allwhite_symbolonly.svg"
-                    style="width:39px;" alt="Eclipse Ditto™"></a>
-            <a class="navbar-brand"><img
-                    src="https://raw.githubusercontent.com/eclipse/ditto/master/documentation/src/main/resources/images/ditto_allwhite_textonly.svg"
-                    style="width:63px;" alt="Eclipse Ditto™"></a>
-            <a class="navbar-brand">explorer</a>
-            <div class="navbar-collapse collapse w-100 justify-content-center" id="mainNavbar">
-                <ul class="navbar-nav text-center">
+            <a class="navbar-brand" href="#">
+                <img
+                  src="https://raw.githubusercontent.com/eclipse/ditto/master/documentation/src/main/resources/images/ditto_allwhite_symbolonly.svg"
+                  style="width:39px;" alt="Eclipse Ditto™">
+                <img
+                  src="https://raw.githubusercontent.com/eclipse/ditto/master/documentation/src/main/resources/images/ditto_allwhite_textonly.svg"
+                  style="width:63px;" alt="Eclipse Ditto™">
+                <span style="vertical-align: middle; padding-left: 5px">explorer</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNavbar">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0 px-4 align-items-end">
                     <li class="nav-item" id="tabThings">
                         <a class="nav-link active" data-bs-target="#collapseThings:not(.show)" data-bs-toggle="collapse">
                             Things
@@ -74,15 +79,16 @@
                         </a>
                     </li>
                 </ul>
+                <div class="d-flex">
+                    <span class="navbar-text px-2">Environment:</span>
+                    <select class="form-select form-select-sm me-2" id="environmentSelector"
+                            style="margin-top: auto; margin-bottom: auto;"></select>
+                    <button id="authorize" class="btn btn-outline-light btn-sm"
+                            data-bs-toggle="modal" data-bs-target="#authorizationModal">Authorize</button>
+                </div>
             </div>
-            <ul class="navbar-nav w-50">
-                <a class="nav-link active">Environment:</a>
-                <select class="form-select form-select-sm" id="environmentSelector"
-                    style="margin-top: auto; margin-bottom: auto;"></select>
-                <button id="authorize" class="btn btn-outline-light btn-sm" style="margin-left:5px;"
-                    data-bs-toggle="modal" data-bs-target="#authorizationModal">Authorize</button>
-            </ul>
         </div>
+
     </nav>
     <div class="container-fluid py-3 overflowauto" id="page-content">
         <div class="collapse show" id="collapseThings" data-bs-parent="#page-content">

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -174,6 +174,13 @@ hr {
     background-color: white;
 }
 
+.editForgroundBig {
+    position: absolute;
+    right: 24px;
+    width: 60%;
+    height: 80%;
+}
+
 .dropdown-menu {
     max-height: 80vh;
     overflow-y: auto;

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -196,3 +196,11 @@ h5>.badge {
 .autoComplete_wrapper ul > li[aria-selected="true"] {
     background-color: rgba(123, 123, 123, 0.1);
 }
+
+.spinner-border {
+    visibility:hidden;
+}
+
+button.busy .spinner-border {
+    visibility:visible !important;
+}

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -177,7 +177,7 @@ hr {
 .editForgroundBig {
     position: absolute;
     right: 24px;
-    width: 60%;
+    width: 90%;
     height: 80%;
 }
 

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -46,10 +46,6 @@ tbody {
     border-top: 0 !important;
 }
 
-body { 
-    padding-top: 60px;
-}
-
 #authorizationModal label {
     display: inline;
 }
@@ -81,8 +77,7 @@ textarea {
 }
 
 .nav-link {
-    padding-top: 0.1rem;
-    padding-bottom: 0.1rem;
+    padding: 0.1rem 0.4rem;
 }
 
 .tab-pane {

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -10,31 +10,33 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
+import { Dropdown } from 'bootstrap';
 /* eslint-disable new-cap */
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './main.scss';
-import {Dropdown} from 'bootstrap';
-
-import * as Authorization from './modules/environments/authorization.js';
-import * as Environments from './modules/environments/environments.js';
-import * as Attributes from './modules/things/attributes.js';
-import * as Features from './modules/things/features.js';
-import * as FeatureMessages from './modules/things/featureMessages.js';
-import * as Fields from './modules/things/fields.js';
-import * as SearchFilter from './modules/things/searchFilter.js';
-import * as Things from './modules/things/things.js';
-import * as ThingsSearch from './modules/things/thingsSearch.js';
-import * as ThingsCRUD from './modules/things/thingsCRUD.js';
-import * as ThingsSSE from './modules/things/thingsSSE.js';
-import * as MessagesIncoming from './modules/things/messagesIncoming.js';
 import * as Connections from './modules/connections/connections.js';
 import * as ConnectionsCRUD from './modules/connections/connectionsCRUD.js';
 import * as ConnectionsMonitor from './modules/connections/connectionsMonitor.js';
+
+import * as Authorization from './modules/environments/authorization.js';
+import * as Environments from './modules/environments/environments.js';
 import * as Operations from './modules/operations/operations.js';
 import * as Policies from './modules/policies/policies.js';
+import * as Attributes from './modules/things/attributes.js';
+import * as FeatureMessages from './modules/things/featureMessages.js';
+import * as Features from './modules/things/features.js';
+import * as Fields from './modules/things/fields.js';
+import * as MessagesIncoming from './modules/things/messagesIncoming.js';
+import * as SearchFilter from './modules/things/searchFilter.js';
+import * as ThingMessages from './modules/things/thingMessages.js';
+import * as Things from './modules/things/things.js';
+import * as ThingsCRUD from './modules/things/thingsCRUD.js';
+import * as ThingsSearch from './modules/things/thingsSearch.js';
+import * as ThingsSSE from './modules/things/thingsSSE.js';
+import { WoTDescription } from './modules/things/wotDescription.js';
 import * as Utils from './modules/utils.js';
-import {WoTDescription} from './modules/things/wotDescription.js';
 import './modules/utils/crudToolbar.js';
+
 let resized = false;
 let mainNavbar;
 
@@ -43,6 +45,7 @@ document.addEventListener('DOMContentLoaded', async function() {
   await Things.ready();
   ThingsSearch.ready();
   ThingsCRUD.ready();
+  await ThingMessages.ready();
   ThingsSSE.ready();
   MessagesIncoming.ready();
   Attributes.ready();

--- a/ui/modules/api.ts
+++ b/ui/modules/api.ts
@@ -346,7 +346,6 @@ export async function callDittoREST(method, path, body = null,
     throw new Error('An error occurred: ' + response.status);
   }
   if (response.status !== 204) {
-    console.log(...response.headers);
     if (returnHeaders) {
       return response;
     } else {

--- a/ui/modules/api.ts
+++ b/ui/modules/api.ts
@@ -12,9 +12,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+import { EventSourcePolyfill } from 'event-source-polyfill';
 import * as Environments from './environments/environments.js';
 import * as Utils from './utils.js';
-import {EventSourcePolyfill} from 'event-source-polyfill';
 
 
 const config = {
@@ -320,11 +320,12 @@ export function setAuthHeader(forDevOps) {
 export async function callDittoREST(method, path, body = null,
     additionalHeaders = null, returnHeaders = false, devOps = false) {
   let response;
+  const contentType = method === 'PATCH' ? 'application/merge-patch+json' : 'application/json';
   try {
     response = await fetch(Environments.current().api_uri + (devOps ? '' : '/api/2') + path, {
       method: method,
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': contentType,
         [authHeaderKey]: authHeaderValue,
         ...additionalHeaders,
       },
@@ -345,6 +346,7 @@ export async function callDittoREST(method, path, body = null,
     throw new Error('An error occurred: ' + response.status);
   }
   if (response.status !== 204) {
+    console.log(...response.headers);
     if (returnHeaders) {
       return response;
     } else {

--- a/ui/modules/connections/connections.html
+++ b/ui/modules/connections/connections.html
@@ -85,7 +85,7 @@
 <div class="collapse show" id="tabConnectionHelper">
     <div class="row resizable_pane" style="height: 80vh;">
         <div class="col-md-4 resizable_flex_column">
-            <ul class="nav nav-tabs">
+            <ul class="nav nav-tabs nav-fill">
                 <li class="nav-item">
                     <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabConnectionMetrics">Metrics</a>
                 </li>

--- a/ui/modules/connections/connections.html
+++ b/ui/modules/connections/connections.html
@@ -43,7 +43,7 @@
         </div>
         <div class="col-md-8 resizable_flex_column">
             <h6>CRUD Connection</h6>
-            <crud-toolbar label="Connection Id" id="crudConnection" style="flex-grow: 1;">
+            <crud-toolbar label="Connection Id" id="crudConnection" style="flex-grow: 1;" extraeditclass="editForgroundBig">
                 <div class="input-group input-group-sm mb-1">
                     <label class="input-group-text">Template</label>
                     <div class="btn-group dropend">

--- a/ui/modules/environments/authorization.html
+++ b/ui/modules/environments/authorization.html
@@ -23,17 +23,17 @@
                     <hr />
                     <div class="row">
                         <div class="col-md-5">
-                            <input type="radio" id="main-userpass" name="main-auth" value="basic"></input>
+                            <input type="radio" id="main-userpass" name="main-auth" value="basic" />
                             <label for="main-userpass">Basic</label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
                                 <label for="userName" class="input-group-text">Username</label>
-                                <input type="text" class="form-control form-control-sm" id="userName"></input>
+                                <input type="text" class="form-control form-control-sm" id="userName" name="username" />
                             </div>
                             <div class="input-group input-group-sm mb-1">
                                 <label for="password" class="input-group-text">Password</label>
-                                <input type="password" class="form-control form-control-sm" id="password"></input>
+                                <input type="password" class="form-control form-control-sm" id="password" name="password" />
                             </div>
                         </div>
                     </div>
@@ -45,13 +45,13 @@
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
                                 <label for="bearer" class="input-group-text">Bearer</label>
-                                <input type="password" class="form-control form-control-sm" id="bearer"></input>
+                                <input type="password" class="form-control form-control-sm" id="bearer" name="bearer" />
                             </div>
                         </div>
                     </div>
                     <div class="row pt-2">
                         <div class="col-md-5">
-                            <input type="radio" id="main-pre" name="main-auth" value="pre"></input>
+                            <input type="radio" id="main-pre" name="main-auth" value="pre" />
                             <label for="main-pre">Pre authenticated<br />
                                 <small>(via HTTP header 'x-ditto-pre-authenticated', must take the form
                                     <code>prefix:suffix</code>)</small>
@@ -60,7 +60,7 @@
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
                                 <label for="dittoPreAuthenticatedUsername" class="input-group-text">prefix:suffix</label>
-                                <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername"></input>
+                                <input type="text" class="form-control form-control-sm" id="dittoPreAuthenticatedUsername" name="pre-authenticated-username"  />
                             </div>
                         </div>
                     </div>
@@ -71,29 +71,29 @@
                     <hr />
                     <div class="row">
                         <div class="col-md-5">
-                            <input type="radio" id="devops-userpass" name="devops-auth" value="basic"></input>
+                            <input type="radio" id="devops-userpass" name="devops-auth" value="basic" />
                             <label for="devops-userpass">Basic<br /></label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
                                 <label for="devOpsUserName" class="input-group-text">DevOps Username</label>
-                                <input type="text" class="form-control form-control-sm" id="devOpsUserName"></input>
+                                <input type="text" class="form-control form-control-sm" id="devOpsUserName" name="username" />
                             </div>
                             <div class="input-group input-group-sm mb-1">
                                 <label for="devOpsPassword" class="input-group-text">DevOps Password</label>
-                                <input type="password" class="form-control form-control-sm" id="devOpsPassword"></input>
+                                <input type="password" class="form-control form-control-sm" id="devOpsPassword" name="password" />
                             </div>
                         </div>
                     </div>
                     <div class="row pt-2">
                         <div class="col-md-5">
-                            <input type="radio" id="devops-bearer" name="devops-auth" value="bearer"></input>
+                            <input type="radio" id="devops-bearer" name="devops-auth" value="bearer" />
                             <label for="devops-bearer">Bearer<br /><small>(JWT OAuth2.0 Bearer token)</small></label>
                         </div>
                         <div class="col-md-7">
                             <div class="input-group input-group-sm mb-1">
                                 <label for="bearerDevOps" class="input-group-text">DevOps Bearer</label>
-                                <input type="password" class="form-control form-control-sm" id="bearerDevOps"></input>
+                                <input type="password" class="form-control form-control-sm" id="bearerDevOps" name="devops-bearer" />
                             </div>
                             <div class="input-group input-group-sm mb-1">
                         </div>

--- a/ui/modules/environments/environments.html
+++ b/ui/modules/environments/environments.html
@@ -10,8 +10,6 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0
   -->
-<h5>Environments</h5>
-<hr />
 <div class="row resizable_pane" style="height: 80vh">
     <div class="col-md-4 resizable_flex_column">
         <div class="input-group has-validation">
@@ -25,7 +23,7 @@
         </div>
     </div>
     <div class="col-md-8 resizable_flex_column">
-        <ul class="nav nav-tabs">
+        <ul class="nav nav-tabs nav-fill">
             <li class="nav-item">
                 <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabEnvDetails">CRUD Environment</a>
             </li>

--- a/ui/modules/policies/policies.html
+++ b/ui/modules/policies/policies.html
@@ -1,6 +1,4 @@
 <div>
-    <h5>Overview</h5>
-    <hr />
     <div class="row resizable_pane" style="height: 30vh;">
         <div class="col-md-6 resizable_flex_column">
             <h6>Load a policy</h6>

--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -169,8 +169,10 @@ function refillTemplates() {
 }
 
 function onFeatureChanged(featureId) {
-  theFeatureId = featureId;
-  clearAllFields();
-  refillTemplates();
+  if (featureId !== theFeatureId) {
+    theFeatureId = featureId;
+    clearAllFields();
+    refillTemplates();
+  }
 }
 

--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -67,6 +67,7 @@ export async function ready() {
   dom.buttonMessageFavorite.onclick = () => {
     const templateName = dom.inputMessageTemplate.value;
     const featureId = theFeatureId;
+    const payload = acePayload.getValue();
     Utils.assert(featureId, 'Please select a Feature', dom.tableValidationFeature);
     Utils.assert(templateName, 'Please give a name for the template', dom.inputMessageTemplate);
     Environments.current().messageTemplates[featureId] = Environments.current().messageTemplates[featureId] || {};
@@ -79,7 +80,7 @@ export async function ready() {
       Environments.current().messageTemplates[featureId][templateName] = {
         subject: dom.inputMessageSubject.value,
         timeout: dom.inputMessageTimeout.value,
-        payload: JSON.parse(acePayload.getValue()),
+        ...(payload) && {payload: JSON.parse(payload)},
       };
       acePayload.session.getUndoManager().markClean();
     }

--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -1,23 +1,23 @@
 /*
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
-*
-* SPDX-License-Identifier: EPL-2.0
-*/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 
 /* eslint-disable require-jsdoc */
 import * as API from '../api.js';
 import * as Environments from '../environments/environments.js';
 import * as Utils from '../utils.js';
-import * as Things from './things.js';
-import * as Features from './features.js';
 import featureMessagesHTML from './featureMessages.html';
+import * as Features from './features.js';
+import * as Things from './things.js';
 
 let theFeatureId;
 
@@ -59,6 +59,8 @@ export async function ready() {
     Utils.assert(theFeatureId, 'Please select a Feature', dom.tableValidationFeature);
     Utils.assert(dom.inputMessageSubject.value, 'Please give a Subject', dom.inputMessageSubject);
     Utils.assert(dom.inputMessageTimeout.value, 'Please give a timeout', dom.inputMessageTimeout);
+    dom.buttonMessageSend.classList.add('busy');
+    dom.buttonMessageSend.disabled = true;
     messageFeature();
   };
 
@@ -113,7 +115,7 @@ export async function ready() {
  * Calls Ditto to send a message with the parameters of the fields in the UI
  */
 function messageFeature() {
-  const payload = JSON.parse(acePayload.getValue());
+  const payload = acePayload && acePayload.getValue().length > 0 && JSON.parse(acePayload.getValue());
   aceResponse.setValue('');
   API.callDittoREST('POST', '/things/' + Things.theThing.thingId +
       '/features/' + theFeatureId +
@@ -121,10 +123,14 @@ function messageFeature() {
       '?timeout=' + dom.inputMessageTimeout.value,
   payload,
   ).then((data) => {
+    dom.buttonMessageSend.classList.remove('busy');
+    dom.buttonMessageSend.disabled = false;
     if (dom.inputMessageTimeout.value > 0) {
       aceResponse.setValue(JSON.stringify(data, null, 2), -1);
     }
   }).catch((err) => {
+    dom.buttonMessageSend.classList.remove('busy');
+    dom.buttonMessageSend.disabled = false;
     aceResponse.setValue('');
   });
 }
@@ -145,7 +151,7 @@ function clearAllFields() {
   dom.inputMessageTemplate.value = null;
   dom.inputMessageSubject.value = null;
   dom.inputMessageTimeout.value = '10';
-  acePayload.setValue('{}');
+  acePayload.setValue('');
   aceResponse.setValue('');
   dom.ulMessageTemplates.innerHTML = '';
 }

--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -45,7 +45,7 @@ export async function ready() {
   Utils.addTab(
       document.getElementById('tabItemsFeatures'),
       document.getElementById('tabContentFeatures'),
-      'send Message',
+      'Send Message',
       featureMessagesHTML,
   );
 

--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -45,7 +45,7 @@ export async function ready() {
   Utils.addTab(
       document.getElementById('tabItemsFeatures'),
       document.getElementById('tabContentFeatures'),
-      'Message to Feature',
+      'send Message',
       featureMessagesHTML,
   );
 

--- a/ui/modules/things/features.html
+++ b/ui/modules/things/features.html
@@ -34,7 +34,7 @@
             </ul>
             <div class="tab-content" style="flex-grow: 1;" id="tabContentFeatures">
                 <div class="tab-pane container active no-margin" id="tabCrudFeature">
-                    <crud-toolbar id="crudFeature" label="Feature ID">
+                    <crud-toolbar id="crudFeature" label="Feature ID" extraeditclass="editForgroundBig">
                         <div class="input-group input-group-sm mb-1">
                             <label class="input-group-text">Definition</label>
                             <input type="text" class="form-control" id="inputFeatureDefinition" disabled></input>

--- a/ui/modules/things/features.html
+++ b/ui/modules/things/features.html
@@ -27,9 +27,9 @@
             </div>
         </div>
         <div class="col-md-8 resizable_flex_column">
-            <ul class="nav nav-tabs" id="tabItemsFeatures">
+            <ul class="nav nav-tabs nav-fill" id="tabItemsFeatures">
                 <li class="nav-item">
-                    <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabCrudFeature">CRUD Feature</a>
+                    <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabCrudFeature">CRUD</a>
                 </li>
             </ul>
             <div class="tab-content" style="flex-grow: 1;" id="tabContentFeatures">

--- a/ui/modules/things/messagesIncoming.html
+++ b/ui/modules/things/messagesIncoming.html
@@ -28,7 +28,7 @@
                     <thead>
                         <tr>
                             <th>Revision</th>
-                            <th>Field</th>
+                            <th>Field(s)</th>
                             <th>Modified</th>
                         </tr>
                     </thead>

--- a/ui/modules/things/messagesIncoming.ts
+++ b/ui/modules/things/messagesIncoming.ts
@@ -12,9 +12,9 @@
  */
 
 import * as Utils from '../utils.js';
+import messagesIncomingHTML from './messagesIncoming.html';
 import * as Things from './things.js';
 import * as ThingsSSE from './thingsSSE.js';
-import messagesIncomingHTML from './messagesIncoming.html';
 /* eslint-disable prefer-const */
 /* eslint-disable max-len */
 /* eslint-disable no-invalid-this */
@@ -64,8 +64,8 @@ function onMessage(messageData) {
   Utils.addTableRow(
       dom.tbodyMessagesIncoming,
       messageData._revision, false, false,
-      [...messageData['features'] ? Object.keys(messageData.features) : [],
-        ...messageData['attributes'] ? Object.keys(messageData.attributes) : []],
+      [...messageData['_context'].value.features ? Object.keys(messageData['_context'].value.features) : [],
+        ...messageData['_context'].value.attributes ? Object.keys(messageData['_context'].value.attributes) : []],
       Utils.formatDate(messageData._modified, true),
   );
 }

--- a/ui/modules/things/messagesIncoming.ts
+++ b/ui/modules/things/messagesIncoming.ts
@@ -61,11 +61,24 @@ function onMessage(messageData) {
   messages.push(messageData);
   dom.badgeMessageIncomingCount.textContent = messages.length;
 
+  function getColumnValues() {
+    if (messageData['_context'] && messageData['_context'].value) {
+      return [
+        ...messageData['_context'].value.features ? Object.keys(messageData['_context'].value.features) : [],
+        ...messageData['_context'].value.attributes ? Object.keys(messageData['_context'].value.attributes) : []
+      ];
+    } else {
+      return [
+        ...messageData['features'] ? Object.keys(messageData.features) : [],
+        ...messageData['attributes'] ? Object.keys(messageData.attributes) : []
+      ]
+    }
+  }
+
   Utils.addTableRow(
       dom.tbodyMessagesIncoming,
       messageData._revision, false, false,
-      [...messageData['_context'].value.features ? Object.keys(messageData['_context'].value.features) : [],
-        ...messageData['_context'].value.attributes ? Object.keys(messageData['_context'].value.attributes) : []],
+      getColumnValues(),
       Utils.formatDate(messageData._modified, true),
   );
 }

--- a/ui/modules/things/thingMessages.html
+++ b/ui/modules/things/thingMessages.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2023 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -14,9 +14,9 @@
     <div class="resizable_flex_column">
         <div class="input-group input-group-sm mb-1 mt-1 has-validation">
             <label class="input-group-text">Subject and Timeout</label>
-            <input type="text" class="form-control" id="inputMessageSubject"></input>
-            <input type="number" class="form-control form-control-sm" id="inputMessageTimeout" value="10"></input>
-            <button class="btn btn-outline-secondary btn-sm" id="buttonMessageSend">
+            <input type="text" class="form-control" id="inputThingMessageSubject"></input>
+            <input type="number" class="form-control form-control-sm" id="inputThingMessageTimeout" value="10"></input>
+            <button class="btn btn-outline-secondary btn-sm" id="buttonThingMessageSend">
                 <i class="bi bi-send"></i>
                 Send
                 <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
@@ -26,25 +26,25 @@
         <div class="input-group input-group-sm mb-1 has-validation">
             <label class="input-group-text">Template</label>
             <div class="btn-group dropend">
-                <button id="buttonMessageFavorite" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
+                <button id="buttonThingMessageFavorite" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
                     title="Save favorite for message on this feature">
-                    <i id="favIconMessage" class="bi bi-star"></i>
+                    <i id="favIconThingMessage" class="bi bi-star"></i>
                 </button>
                 <button class="btn btn-outline-secondary btn-sm dropdown-toggle dropdown-toggle-split"
                     data-bs-toggle="dropdown"></button>
-                <ul id="ulMessageTemplates" class="dropdown-menu" style="position: fixed; top: auto;">
+                <ul id="ulThingMessageTemplates" class="dropdown-menu" style="position: fixed; top: auto;">
                 </ul>
             </div>
-            <input type="text" class="form-control" id="inputMessageTemplate">
+            <input type="text" class="form-control" id="inputThingMessageTemplate">
             <div class="invalid-feedback"></div>
         </div>
         <div class="input-group input-group-sm" style="flex-grow: 1; display: flex;">
             <label class="input-group-text">Payload<br>and<br>Response</label>
             <div class="ace_container" style="flex-grow: 1;">
-                <div class="script_editor" id="acePayload"></div>
+                <div class="script_editor" id="acePayloadThingMessage"></div>
             </div>
             <div class="ace_container" style="flex-grow: 1;">
-                <div class="script_editor" id="aceResponse"></div>
+                <div class="script_editor" id="aceResponseThingMessage"></div>
             </div>
         </div>
 

--- a/ui/modules/things/thingMessages.ts
+++ b/ui/modules/things/thingMessages.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/* eslint-disable require-jsdoc */
+import * as API from '../api.js';
+import * as Environments from '../environments/environments.js';
+import * as Utils from '../utils.js';
+import messagesHTML from './thingMessages.html';
+import * as Things from './things.js';
+
+const dom = {
+  inputThingMessageSubject: null,
+  inputThingMessageTimeout: null,
+  inputThingMessageTemplate: null,
+  buttonThingMessageSend: null,
+  buttonThingMessageFavorite: null,
+  ulThingMessageTemplates: null,
+  favIconThingMessage: null,
+};
+
+let acePayload;
+let aceResponse;
+
+/**
+ * Initializes components. Should be called after DOMContentLoaded event
+ */
+export async function ready() {
+  Environments.addChangeListener(onEnvironmentChanged);
+
+  Utils.addTab(
+      document.getElementById('tabItemsThing'),
+      document.getElementById('tabContentThing'),
+      'Message to Thing',
+      messagesHTML,
+  );
+
+  Utils.getAllElementsById(dom);
+
+  acePayload = Utils.createAceEditor('acePayloadThingMessage', 'ace/mode/json');
+  aceResponse = Utils.createAceEditor('aceResponseThingMessage', 'ace/mode/json', true);
+
+
+  dom.buttonThingMessageSend.onclick = () => {
+    Utils.assert(dom.inputThingMessageSubject.value, 'Please give a Subject', dom.inputThingMessageSubject);
+    Utils.assert(dom.inputThingMessageTimeout.value, 'Please give a timeout', dom.inputThingMessageTimeout);
+    dom.buttonThingMessageSend.classList.add('busy');
+    dom.buttonThingMessageSend.disabled = true;
+    messageThing();
+  };
+
+  dom.buttonThingMessageFavorite.onclick = () => {
+    const templateName = dom.inputThingMessageTemplate.value;
+    Utils.assert(templateName, 'Please give a name for the template', dom.inputThingMessageTemplate);
+    Environments.current().messageTemplates['/'] = Environments.current().messageTemplates['/'] || {};
+    if (Object.keys(Environments.current().messageTemplates['/']).includes(templateName) &&
+        dom.favIconThingMessage.classList.contains('bi-star-fill')) {
+      dom.favIconThingMessage.classList.replace('bi-star-fill', 'bi-star');
+      delete Environments.current().messageTemplates['/'][templateName];
+    } else {
+      dom.favIconThingMessage.classList.replace('bi-star', 'bi-star-fill');
+      Environments.current().messageTemplates['/'][templateName] = {
+        subject: dom.inputThingMessageSubject.value,
+        timeout: dom.inputThingMessageTimeout.value,
+        payload: JSON.parse(acePayload.getValue()),
+      };
+      acePayload.session.getUndoManager().markClean();
+    }
+    Environments.environmentsJsonChanged('messageTemplates');
+  };
+
+  dom.ulThingMessageTemplates.addEventListener('click', (event) => {
+    if (event.target && event.target.classList.contains('dropdown-item')) {
+      dom.favIconThingMessage.classList.replace('bi-star', 'bi-star-fill');
+      const template = Environments.current().messageTemplates['/'][event.target.textContent];
+      dom.inputThingMessageTemplate.value = event.target.textContent;
+      dom.inputThingMessageSubject.value = template.subject;
+      dom.inputThingMessageTimeout.value = template.timeout;
+      acePayload.setValue(JSON.stringify(template.payload, null, 2), -1);
+      acePayload.session.getUndoManager().markClean();
+    }
+  });
+
+  [dom.inputThingMessageTemplate, dom.inputThingMessageSubject, dom.inputThingMessageTimeout].forEach((e) => {
+    e.addEventListener('change', () => {
+      dom.favIconThingMessage.classList.replace('bi-star-fill', 'bi-star');
+    });
+  });
+
+  acePayload.on('input', () => {
+    if (!acePayload.session.getUndoManager().isClean()) {
+      dom.favIconThingMessage.classList.replace('bi-star-fill', 'bi-star');
+    }
+  });
+}
+
+/**
+ * Calls Ditto to send a message with the parameters of the fields in the UI
+ */
+function messageThing() {
+  const payload = acePayload && acePayload.getValue().length > 0 && JSON.parse(acePayload.getValue());
+  aceResponse.setValue('');
+  API.callDittoREST('POST', '/things/' + Things.theThing.thingId +
+      '/inbox/messages/' + dom.inputThingMessageSubject.value +
+      '?timeout=' + dom.inputThingMessageTimeout.value,
+  payload,
+  ).then((data) => {
+    dom.buttonThingMessageSend.classList.remove('busy');
+    dom.buttonThingMessageSend.disabled = false;
+    if (dom.inputThingMessageTimeout.value > 0) {
+      aceResponse.setValue(JSON.stringify(data, null, 2), -1);
+    }
+  }).catch((err) => {
+    dom.buttonThingMessageSend.classList.remove('busy');
+    dom.buttonThingMessageSend.disabled = false;
+    aceResponse.setValue('');
+  });
+}
+
+function onEnvironmentChanged(modifiedField) {
+  Environments.current()['messageTemplates'] = Environments.current()['messageTemplates'] || {};
+
+  if (!modifiedField) {
+    clearAllFields();
+  }
+  if (modifiedField === 'messageTemplates') {
+    refillTemplates();
+  }
+}
+
+function clearAllFields() {
+  dom.favIconThingMessage.classList.replace('bi-star-fill', 'bi-star');
+  dom.inputThingMessageTemplate.value = null;
+  dom.inputThingMessageSubject.value = null;
+  dom.inputThingMessageTimeout.value = '10';
+  acePayload.setValue('');
+  aceResponse.setValue('');
+  dom.ulThingMessageTemplates.innerHTML = '';
+}
+
+function refillTemplates() {
+  dom.ulThingMessageTemplates.innerHTML = '';
+  Utils.addDropDownEntries(dom.ulThingMessageTemplates, ['Saved message templates'], true);
+  if (Environments.current().messageTemplates['/']) {
+    Utils.addDropDownEntries(
+        dom.ulThingMessageTemplates,
+        Object.keys(Environments.current().messageTemplates['/']),
+    );
+  }
+}

--- a/ui/modules/things/thingMessages.ts
+++ b/ui/modules/things/thingMessages.ts
@@ -40,7 +40,7 @@ export async function ready() {
   Utils.addTab(
       document.getElementById('tabItemsThing'),
       document.getElementById('tabContentThing'),
-      'send Message',
+      'Send Message',
       messagesHTML,
   );
 

--- a/ui/modules/things/thingMessages.ts
+++ b/ui/modules/things/thingMessages.ts
@@ -40,7 +40,7 @@ export async function ready() {
   Utils.addTab(
       document.getElementById('tabItemsThing'),
       document.getElementById('tabContentThing'),
-      'Message to Thing',
+      'send Message',
       messagesHTML,
   );
 

--- a/ui/modules/things/thingMessages.ts
+++ b/ui/modules/things/thingMessages.ts
@@ -60,6 +60,7 @@ export async function ready() {
 
   dom.buttonThingMessageFavorite.onclick = () => {
     const templateName = dom.inputThingMessageTemplate.value;
+    const payload = acePayload.getValue();
     Utils.assert(templateName, 'Please give a name for the template', dom.inputThingMessageTemplate);
     Environments.current().messageTemplates['/'] = Environments.current().messageTemplates['/'] || {};
     if (Object.keys(Environments.current().messageTemplates['/']).includes(templateName) &&
@@ -71,7 +72,7 @@ export async function ready() {
       Environments.current().messageTemplates['/'][templateName] = {
         subject: dom.inputThingMessageSubject.value,
         timeout: dom.inputThingMessageTimeout.value,
-        payload: JSON.parse(acePayload.getValue()),
+        ...(payload) && {payload: JSON.parse(payload)},
       };
       acePayload.session.getUndoManager().markClean();
     }
@@ -132,9 +133,7 @@ function onEnvironmentChanged(modifiedField) {
   if (!modifiedField) {
     clearAllFields();
   }
-  if (modifiedField === 'messageTemplates') {
-    refillTemplates();
-  }
+  refillTemplates();
 }
 
 function clearAllFields() {

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -14,30 +14,31 @@
     <div>
         <div class="row resizable_pane" style="height: 40vh;">
             <div class="col-md-7 resizable_flex_column">
-                <div class="input-group input-group-sm mb-1 mt-1">
+                <form class="input-group input-group-sm mb-1 mt-1" autocomplete="off">
                     <div class="btn-group dropend">
                         <button id="searchFavorite" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
                             title="Toggle favorite for search filter">
                             <i id="favIcon" class="bi bi-star"></i>
                         </button>
                     </div>
-                    <input type="search" class="form-control form-control-sm" 
-                        id="searchFilterEdit" spellcheck=false autocomplete="off"></input>
-                    <button id="searchThings" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
+                    <input autocomplete="false" name="hidden" type="text" style="display:none;">
+                    <input type="text" class="form-control form-control-sm" id="searchFilterEdit" name="search"
+                           spellcheck=false autocomplete="off" />
+                    <button type="button" id="searchThings" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
                         title="Search things by thingId or valid ditto search filter">
                         search
                     </button>
-                    <button id="pinnedThings" class="btn btn-outline-secondary btn-sm me-3 button_round_right"
+                    <button type="button" id="pinnedThings" class="btn btn-outline-secondary btn-sm me-3 button_round_right"
                         data-bs-toggle="tooltip" title="Pinned things: get the list of all individually pinned things">
                         pinned
                     </button>
-                    <button id="tableSettings" class="btn btn-outline-secondary btn-sm button_round_both"
+                    <button type="button" id="tableSettings" class="btn btn-outline-secondary btn-sm button_round_both"
                         data-bs-toggle="modal" data-bs-target="#fieldsModal">
                         <span data-bs-toggle="tooltip" title="Adjust fields for things table">
                             <i class="bi bi-gear"></i>
                         </span>
                     </button>
-                </div>
+                </form>
                 <div class="table-wrap">
                     <table class="table table-striped table-hover table-sm">
                         <thead>

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -11,11 +11,9 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 <div>
-    <h5>Things</h5>
-    <hr />
     <div>
-        <div class="row resizable_pane" style="height: 30vh;">
-            <div class="col-md-6 resizable_flex_column">
+        <div class="row resizable_pane" style="height: 40vh;">
+            <div class="col-md-7 resizable_flex_column">
                 <div class="input-group input-group-sm mb-1 mt-1">
                     <div class="btn-group dropend">
                         <button id="searchFavorite" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip"
@@ -49,15 +47,14 @@
                     </table>
                 </div>
             </div>
-            <div class="col-md-6 resizable_flex_column" id="details">
-                <ul id="tabItemsThing" class="nav nav-tabs">
+            <div class="col-md-5 resizable_flex_column" id="details">
+                <ul id="tabItemsThing" class="nav nav-tabs nav-fill">
                     <li class="nav-item">
-                        <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabThingDetails">Thing
-                            Details</a>
+                        <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabThingDetails">Details</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" data-bs-toggle="tab" data-bs-target="#tabModifyThing">
-                                CRUD Thing<span class="badge badge-warn" id="thingsCrudWaring">!</span></a>
+                                CRUD<span class="badge badge-warn" id="thingsCrudWaring">!</span></a>
                         </li>
                     </ul>
                     <div id="tabContentThing" class="tab-content" style="flex-grow:1; overflow:hidden;">
@@ -100,9 +97,9 @@
             </table>
         </div>
         <div class="col-md-8">
-            <ul class="nav nav-tabs">
+            <ul class="nav nav-tabs nav-fill">
                 <li class="nav-item">
-                    <a class="nav-link active">CRUD Attribute</a>
+                    <a class="nav-link active">CRUD</a>
                 </li>
             </ul>
             <div class="tab-content">

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -67,7 +67,7 @@
                             </div>
                     </div>
                     <div class="tab-pane fade container no-margin" style="height:100%;" id="tabModifyThing">
-                        <crud-toolbar id="crudThings" label="Thing ID">
+                        <crud-toolbar id="crudThings" label="Thing ID" extraeditclass="editForgroundBig">
                             <div class="input-group input-group-sm mb-1">
                                 <label class="input-group-text" id="labelX">Definition</label>
                                 <div class="btn-group dropend">

--- a/ui/modules/things/things.ts
+++ b/ui/modules/things/things.ts
@@ -1,24 +1,24 @@
 /* eslint-disable new-cap */
 /*
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
-* information regarding copyright ownership.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0
-*
-* SPDX-License-Identifier: EPL-2.0
-*/
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 /* eslint-disable require-jsdoc */
 // @ts-check
 import * as API from '../api.js';
 
 import * as Utils from '../utils.js';
-import {TabHandler} from '../utils/tabHandler.js';
-import * as ThingsSearch from './thingsSearch.js';
+import { TabHandler } from '../utils/tabHandler.js';
 import thingsHTML from './things.html';
+import * as ThingsSearch from './thingsSearch.js';
 
 export let theThing;
 
@@ -57,7 +57,7 @@ export function refreshThing(thingId, successCallback = null) {
   console.assert(thingId && thingId !== '', 'thingId expected');
   API.callDittoREST('GET',
       `/things/${thingId}?` +
-      'fields=thingId%2CpolicyId%2Cdefinition%2Cattributes%2Cfeatures%2C_created%2C_modified%2C_revision')
+      'fields=thingId%2CpolicyId%2Cdefinition%2Cattributes%2Cfeatures%2C_created%2C_modified%2C_revision%2C_metadata')
       .then((thing) => {
         setTheThing(thing);
         successCallback && successCallback();

--- a/ui/modules/things/thingsCRUD.ts
+++ b/ui/modules/things/thingsCRUD.ts
@@ -1,22 +1,22 @@
 /*
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
-* information regarding copyright ownership.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0
-*
-* SPDX-License-Identifier: EPL-2.0
-*/
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 /* eslint-disable require-jsdoc */
 // @ts-check
 import * as API from '../api.js';
 
 import * as Utils from '../utils.js';
-import * as ThingsSearch from './thingsSearch.js';
 import * as Things from './things.js';
+import * as ThingsSearch from './thingsSearch.js';
 import thingTemplates from './thingTemplates.json';
 
 let thingJsonEditor;
@@ -67,9 +67,10 @@ function onDeleteThingClick() {
 }
 
 function onUpdateThingClick() {
-  API.callDittoREST('PUT', `/things/${dom.crudThings.idValue}`, JSON.parse(thingJsonEditor.getValue()),
+  API.callDittoREST('PATCH', `/things/${dom.crudThings.idValue}`, JSON.parse(thingJsonEditor.getValue()),
       {
-        'if-match': eTag,
+        'if-match': eTag || "*",
+        'if-equal': 'skip-minimizing-merge'
       },
   ).then(() => {
     dom.crudThings.toggleEdit();

--- a/ui/modules/things/thingsSSE.ts
+++ b/ui/modules/things/thingsSSE.ts
@@ -1,15 +1,15 @@
 /*
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
-* information regarding copyright ownership.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License 2.0 which is available at
-* http://www.eclipse.org/legal/epl-2.0
-*
-* SPDX-License-Identifier: EPL-2.0
-*/
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 /* eslint-disable require-jsdoc */
 /* eslint-disable arrow-parens */
 // @ts-check
@@ -18,7 +18,6 @@ import * as Environments from '../environments/environments.js';
 
 import * as Things from './things.js';
 import * as ThingsSearch from './thingsSearch.js';
-import merge from 'lodash/merge';
 
 let selectedThingEventSource;
 let thingsTableEventSource;
@@ -57,7 +56,8 @@ function onSelectedThingChanged(newThingJson, isNewThingId) {
     selectedThingEventSource && selectedThingEventSource.close();
     console.log('SSE Start: SELECTED THING : ' + newThingJson.thingId);
     selectedThingEventSource = API.getEventSource(newThingJson.thingId,
-        'fields=thingId,attributes,features,_revision,_modified');
+        'fields=thingId,policyId,definition,attributes,features,_revision,_created,_modified,_metadata,_context/topic,_context/path,_context/value' +
+      '&extraFields=thingId,policyId,definition,attributes,features,_revision,_created,_modified,_metadata');
     selectedThingEventSource.onmessage = onMessageSelectedThing;
   }
 }
@@ -78,8 +78,8 @@ function onEnvironmentChanged(modifiedField) {
 
 function onMessageSelectedThing(event) {
   if (event.data && event.data !== '') {
-    const merged = merge(Things.theThing, JSON.parse(event.data));
-    Things.setTheThing(merged);
+    const completeChangedThing = JSON.parse(event.data);
+    Things.setTheThing(completeChangedThing);
     notifyAll(JSON.parse(event.data));
   }
 }

--- a/ui/modules/things/thingsSearch.ts
+++ b/ui/modules/things/thingsSearch.ts
@@ -16,15 +16,15 @@
 /* eslint-disable no-invalid-this */
 /* eslint-disable arrow-parens */
 
-import {JSONPath} from 'jsonpath-plus';
+import { JSONPath } from 'jsonpath-plus';
 
 import * as API from '../api.js';
+import * as Environments from '../environments/environments.js';
 
 import * as Utils from '../utils.js';
 import * as Fields from './fields.js';
 import * as Things from './things.js';
 import * as ThingsSSE from './thingsSSE.js';
-import * as Environments from '../environments/environments.js';
 
 let lastSearch = '';
 let theSearchCursor;
@@ -78,7 +78,7 @@ function onThingsTableClicked(event) {
  */
 export function searchTriggered(filter) {
   lastSearch = filter;
-  const regex = /^(eq\(|ne\(|gt\(|ge\(|lt\(|le\(|in\(|like\(|exists\(|and\(|or\(|not\().*/;
+  const regex = /^(eq\(|ne\(|gt\(|ge\(|lt\(|le\(|in\(|like\(|ilike\(|exists\(|and\(|or\(|not\().*/;
   if (filter === '' || regex.test(filter)) {
     searchThings(filter);
   } else {

--- a/ui/modules/utils.ts
+++ b/ui/modules/utils.ts
@@ -14,7 +14,7 @@
 /* eslint-disable quotes */
 import autoComplete from '@tarekraafat/autocomplete.js';
 import * as ace from 'ace-builds/src-noconflict/ace';
-import {Toast, Modal} from 'bootstrap';
+import { Modal, Toast } from 'bootstrap';
 
 
 const dom = {
@@ -65,6 +65,7 @@ export const addTableRow = function(table, key, selected, withClipBoardCopy = fa
 export function addCheckboxToRow(row, id, checked, onToggle) {
   const td = row.insertCell(0);
   td.style.verticalAlign = 'middle';
+  td.style.width = '25px';
   const checkBox = document.createElement('input');
   checkBox.type = 'checkbox';
   checkBox.id = id;

--- a/ui/modules/utils/crudToolbar.ts
+++ b/ui/modules/utils/crudToolbar.ts
@@ -30,8 +30,33 @@ class CrudToolbar extends HTMLElement {
     divRoot: null,
   };
 
+  static get observedAttributes() {
+    return [`extraeditclass`];
+  }
+
+  private _extraEditClass: string;
+
+  get extraeditclass() {
+    return this._extraEditClass;
+  }
+
+  set extraeditclass(val: string) {
+    if (val == null) { // check for null and undefined
+      this.removeAttribute('extraeditclass');
+    }
+    else {
+      this.setAttribute('extraeditclass', val);
+    }
+  }
+
   get idValue() {
     return this.dom.inputIdValue.value;
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === `extraeditclass`) {
+      this._extraEditClass = newValue;
+    }
   }
 
   set idValue(newValue) {
@@ -110,6 +135,9 @@ class CrudToolbar extends HTMLElement {
     this.isEditing = !this.isEditing;
     document.getElementById('modalCrudEdit').classList.toggle('editBackground');
     this.dom.divRoot.classList.toggle('editForground');
+    if (this._extraEditClass) {
+      this.dom.divRoot.classList.toggle(this._extraEditClass);
+    }
 
     if (this.isEditing || this.isEditDisabled) {
       this.dom.buttonEdit.setAttribute('hidden', '');

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,8 +15,7 @@
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.5",
         "event-source-polyfill": "^1.0.31",
-        "jsonpath-plus": "^7.2.0",
-        "lodash": "^4.17.21"
+        "jsonpath-plus": "^7.2.0"
       },
       "devDependencies": {
         "@types/ace": "^0.0.48",
@@ -2266,11 +2265,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,6 @@
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.5",
     "event-source-polyfill": "^1.0.31",
-    "jsonpath-plus": "^7.2.0",
-    "lodash": "^4.17.21"
+    "jsonpath-plus": "^7.2.0"
   }
 }


### PR DESCRIPTION
* add a tab "Message to Thing" to send thing messages
* add a loading spinner to the "Send" (message) button and deactivate it while sending
* update a complete Thing using "PATCH" and with the new 3.4.0 header "if-equal: skip-minimizing-merge"
* only send eTag if it could be retrieved when updating complete thing
* added missing "ilike" predicate to the search slot
* made UI more responsive for small screens
* prevent browser for doing autocomplete in the "search" input field
* increase size of the "Things" JSON editor - keep sizes and position of other JSON editors as they were
* fixes #1712 - by doing the "merge" on Ditto server side and subscribing complete thing changes instead of only deltas in the UI 