### PR TITLE
fix that ThingFieldSelector did not allow specific paths of "_metadata"

### DIFF
--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ThingFieldSelector.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ThingFieldSelector.java
@@ -38,8 +38,8 @@ public final class ThingFieldSelector implements JsonFieldSelector {
             .withoutUrlDecoding()
             .build();
     static final List<String> SELECTABLE_FIELDS = Arrays.asList("thingId", "policyId", "definition",
-            "_namespace", "_revision", "_created", "_modified", "_metadata", "_policy", "_context", "_context(/[^,]+)?",
-            "features(/[^,]+)?", "attributes(/[^,]+)?");
+            "_namespace", "_revision", "_created", "_modified", "_metadata(/[^,]+)?", "_policy", "_context",
+            "_context(/[^,]+)?", "features(/[^,]+)?", "attributes(/[^,]+)?");
     private static final String KNOWN_FIELDS_REGEX = "/?(" + String.join("|", SELECTABLE_FIELDS) + ")";
     private static final String FIELD_SELECTION_REGEX = "^" + KNOWN_FIELDS_REGEX + "(," + KNOWN_FIELDS_REGEX + ")*$";
     private static final Pattern FIELD_SELECTION_PATTERN = Pattern.compile(FIELD_SELECTION_REGEX);


### PR DESCRIPTION
* it only allowed to select top-level "_metadata" - which does not make sense to limit, as even selecting only specific _metadata is already supported
* also add missing support for featureId wildcard when selecting e.g. "_metadata/features/*/properties"