### PR TITLE
fix that JsonObjectBuilder.remove removes to much in certain cases

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObjectBuilder.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObjectBuilder.java
@@ -175,7 +175,7 @@ final class ImmutableJsonObjectBuilder implements JsonObjectBuilder {
                         rootObject = rootObject.remove(nextPointerLevel);
                         set(JsonFactory.newField(jsonField.getKey(), rootObject,
                                 jsonField.getDefinition().orElse(null)));
-                    } else {
+                    } else if (nextPointerLevel.isEmpty()) {
                         fields.remove(jsonField.getKeyName());
                     }
                 });

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectBuilderTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectBuilderTest.java
@@ -289,6 +289,7 @@ public final class ImmutableJsonObjectBuilderTest {
                 .set(robert)
                 .set(cersei)
                 .remove(JsonFactory.newPointer(fooKey, bazKey))
+                .remove(JsonFactory.newPointer(robert.getKey(), JsonKey.of("non-existing")))
                 .build();
 
         assertThat(actualJsonObject).isEqualTo(expectedJsonObject);

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/serializer/ThingMongoEventAdapter.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/serializer/ThingMongoEventAdapter.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.things.service.persistence.serializer;
 
+import org.apache.pekko.actor.ExtendedActorSystem;
 import org.eclipse.ditto.base.model.signals.events.Event;
 import org.eclipse.ditto.base.model.signals.events.GlobalEventRegistry;
 import org.eclipse.ditto.base.service.config.DittoServiceConfig;
@@ -24,8 +25,6 @@ import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
 import org.eclipse.ditto.things.model.signals.events.ThingMerged;
 import org.eclipse.ditto.things.service.common.config.DefaultThingConfig;
-
-import org.apache.pekko.actor.ExtendedActorSystem;
 
 /**
  * EventAdapter for {@link Event}s persisted into pekko-persistence event-journal. Converts Event to MongoDB
@@ -48,7 +47,7 @@ public final class ThingMongoEventAdapter extends AbstractMongoEventAdapter<Thin
 
     @Override
     protected JsonObjectBuilder performToJournalMigration(final Event<?> event, final JsonObject jsonObject) {
-        if (event instanceof ThingMerged) {
+        if (event instanceof ThingMerged thingMerged && thingMerged.getResourcePath().isEmpty()) {
             return super.performToJournalMigration(event, jsonObject)
                     .remove(POLICY_IN_THING_MERGED_VALUE_PAYLOAD); // remove the policy entries from thing merged payload
         } else {


### PR DESCRIPTION
This looks like a really small bug, but is has a huge impact:
* Currently, for `ThingMerged` events the payload `value` can get "lost" before persisting a merge because of this bug

Here an inline policy is removed from the to-be-persisted JSON:
https://github.com/eclipse-ditto/ditto/blob/d008959c019a966af0c1b152c12f953002669c58/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/serializer/ThingMongoEventAdapter.java#L51-L53

The JsonPointer to be removed is `/value/_policy` - if this `_policy` however does not exist *and* if the `value` does not even contain a `JsonObject` (which can be the case when using "merge", e.g. only updating one specific path to e.g. a JsonNumber), *then* the current implementation of `ImmutableJsonObjectBuilder.remove` will remove the `value` from the event.  
That leads to the event missing its `value` in persistence and that leads to much pain and suffering when replaying events for that persistence actor, throwing exceptions on deserialization if the `value` is missing.