### PR TITLE
disable reduced pom generation

### DIFF
--- a/connectivity/service/pom.xml
+++ b/connectivity/service/pom.xml
@@ -275,6 +275,7 @@ jmh-generator-annprocess). jmh-generator-annprocess overwrites the whole META-IN
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>allinone</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>*:*</include>

--- a/gateway/service/pom.xml
+++ b/gateway/service/pom.xml
@@ -250,6 +250,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>allinone</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>*:*</include>

--- a/policies/service/pom.xml
+++ b/policies/service/pom.xml
@@ -256,6 +256,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>allinone</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>*:*</include>

--- a/things/service/pom.xml
+++ b/things/service/pom.xml
@@ -293,6 +293,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>allinone</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>*:*</include>

--- a/thingsearch/service/pom.xml
+++ b/thingsearch/service/pom.xml
@@ -187,6 +187,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>allinone</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>*:*</include>


### PR DESCRIPTION
Reduced pom generation leads to missing license headers and all compile dependencies in a target built/released pom for the services modules.