### PR TITLE
#1780 fix update headers of ConnectionClosed event

### DIFF
--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/events/ConnectionClosed.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/events/ConnectionClosed.java
@@ -128,7 +128,8 @@ public final class ConnectionClosed extends AbstractConnectivityEvent<Connection
 
     @Override
     public ConnectionClosed setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return this;
+        return of(getEntityId(), getRevision(), getTimestamp().orElse(null), dittoHeaders,
+                getMetadata().orElse(null));
     }
 
     @Override


### PR DESCRIPTION
ditto headers are used for persisting tags, when missing there are no tags in the event persisted in the journal collection