### PR TITLE
#1806 Provide configurable search count metrics to be exposed via Prometheus

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -65,7 +65,7 @@ jobs:
         k8s:
           - v1.26.6
           - v1.27.3
-          - v1.28.3
+          - v1.28.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/common/DittoSystemProperties.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/common/DittoSystemProperties.java
@@ -39,6 +39,11 @@ public final class DittoSystemProperties {
      */
     public static final String DITTO_LIMITS_POLICY_IMPORTS_LIMIT = "ditto.limits.policy.imports-limit";
 
+    /**
+     * System property name of the property defining a common prefix for all metrics Ditto reports via Prometheus.
+     */
+    public static final String DITTO_METRICS_METRIC_PREFIX = "ditto.metrics.metric-prefix";
+
     private DittoSystemProperties() {
         throw new AssertionError();
     }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
@@ -123,7 +123,7 @@ public final class DefaultLimitsConfig implements LimitsConfig, WithConfigPath {
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", thingsMaxSize=" + thingsMaxSize +
+                "thingsMaxSize=" + thingsMaxSize +
                 ", policiesMaxSize=" + policiesMaxSize +
                 ", messagesMaxSize=" + messagesMaxSize +
                 ", thingsSearchDefaultPageSize=" + thingsSearchDefaultPageSize +

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.4.2  # chart version is effectively set by release-job
+version: 3.4.3  # chart version is effectively set by release-job
 appVersion: 3.4.1
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -82,10 +82,14 @@ spec:
           env:
             {{- if not .Values.global.logging.customConfigFile.enabled }}
             - name: DITTO_LOGGING_DISABLE_SYSOUT_LOG
-              value: "{{ if .Values.global.logging.sysout.enabled }}false{{ else }}true{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.sysout.enabled }}"
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.logFiles.enabled }}"
             {{- end }}
+            - name: DITTO_METRICS_METRIC_PREFIX
+              value: "{{ .Values.global.metrics.metricsPrefix }}"
+            - name: SYSTEM_METRICS_ENABLED
+              value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
@@ -137,7 +141,7 @@ spec:
                 {{- end }}
                 {{ join " " .Values.connectivity.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
-              value: "{{ if .Values.dbconfig.connectivity.ssl }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.dbconfig.connectivity.ssl }}"
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -83,10 +83,14 @@ spec:
           env:
             {{- if not .Values.global.logging.customConfigFile.enabled }}
             - name: DITTO_LOGGING_DISABLE_SYSOUT_LOG
-              value: "{{ if .Values.global.logging.sysout.enabled }}false{{ else }}true{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.sysout.enabled }}"
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.logFiles.enabled }}"
             {{- end }}
+            - name: DITTO_METRICS_METRIC_PREFIX
+              value: "{{ .Values.global.metrics.metricsPrefix }}"
+            - name: SYSTEM_METRICS_ENABLED
+              value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -82,10 +82,14 @@ spec:
           env:
             {{- if not .Values.global.logging.customConfigFile.enabled }}
             - name: DITTO_LOGGING_DISABLE_SYSOUT_LOG
-              value: "{{ if .Values.global.logging.sysout.enabled }}false{{ else }}true{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.sysout.enabled }}"
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.logFiles.enabled }}"
             {{- end }}
+            - name: DITTO_METRICS_METRIC_PREFIX
+              value: "{{ .Values.global.metrics.metricsPrefix }}"
+            - name: SYSTEM_METRICS_ENABLED
+              value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
@@ -155,7 +159,7 @@ spec:
                 {{- end }}
                 {{ join " " .Values.policies.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
-              value: "{{ if .Values.dbconfig.policies.ssl }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.dbconfig.policies.ssl }}"
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -82,10 +82,14 @@ spec:
           env:
             {{- if not .Values.global.logging.customConfigFile.enabled }}
             - name: DITTO_LOGGING_DISABLE_SYSOUT_LOG
-              value: "{{ if .Values.global.logging.sysout.enabled }}false{{ else }}true{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.sysout.enabled }}"
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.logFiles.enabled }}"
             {{- end }}
+            - name: DITTO_METRICS_METRIC_PREFIX
+              value: "{{ .Values.global.metrics.metricsPrefix }}"
+            - name: SYSTEM_METRICS_ENABLED
+              value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
@@ -156,7 +160,7 @@ spec:
                 '-Dditto.things.wot.to-thing-description.json-template={{ .Values.things.config.wot.tdJsonTemplate | replace "\n" "" | replace "\\\"" "\"" }}'
                 {{ join " " .Values.things.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
-              value: "{{ if .Values.dbconfig.things.ssl }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.dbconfig.things.ssl }}"
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -82,10 +82,14 @@ spec:
           env:
             {{- if not .Values.global.logging.customConfigFile.enabled }}
             - name: DITTO_LOGGING_DISABLE_SYSOUT_LOG
-              value: "{{ if .Values.global.logging.sysout.enabled }}false{{ else }}true{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.sysout.enabled }}"
             - name: DITTO_LOGGING_FILE_APPENDER
-              value: "{{ if .Values.global.logging.logFiles.enabled }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.global.logging.logFiles.enabled }}"
             {{- end }}
+            - name: DITTO_METRICS_METRIC_PREFIX
+              value: "{{ .Values.global.metrics.metricsPrefix }}"
+            - name: SYSTEM_METRICS_ENABLED
+              value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
@@ -132,9 +136,20 @@ spec:
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
                 {{- end }}
+                {{- range $key, $value := .Values.thingsSearch.config.operatorMetrics.customMetrics }}
+                "{{ printf "%s%s%s=%t" "-Dditto.search.operator-metrics.custom-metrics." $key ".enabled" $value.enabled }}"
+                "{{ printf "%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".scrape-interval" $value.scrapeInterval }}"
+                {{- range $index, $namespace := $value.namespaces }}
+                "{{ printf "%s%s%s%d=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".namespaces." $index $namespace }}"
+                {{- end }}
+                "{{ printf "%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".filter" $value.filter }}"
+                {{- range $tagKey, $tagValue := $value.tags }}
+                "{{ printf "%s%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".tags." $tagKey $tagValue }}"
+                {{- end }}
+                {{- end }}
                 {{ join " " .Values.thingsSearch.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
-              value: "{{ if .Values.dbconfig.thingsSearch.ssl }}true{{ else }}false{{ end }}"
+              value: "{{ printf "%t" .Values.dbconfig.thingsSearch.ssl }}"
             - name: MONGO_DB_URI
               valueFrom:
                 secretKeyRef:
@@ -204,6 +219,10 @@ spec:
               value: "{{ .Values.thingsSearch.config.updater.stream.retrievalParallelism }}"
             - name: THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_PARALLELISM
               value: "{{ .Values.thingsSearch.config.updater.stream.persistence.parallelism }}"
+            - name: THINGS_SEARCH_OPERATOR_METRICS_ENABLED
+              value: "{{ .Values.thingsSearch.config.operatorMetrics.enabled }}"
+            - name: THINGS_SEARCH_OPERATOR_METRICS_SCRAPE_INTERVAL
+              value: "{{ .Values.thingsSearch.config.operatorMetrics.scrapeInterval }}"
             - name: ACTIVITY_CHECK_INTERVAL
               value: "{{ .Values.thingsSearch.config.updater.activityCheckInterval }}"
             - name: BACKGROUND_SYNC_ENABLED

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -135,6 +135,14 @@ global:
       enabled: true
       # fileName passed as Java system property "-Dlogback.configurationFile"
       fileName: logback.xml
+  # metrics configuration for Ditto
+  metrics:
+    # metricsPrefix defines a prefix to use for all Ditto created metrics (counters, gauges, histograms)
+    metricsPrefix: ""
+    # systemMetrics contains the configuration for obtaining system metrics (via Kamon)
+    systemMetrics:
+      # enabled if enabled, system metrics are gathered
+      enabled: true
   # tracing configuration for Ditto
   tracing:
     # enabled whether tracing (via OpenTelemetry) is enabled
@@ -1069,6 +1077,22 @@ thingsSearch:
           throughput: 100
           # period the throttle period
           period: 30s
+    # operatorMetrics contains configuration for operator defined custom metrics, using a search "count" with namespaces and filter
+    operatorMetrics:
+      # enabled configures whether operator metrics should be enabled or not
+      enabled: true
+      # scrapeInterval defines the default scrape interval if a "customMetric" did not specify a custom scrape interval
+      scrapeInterval: 15m
+      # customMetrics holds a map of metric-names as key (e.g. "ditto_my_awesome_things") and custom metric config as value
+      customMetrics:
+      # ditto_my_awesome_things:
+      #   enabled: true
+      #   scrapeInterval: 5m
+      #   namespaces:
+      #     - "org.eclipse.ditto"
+      #   filter: "eq(attributes/awesome,true)"
+      #   tags:
+      #     foo: bar
 
 
 ## ----------------------------------------------------------------------------

--- a/internal/utils/config/src/main/resources/ditto-metrics.conf
+++ b/internal/utils/config/src/main/resources/ditto-metrics.conf
@@ -2,6 +2,10 @@ ditto.metrics {
   systemMetrics.enabled = true
   systemMetrics.enabled = ${?SYSTEM_METRICS_ENABLED}
 
+  # the metric prefix to apply for all gathered metrics in Ditto provided to Prometheus
+  metric-prefix = ""
+  metric-prefix = ${?DITTO_METRICS_METRIC_PREFIX}
+
   prometheus {
     enabled = true
     enabled = ${?PROMETHEUS_ENABLED}

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
@@ -30,12 +30,14 @@ public final class DefaultMetricsConfig implements MetricsConfig {
     private static final String CONFIG_PATH = "metrics";
 
     private final boolean systemMetricEnabled;
+    private final String metricPrefix;
     private final boolean prometheusEnabled;
     private final String prometheusHostname;
     private final int prometheusPort;
 
     private DefaultMetricsConfig(final ConfigWithFallback metricsScopedConfig) {
         systemMetricEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.SYSTEM_METRICS_ENABLED.getConfigPath());
+        metricPrefix = metricsScopedConfig.getString(MetricsConfigValue.METRIC_PREFIX.getConfigPath());
         prometheusEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.PROMETHEUS_ENABLED.getConfigPath());
         prometheusHostname = metricsScopedConfig.getString(MetricsConfigValue.PROMETHEUS_HOSTNAME.getConfigPath());
         prometheusPort = metricsScopedConfig.getNonNegativeIntOrThrow(MetricsConfigValue.PROMETHEUS_PORT);
@@ -56,6 +58,11 @@ public final class DefaultMetricsConfig implements MetricsConfig {
     @Override
     public boolean isSystemMetricsEnabled() {
         return systemMetricEnabled;
+    }
+
+    @Override
+    public String getMetricPrefix() {
+        return metricPrefix;
     }
 
     @Override
@@ -83,6 +90,7 @@ public final class DefaultMetricsConfig implements MetricsConfig {
         }
         final DefaultMetricsConfig that = (DefaultMetricsConfig) o;
         return systemMetricEnabled == that.systemMetricEnabled &&
+                Objects.equals(metricPrefix, that.metricPrefix) &&
                 prometheusEnabled == that.prometheusEnabled &&
                 prometheusPort == that.prometheusPort &&
                 Objects.equals(prometheusHostname, that.prometheusHostname);
@@ -90,13 +98,14 @@ public final class DefaultMetricsConfig implements MetricsConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(systemMetricEnabled, prometheusEnabled, prometheusHostname, prometheusPort);
+        return Objects.hash(systemMetricEnabled, metricPrefix, prometheusEnabled, prometheusHostname, prometheusPort);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "systemMetricEnabled=" + systemMetricEnabled +
+                ", metricPrefix=" + metricPrefix +
                 ", prometheusEnabled=" + prometheusEnabled +
                 ", prometheusHostname=" + prometheusHostname +
                 ", prometheusPort=" + prometheusPort +

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/MetricsConfig.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/MetricsConfig.java
@@ -30,6 +30,13 @@ public interface MetricsConfig {
     boolean isSystemMetricsEnabled();
 
     /**
+     * Returns the metric prefix to apply for all gathered metrics in Ditto provided to Prometheus.
+     *
+     * @return the metric prefix to apply or empty string for no prefix.
+     */
+    String getMetricPrefix();
+
+    /**
      * Indicates whether Prometheus is enabled.
      *
      * @return {@code true} if Prometheus is enabled, {@code false} if not.
@@ -62,6 +69,11 @@ public interface MetricsConfig {
         SYSTEM_METRICS_ENABLED("systemMetrics.enabled", false),
 
         /**
+         * The metric prefix to apply for all gathered Metrics in Ditto.
+         */
+        METRIC_PREFIX("metric-prefix", ""),
+
+        /**
          * Determines whether Prometheus is enabled.
          */
         PROMETHEUS_ENABLED("prometheus.enabled", false),
@@ -79,7 +91,7 @@ public interface MetricsConfig {
         private final String path;
         private final Object defaultValue;
 
-        private MetricsConfigValue(final String thePath, final Object theDefaultValue) {
+        MetricsConfigValue(final String thePath, final Object theDefaultValue) {
             path = thePath;
             defaultValue = theDefaultValue;
         }

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/package-info.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.eclipse.ditto.utils.jsr305.annotations.AllParametersAndReturnValuesAreNonnullByDefault
+package org.eclipse.ditto.internal.utils.metrics.config;

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
@@ -17,6 +17,7 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.KamonTagSetConverter;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
@@ -55,7 +56,8 @@ public final class KamonCounter implements Counter {
      * @throws IllegalArgumentException if {@code name} is empty.
      */
     public static KamonCounter newCounter(final String name, final TagSet tags) {
-        return new KamonCounter(name, tags);
+        final String metricPrefix = System.getProperty(DittoSystemProperties.DITTO_METRICS_METRIC_PREFIX, "");
+        return new KamonCounter(metricPrefix + name, tags);
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.internal.utils.metrics.instruments.gauge;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.KamonTagSetConverter;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
@@ -39,7 +40,8 @@ public final class KamonGauge implements Gauge {
     }
 
     public static Gauge newGauge(final String name) {
-        return new KamonGauge(name, TagSet.empty());
+        final String metricPrefix = System.getProperty(DittoSystemProperties.DITTO_METRICS_METRIC_PREFIX, "");
+        return new KamonGauge(metricPrefix + name, TagSet.empty());
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/histogram/KamonHistogram.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/histogram/KamonHistogram.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.KamonTagSetConverter;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
@@ -47,7 +48,8 @@ public final class KamonHistogram implements Histogram {
     }
 
     public static Histogram newHistogram(final String name) {
-        return new KamonHistogram(name, TagSet.empty());
+        final String metricPrefix = System.getProperty(DittoSystemProperties.DITTO_METRICS_METRIC_PREFIX, "");
+        return new KamonHistogram(metricPrefix + name, TagSet.empty());
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/PreparedKamonTimer.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/PreparedKamonTimer.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.KamonTagSetConverter;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
@@ -61,7 +62,8 @@ final class PreparedKamonTimer implements PreparedTimer {
     }
 
     static PreparedTimer newTimer(final String name) {
-        return new PreparedKamonTimer(name);
+        final String metricPrefix = System.getProperty(DittoSystemProperties.DITTO_METRICS_METRIC_PREFIX, "");
+        return new PreparedKamonTimer(metricPrefix + name);
     }
 
     private static void defaultExpirationHandling(

--- a/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
+++ b/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
@@ -101,7 +101,8 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
     /**
      * Returns a new instance of {@code SudoCountThings}.
      *
-     * @param filter the optional filter string
+     * @param filter the optional filter string.
+     * @param namespaces the namespaces to perform the count in.
      * @param dittoHeaders the headers of the command.
      * @return a new command for counting Things.
      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.

--- a/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
+++ b/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
@@ -13,24 +13,32 @@
 package org.eclipse.ditto.thingsearch.api.commands.sudo;
 
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonFieldDefinition;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonParsableCommand;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
 import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
 
 
@@ -57,12 +65,25 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
             JsonFactory.newStringFieldDefinition("filter", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
 
+    static final JsonFieldDefinition<JsonArray> JSON_NAMESPACES =
+            JsonFactory.newJsonArrayFieldDefinition("namespaces", FieldType.REGULAR,
+                    JsonSchemaVersion.V_2);
+
     @Nullable
     private final String filter;
 
-    private SudoCountThings(final DittoHeaders dittoHeaders, @Nullable final String filter) {
+    @Nullable
+    private final Set<String> namespaces;
+
+    private SudoCountThings(final DittoHeaders dittoHeaders, @Nullable final String filter,
+            @Nullable final Collection<String> namespaces) {
         super(TYPE, dittoHeaders);
         this.filter = filter;
+        if (namespaces != null) {
+            this.namespaces = Collections.unmodifiableSet(new HashSet<>(namespaces));
+        } else {
+            this.namespaces = null;
+        }
     }
 
     /**
@@ -74,7 +95,20 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
      */
     public static SudoCountThings of(@Nullable final String filter, final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, filter);
+        return new SudoCountThings(dittoHeaders, filter, null);
+    }
+
+    /**
+     * Returns a new instance of {@code SudoCountThings}.
+     *
+     * @param filter the optional filter string
+     * @param dittoHeaders the headers of the command.
+     * @return a new command for counting Things.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     */
+    public static SudoCountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
+            final DittoHeaders dittoHeaders) {
+        return new SudoCountThings(dittoHeaders, filter, namespaces);
     }
 
     /**
@@ -85,7 +119,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static SudoCountThings of(final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, null);
+        return new SudoCountThings(dittoHeaders, null, null);
     }
 
     /**
@@ -119,7 +153,14 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
         return new CommandJsonDeserializer<SudoCountThings>(TYPE, jsonObject).deserialize(() -> {
             final String extractedFilter = jsonObject.getValue(JSON_FILTER).orElse(null);
 
-            return new SudoCountThings(dittoHeaders, extractedFilter);
+            final Set<String> extractedNamespaces = jsonObject.getValue(JSON_NAMESPACES)
+                    .map(jsonValues -> jsonValues.stream()
+                            .filter(JsonValue::isString)
+                            .map(JsonValue::asString)
+                            .collect(Collectors.toSet()))
+                    .orElse(null);
+
+            return new SudoCountThings(dittoHeaders, extractedFilter, extractedNamespaces);
         });
     }
 
@@ -132,12 +173,24 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
         return Optional.ofNullable(filter);
     }
 
+    /**
+     * Get the optional set of namespaces.
+     *
+     * @return the optional set of namespaces.
+     */
+    public Optional<Set<String>> getNamespaces() {
+        return Optional.ofNullable(namespaces);
+    }
+
     @Override
     protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
             final Predicate<JsonField> thePredicate) {
 
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         getFilter().ifPresent(theFilter -> jsonObjectBuilder.set(JSON_FILTER, theFilter, predicate));
+        getNamespaces().ifPresent(presentOptions -> jsonObjectBuilder.set(JSON_NAMESPACES, presentOptions.stream()
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray()), predicate));
     }
 
     @Override
@@ -147,7 +200,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
 
     @Override
     public SudoCountThings setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return of(filter, dittoHeaders);
+        return of(filter, namespaces, dittoHeaders);
     }
 
     @Override
@@ -159,17 +212,21 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
         if (!super.equals(o))
             return false;
         final SudoCountThings that = (SudoCountThings) o;
-        return Objects.equals(filter, that.filter);
+        return Objects.equals(filter, that.filter) &&
+                Objects.equals(namespaces, that.namespaces);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filter);
+        return Objects.hash(super.hashCode(), filter, namespaces);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + "filter='" + filter + "']";
+        return getClass().getSimpleName() + "[" +
+                "filter='" + filter + "'" +
+                ", namespaces=" + namespaces +
+                "]";
     }
 
 }

--- a/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/signals/commands/query/CountThings.java
+++ b/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/signals/commands/query/CountThings.java
@@ -24,6 +24,12 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -32,12 +38,6 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableCommand;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
-import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
-import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
 import org.eclipse.ditto.thingsearch.model.signals.commands.ThingSearchCommand;
 
 /**
@@ -87,7 +87,7 @@ public final class CountThings extends AbstractCommand<CountThings> implements T
      * @return a new command for counting Things.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static CountThings of(@Nullable final String filter, @Nullable final Set<String> namespaces,
+    public static CountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
             final DittoHeaders dittoHeaders) {
 
         return new CountThings(dittoHeaders, filter, namespaces);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/CustomMetricConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/CustomMetricConfig.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+/**
+ * Provides the configuration settings for a single custom operator metric.
+ */
+public interface CustomMetricConfig {
+
+    /**
+     * Returns whether this specific search operator metric gathering is turned on.
+     *
+     * @return true or false.
+     */
+    boolean isEnabled();
+
+    /**
+     * Returns the optional scrape interval override for this specific custom metric, how often the metrics should be
+     * gathered.
+     *
+     * @return the optional scrape interval override.
+     */
+    Optional<Duration> getScrapeInterval();
+
+    /**
+     * Returns the namespaces the custom metric should be executed in or an empty list for gathering metrics in all
+     * namespaces.
+     *
+     * @return a list of namespaces.
+     */
+    List<String> getNamespaces();
+
+    /**
+     * Returns the filter (RQL statement) to include in the "CountThings" request or an empty string of no filter
+     * should be applied.
+     *
+     * @return the filter RQL statement.
+     */
+    String getFilter();
+
+    /**
+     * Return optional tags to report to the custom Gauge metric.
+     *
+     * @return optional tags to report.
+     */
+    Map<String, String> getTags();
+
+    enum CustomMetricConfigValue implements KnownConfigValue {
+
+        /**
+         * Whether the metrics should be gathered.
+         */
+        ENABLED("enabled", true),
+
+        /**
+         * The optional custom scrape interval, how often the metrics should be gathered.
+         * If this is {@code Duration.ZERO}, then there is no overwrite for the "global" scrape-interval to be applied.
+         */
+        SCRAPE_INTERVAL("scrape-interval", Duration.ZERO),
+
+        /**
+         * The namespaces the custom metric should be executed in or an empty list for gathering metrics in all
+         * namespaces.
+         */
+        NAMESPACES("namespaces", List.of()),
+
+        /**
+         * The filter RQL statement.
+         */
+        FILTER("filter", ""),
+
+        /**
+         * The optional tags to report to the custom Gauge metric.
+         */
+        TAGS("tags", Map.of());
+
+        private final String path;
+        private final Object defaultValue;
+
+        CustomMetricConfigValue(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+    }
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultCustomMetricConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultCustomMetricConfig.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class is the default implementation of the CustomMetricConfig.
+ * It is instantiated for each {@code custom-metrics} entry containing the configuration for the custom metric.
+ */
+public final class DefaultCustomMetricConfig implements CustomMetricConfig {
+
+    private final String customMetricName;
+    private final boolean enabled;
+    private final Duration scrapeInterval;
+    private final List<String> namespaces;
+    private final String filter;
+    private final Map<String, String> tags;
+
+    private DefaultCustomMetricConfig(final String customMetricName, final ConfigWithFallback configWithFallback) {
+        this.customMetricName = customMetricName;
+        enabled = configWithFallback.getBoolean(CustomMetricConfigValue.ENABLED.getConfigPath());
+        scrapeInterval = configWithFallback.getDuration(CustomMetricConfigValue.SCRAPE_INTERVAL.getConfigPath());
+        namespaces = configWithFallback.getStringList(CustomMetricConfigValue.NAMESPACES.getConfigPath());
+        filter = configWithFallback.getString(CustomMetricConfigValue.FILTER.getConfigPath());
+        tags = configWithFallback.getObject(CustomMetricConfigValue.TAGS.getConfigPath()).unwrapped()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
+    }
+
+    /**
+     * Returns an instance of {@code DefaultCustomMetricConfig} based on the settings of the specified Config.
+     *
+     * @param key the key of the {@code custom-metrics} entry config passed in the {@code config}.
+     * @param config is supposed to provide the config for the issuer at its current level.
+     * @return the instance.
+     * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultCustomMetricConfig of(final String key, final Config config) {
+        return new DefaultCustomMetricConfig(key,
+                ConfigWithFallback.newInstance(config, CustomMetricConfigValue.values()));
+    }
+
+    public String getCustomMetricName() {
+        return customMetricName;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public Optional<Duration> getScrapeInterval() {
+        return scrapeInterval.isZero() ? Optional.empty() : Optional.of(scrapeInterval);
+    }
+
+    @Override
+    public List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultCustomMetricConfig that = (DefaultCustomMetricConfig) o;
+        return enabled == that.enabled &&
+                Objects.equals(scrapeInterval, that.scrapeInterval) &&
+                Objects.equals(namespaces, that.namespaces) &&
+                Objects.equals(filter, that.filter) &&
+                Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, scrapeInterval, namespaces, filter, tags);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "enabled=" + enabled +
+                ", scrapeInterval=" + scrapeInterval +
+                ", namespaces=" + namespaces +
+                ", filter=" + filter +
+                ", tags=" + tags +
+                "]";
+    }
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+
+/**
+ * This class is the default implementation for {@link OperatorMetricsConfig}.
+ */
+@Immutable
+public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig {
+
+    /**
+     * Path where the operator metrics config values are expected.
+     */
+    static final String CONFIG_PATH = "operator-metrics";
+
+    private final boolean enabled;
+    private final Duration scrapeInterval;
+    private final Map<String, CustomMetricConfig> customMetricConfigurations;
+
+    private DefaultOperatorMetricsConfig(final ConfigWithFallback updaterScopedConfig) {
+        enabled = updaterScopedConfig.getBoolean(OperatorMetricsConfigValue.ENABLED.getConfigPath());
+        scrapeInterval = updaterScopedConfig.getNonNegativeDurationOrThrow(OperatorMetricsConfigValue.SCRAPE_INTERVAL);
+        customMetricConfigurations = loadCustomMetricConfigurations(updaterScopedConfig,
+                OperatorMetricsConfigValue.CUSTOM_METRICS);
+    }
+
+    /**
+     * Returns an instance of DefaultOperatorMetricsConfig based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the updater config at {@value #CONFIG_PATH}.
+     * @return the instance.
+     * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultOperatorMetricsConfig of(final Config config) {
+        return new DefaultOperatorMetricsConfig(
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, OperatorMetricsConfigValue.values()));
+    }
+
+    private static Map<String, CustomMetricConfig> loadCustomMetricConfigurations(final ConfigWithFallback config,
+            final KnownConfigValue configValue) {
+
+        final ConfigObject customMetricsConfig = config.getObject(configValue.getConfigPath());
+
+        return customMetricsConfig.entrySet().stream().collect(CustomMetricConfigCollector.toMap());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultOperatorMetricsConfig that = (DefaultOperatorMetricsConfig) o;
+        return enabled == that.enabled &&
+                Objects.equals(scrapeInterval, that.scrapeInterval);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, scrapeInterval, customMetricConfigurations);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "enabled=" + enabled +
+                ", scrapeInterval=" + scrapeInterval +
+                ", customMetricConfigurations=" + customMetricConfigurations +
+                "]";
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public Duration getScrapeInterval() {
+        return scrapeInterval;
+    }
+
+    @Override
+    public Map<String, CustomMetricConfig> getCustomMetricConfigurations() {
+        return customMetricConfigurations;
+    }
+
+    private static class CustomMetricConfigCollector
+            implements
+            Collector<Map.Entry<String, ConfigValue>, Map<String, CustomMetricConfig>, Map<String, CustomMetricConfig>> {
+
+        private static CustomMetricConfigCollector toMap() {
+            return new CustomMetricConfigCollector();
+        }
+
+        @Override
+        public Supplier<Map<String, CustomMetricConfig>> supplier() {
+            return LinkedHashMap::new;
+        }
+
+        @Override
+        public BiConsumer<Map<String, CustomMetricConfig>, Map.Entry<String, ConfigValue>> accumulator() {
+            return (map, entry) -> map.put(entry.getKey(),
+                    DefaultCustomMetricConfig.of(entry.getKey(), ConfigFactory.empty().withFallback(entry.getValue())));
+        }
+
+        @Override
+        public BinaryOperator<Map<String, CustomMetricConfig>> combiner() {
+            return (left, right) -> Stream.concat(left.entrySet().stream(), right.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        @Override
+        public Function<Map<String, CustomMetricConfig>, Map<String, CustomMetricConfig>> finisher() {
+            return map -> Collections.unmodifiableMap(new LinkedHashMap<>(map));
+        }
+
+        @Override
+        public Set<Characteristics> characteristics() {
+            return Collections.singleton(Characteristics.UNORDERED);
+        }
+    }
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
@@ -60,6 +60,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
     private final MongoDbConfig mongoDbConfig;
     private final SearchPersistenceConfig queryPersistenceConfig;
     private final Map<String, String> simpleFieldMappings;
+    private final DefaultOperatorMetricsConfig operatorMetricsConfig;
 
     private DittoSearchConfig(final ScopedConfig dittoScopedConfig) {
         dittoServiceConfig = DittoServiceConfig.of(dittoScopedConfig, CONFIG_PATH);
@@ -79,6 +80,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
         queryPersistenceConfig = DefaultSearchPersistenceConfig.of(queryConfig);
         simpleFieldMappings =
                 convertToMap(configWithFallback.getConfig(SearchConfigValue.SIMPLE_FIELD_MAPPINGS.getConfigPath()));
+        operatorMetricsConfig = DefaultOperatorMetricsConfig.of(configWithFallback);
     }
 
     /**
@@ -110,6 +112,11 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
 
     public Map<String, String> getSimpleFieldMappings() {
         return simpleFieldMappings;
+    }
+
+    @Override
+    public DefaultOperatorMetricsConfig getOperatorMetricsConfig() {
+        return operatorMetricsConfig;
     }
 
     @Override
@@ -175,13 +182,15 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
                 Objects.equals(persistenceOperationsConfig, that.persistenceOperationsConfig) &&
                 Objects.equals(mongoDbConfig, that.mongoDbConfig) &&
                 Objects.equals(queryPersistenceConfig, that.queryPersistenceConfig) &&
-                Objects.equals(simpleFieldMappings, that.simpleFieldMappings);
+                Objects.equals(simpleFieldMappings, that.simpleFieldMappings) &&
+                Objects.equals(operatorMetricsConfig, that.operatorMetricsConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(mongoHintsByNamespace, updaterConfig, dittoServiceConfig, healthCheckConfig,
-                indexInitializationConfig, persistenceOperationsConfig, mongoDbConfig, queryPersistenceConfig, simpleFieldMappings);
+                indexInitializationConfig, persistenceOperationsConfig, mongoDbConfig, queryPersistenceConfig,
+                simpleFieldMappings, operatorMetricsConfig);
     }
 
     @Override
@@ -196,6 +205,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
                 ", mongoDbConfig=" + mongoDbConfig +
                 ", queryPersistenceConfig=" + queryPersistenceConfig +
                 ", simpleFieldMappings=" + simpleFieldMappings +
+                ", operatorMetricsConfig=" + operatorMetricsConfig +
                 "]";
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+/**
+ * Provides the configuration settings for the search operator metrics.
+ */
+@Immutable
+public interface OperatorMetricsConfig {
+
+    /**
+     * Returns whether search operator metrics gathering is turned on.
+     *
+     * @return true or false.
+     */
+    boolean isEnabled();
+
+    /**
+     * Returns the default scrape interval, how often the metrics should be gathered.
+     *
+     * @return the default scrape interval.
+     */
+    Duration getScrapeInterval();
+
+    /**
+     * Returns all registered custom metrics with the key being the metric name to use.
+     *
+     * @return the registered custom metrics.
+     */
+    Map<String, CustomMetricConfig> getCustomMetricConfigurations();
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values for
+     * OperatorMetricsConfig.
+     */
+    enum OperatorMetricsConfigValue implements KnownConfigValue {
+
+        /**
+         * Whether the metrics should be gathered.
+         */
+        ENABLED("enabled", true),
+
+        /**
+         * The default scrape interval, how often the metrics should be gathered.
+         */
+        SCRAPE_INTERVAL("scrape-interval", Duration.ofMinutes(15)),
+
+        /**
+         * All registered custom metrics with the key being the metric name to use.
+         */
+        CUSTOM_METRICS("custom-metrics", Collections.emptyMap());
+
+        private final String path;
+        private final Object defaultValue;
+
+        OperatorMetricsConfigValue(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+    }
+
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SearchConfig.java
@@ -53,9 +53,16 @@ public interface SearchConfig extends ServiceSpecificConfig, WithHealthCheckConf
      * Returns how simple fields are mapped during query parsing.
      *
      * @return the simple field mapping.
-     * @since 3.0.0
      */
     Map<String, String> getSimpleFieldMappings();
+
+    /**
+     * Returns the operator metrics configuration containing metrics to be exposed via Prometheus based on configured
+     * search "count" queries.
+     *
+     * @return the operator metrics configuration.
+     */
+    OperatorMetricsConfig getOperatorMetricsConfig();
 
     /**
      * An enumeration of the known config path expressions and their associated default values for SearchConfig.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/query/QueryParser.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/query/QueryParser.java
@@ -122,7 +122,13 @@ public final class QueryParser {
     public CompletionStage<Query> parseSudoCountThings(final SudoCountThings sudoCountThings) {
         final DittoHeaders headers = sudoCountThings.getDittoHeaders();
         final String filters = sudoCountThings.getFilter().orElse(null);
-        final Criteria criteria = queryFilterCriteriaFactory.filterCriteria(filters, headers);
+        final Set<String> namespaces = sudoCountThings.getNamespaces().orElse(null);
+        final Criteria criteria;
+        if (null != namespaces) {
+            criteria = queryFilterCriteriaFactory.filterCriteriaRestrictedByNamespaces(filters, headers, namespaces);
+        } else {
+            criteria = queryFilterCriteriaFactory.filterCriteria(filters, headers);
+        }
         return CompletableFuture.completedFuture(queryBuilderFactory.newUnlimitedBuilder(criteria).build());
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.starter.actors;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.pekko.actor.AbstractActorWithTimers;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.actor.Status;
+import org.apache.pekko.japi.pf.ReceiveBuilder;
+import org.apache.pekko.pattern.Patterns;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.Gauge;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.KamonGauge;
+import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
+import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+import org.eclipse.ditto.thingsearch.api.commands.sudo.SudoCountThings;
+import org.eclipse.ditto.thingsearch.model.signals.commands.query.CountThingsResponse;
+import org.eclipse.ditto.thingsearch.service.common.config.CustomMetricConfig;
+import org.eclipse.ditto.thingsearch.service.common.config.OperatorMetricsConfig;
+
+/**
+ * Actor which is started as singleton for "search" role and is responsible for querying for operator defined
+ * "custom metrics" (configured via Ditto search service configuration) to expose as {@code Gauge} via Prometheus.
+ */
+public final class OperatorMetricsProviderActor extends AbstractActorWithTimers {
+
+    /**
+     * This Actor's actor name.
+     */
+    public static final String ACTOR_NAME = "operatorMetricsProvider";
+
+    private static final int MIN_INITIAL_DELAY_SECONDS = 30;
+    private static final int MAX_INITIAL_DELAY_SECONDS = 90;
+    private static final int DEFAULT_COUNT_TIMEOUT_SECONDS = 60;
+
+    private final DittoDiagnosticLoggingAdapter log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
+
+    private final ActorRef searchActor;
+    private final Map<String, Gauge> metricsGauges;
+
+    @SuppressWarnings("unused")
+    private OperatorMetricsProviderActor(final OperatorMetricsConfig operatorMetricsConfig,
+            final ActorRef searchActor) {
+
+        this.searchActor = searchActor;
+        metricsGauges = new HashMap<>();
+        operatorMetricsConfig.getCustomMetricConfigurations().forEach((metricName, config) -> {
+            if (config.isEnabled()) {
+                initializeCustomMetric(operatorMetricsConfig, metricName, config);
+            } else {
+                log.info("Initializing custom metric Gauge for metric <{}> is DISABLED", metricName);
+            }
+        });
+    }
+
+    /**
+     * Create Props for this actor.
+     *
+     * @param operatorMetricsConfig the config to use
+     * @param searchActor the SearchActor Actor reference
+     * @return the Props object.
+     */
+    public static Props props(final OperatorMetricsConfig operatorMetricsConfig, final ActorRef searchActor) {
+        return Props.create(OperatorMetricsProviderActor.class, operatorMetricsConfig, searchActor);
+    }
+
+    @Override
+    public Receive createReceive() {
+        return ReceiveBuilder.create()
+                .match(GatherMetrics.class, this::handleGatheringMetrics)
+                .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
+                .matchAny(m -> {
+                    log.warning("Unknown message: {}", m);
+                    unhandled(m);
+                })
+                .build();
+    }
+
+    private void initializeCustomMetric(final OperatorMetricsConfig operatorMetricsConfig, final String metricName,
+            final CustomMetricConfig config) {
+        // start each custom metric provider with a random initialDelay
+        final Duration initialDelay = Duration.ofSeconds(
+                ThreadLocalRandom.current().nextInt(MIN_INITIAL_DELAY_SECONDS, MAX_INITIAL_DELAY_SECONDS)
+        );
+        final Duration scrapeInterval = config.getScrapeInterval()
+                .orElse(operatorMetricsConfig.getScrapeInterval());
+        getTimers().startTimerAtFixedRate(
+                metricName, createGatherCustomMetric(metricName, config), initialDelay, scrapeInterval);
+
+        final List<Tag> tags = config.getTags().entrySet().stream()
+                .map(e -> Tag.of(e.getKey(), e.getValue()))
+                .toList();
+        log.info("Initializing custom metric Gauge for metric <{}> with tags <{}>, initial delay <{}> " +
+                "and a scrape-interval of <{}>", metricName, tags, initialDelay, scrapeInterval);
+        final Gauge gauge = KamonGauge.newGauge(metricName)
+                .tags(TagSet.ofTagCollection(tags));
+        metricsGauges.put(metricName, gauge);
+    }
+
+    private static GatherMetrics createGatherCustomMetric(final String metricName, final CustomMetricConfig config) {
+        return new GatherMetrics(metricName, config);
+    }
+
+    private void handleGatheringMetrics(final GatherMetrics gatherMetrics) {
+        final String metricName = gatherMetrics.metricName();
+        final CustomMetricConfig config = gatherMetrics.config();
+        final String filter = config.getFilter();
+        final List<String> namespaces = config.getNamespaces();
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId("gather-metrics_" + metricName + "_" + UUID.randomUUID())
+                .build();
+        final SudoCountThings sudoCountThings = SudoCountThings.of(
+                filter.isEmpty() ? null : filter, namespaces.isEmpty() ? null : namespaces, dittoHeaders);
+
+        final long startTs = System.nanoTime();
+        log.withCorrelationId(dittoHeaders)
+                .debug("Asking for count of custom metric <{}>..", metricName);
+
+        Patterns.ask(searchActor, sudoCountThings, Duration.ofSeconds(DEFAULT_COUNT_TIMEOUT_SECONDS))
+                .whenComplete((response, throwable) -> {
+                    if (response instanceof CountThingsResponse countThingsResponse) {
+                        log.withCorrelationId(countThingsResponse)
+                                .info("Received sudo CountThingsResponse for custom metric count <{}>: {} - " +
+                                                "duration: <{}ms>",
+                                        metricName, countThingsResponse.getCount(),
+                                        Duration.ofNanos(System.nanoTime() - startTs).toMillis()
+                                );
+                        metricsGauges.get(metricName).set(countThingsResponse.getCount());
+                    } else if (response instanceof DittoRuntimeException dre) {
+                        log.withCorrelationId(dittoHeaders).warning(
+                                "Received DittoRuntimeException when gathering count for " +
+                                        "custom metric <{}>: {}", metricName, dre.getMessage(), dre
+                        );
+                    } else {
+                        log.withCorrelationId(dittoHeaders).warning(
+                                "Received unexpected result or throwable when gathering count for " +
+                                        "custom metric <{}>: {}", metricName, response, throwable
+                        );
+                    }
+                });
+    }
+
+    private record GatherMetrics(String metricName, CustomMetricConfig config) {}
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
@@ -270,7 +270,8 @@ public final class SearchActor extends AbstractActorWithShutdownBehaviorAndReque
     private void sudoCount(final SudoCountThings sudoCountThings) {
         final var sender = getSender();
         final ThreadSafeDittoLoggingAdapter l = log.withCorrelationId(sudoCountThings);
-        l.info("Processing SudoCountThings command with filter: <{}>", sudoCountThings.getFilter());
+        l.info("Processing SudoCountThings command with filter: <{}> and namespaces: <{}>",
+                sudoCountThings.getFilter(), sudoCountThings.getNamespaces());
         l.debug("Processing SudoCountThings command: <{}>", sudoCountThings);
 
         withRequestCounting(

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchRootActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchRootActor.java
@@ -14,11 +14,17 @@ package org.eclipse.ditto.thingsearch.service.starter.actors;
 
 import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.BACKGROUND_SYNC_COLLECTION_NAME;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.event.Logging;
+import org.apache.pekko.event.LoggingAdapter;
+import org.apache.pekko.stream.SystemMaterializer;
 import org.eclipse.ditto.base.service.RootChildActorStarter;
 import org.eclipse.ditto.base.service.actors.DittoRootActor;
-import org.eclipse.ditto.internal.utils.pekko.streaming.TimestampPersistence;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.streaming.TimestampPersistence;
 import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoTimestampPersistence;
 import org.eclipse.ditto.rql.query.QueryBuilderFactory;
@@ -31,13 +37,6 @@ import org.eclipse.ditto.thingsearch.service.persistence.read.MongoThingsSearchP
 import org.eclipse.ditto.thingsearch.service.persistence.read.ThingsSearchPersistence;
 import org.eclipse.ditto.thingsearch.service.persistence.read.query.MongoQueryBuilderFactory;
 import org.eclipse.ditto.thingsearch.service.updater.actors.SearchUpdaterRootActor;
-
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Props;
-import org.apache.pekko.event.Logging;
-import org.apache.pekko.event.LoggingAdapter;
-import org.apache.pekko.stream.SystemMaterializer;
 
 /**
  * Our "Parent" Actor which takes care of supervision of all other Actors in our system.
@@ -74,7 +73,7 @@ public final class SearchRootActor extends DittoRootActor {
                         SystemMaterializer.get(actorSystem).materializer());
 
         final ActorRef searchUpdaterRootActor = startChildActor(SearchUpdaterRootActor.ACTOR_NAME,
-                SearchUpdaterRootActor.props(searchConfig, pubSubMediator, thingsSearchPersistence,
+                SearchUpdaterRootActor.props(searchConfig, searchActor, pubSubMediator, thingsSearchPersistence,
                         backgroundSyncPersistence));
         final ActorRef healthCheckingActor = initializeHealthCheckActor(searchConfig, searchUpdaterRootActor);
 

--- a/thingsearch/service/src/main/resources/search-dev.conf
+++ b/thingsearch/service/src/main/resources/search-dev.conf
@@ -6,6 +6,24 @@ ditto {
 
   metrics.prometheus.port = 9013
 
+  search {
+    operator-metrics {
+      custom-metrics {
+        my_awesome_things {
+          scrape-interval = 1m # overwrite scrape interval, run each minute
+          namespaces = [
+            "org.eclipse.ditto.foo"
+            "org.eclipse.ditto.bar"
+          ]
+          # with an empty filter query, counting all existing things
+          filter = "eq(attributes/awesome,true)"
+          tags {
+            category = "bumlux"
+          }
+        }
+      }
+    }
+  }
 }
 
 pekko {

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -284,6 +284,42 @@ ditto {
         readConcern = ${?UPDATER_PERSISTENCE_MONGO_DB_READ_CONCERN}
       }
     }
+
+    operator-metrics {
+      enabled = true
+      enabled = ${?THINGS_SEARCH_OPERATOR_METRICS_ENABLED}
+
+      # by default, execute "count" metrics once every 15 minutes:
+      scrape-interval = 15m
+      scrape-interval = ${?THINGS_SEARCH_OPERATOR_METRICS_SCRAPE_INTERVAL}
+
+      # map <metric-name, metric-config> of all custom metric providers
+      custom-metrics {
+        # built-in query, delivering the total things as metric
+        total_things {
+          enabled = true
+          # for all namespaces
+          namespaces = []
+          # with an empty filter query, counting all existing things
+          filter = ""
+          # optionally, provide tags to categorize metrics
+          tags {
+            # key = "value"
+          }
+        }
+
+        # add new metrics by providing more configuration entries:
+        # my_awesome_things {
+        #   scrape-interval = 1m # overwrite scrape interval, run each minute
+        #   namespaces [
+        #     "org.eclipse.ditto.foo"
+        #     "org.eclipse.ditto.bar"
+        #   ]
+        #   # with an empty filter query, counting all existing things
+        #   filter = "eq(attributes/awesome,true)"
+        # }
+      }
+    }
   }
 }
 

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -298,6 +298,7 @@ ditto {
         # built-in query, delivering the total things as metric
         total_things {
           enabled = true
+          scrape-interval = 15m # overwrite scrape interval, run each minute
           # for all namespaces
           namespaces = []
           # with an empty filter query, counting all existing things

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchUpdaterRootActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchUpdaterRootActorTest.java
@@ -14,18 +14,17 @@ package org.eclipse.ditto.thingsearch.service.starter.actors;
 
 import java.util.Optional;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Props;
 import org.eclipse.ditto.base.service.actors.AbstractDittoRootActorTest;
-import org.eclipse.ditto.internal.utils.pekko.streaming.TimestampPersistence;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.streaming.TimestampPersistence;
 import org.eclipse.ditto.thingsearch.service.common.config.DittoSearchConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.SearchConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.read.MongoThingsSearchPersistence;
 import org.eclipse.ditto.thingsearch.service.starter.SearchService;
 import org.eclipse.ditto.thingsearch.service.updater.actors.SearchUpdaterRootActor;
 import org.mockito.Mockito;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Props;
 
 /**
  * Tests {@link SearchRootActor}.
@@ -46,7 +45,7 @@ public final class SearchUpdaterRootActorTest extends AbstractDittoRootActorTest
     protected Props getRootActorProps(final ActorSystem system) {
         final SearchConfig config =
                 DittoSearchConfig.of(DefaultScopedConfig.dittoScoped(system.settings().config()));
-        return SearchUpdaterRootActor.props(config, system.deadLetters(),
+        return SearchUpdaterRootActor.props(config, system.deadLetters(), system.deadLetters(),
                 Mockito.mock(MongoThingsSearchPersistence.class), Mockito.mock(TimestampPersistence.class));
     }
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/config/DittoSearchConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/config/DittoSearchConfigTest.java
@@ -24,6 +24,7 @@ import org.eclipse.ditto.internal.utils.health.config.DefaultHealthCheckConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.DefaultMongoDbConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
+import org.eclipse.ditto.thingsearch.service.common.config.DefaultOperatorMetricsConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.DefaultSearchPersistenceConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.DefaultUpdaterConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.DittoSearchConfig;
@@ -43,7 +44,8 @@ public final class DittoSearchConfigTest {
         assertInstancesOf(DittoSearchConfig.class,
                 areImmutable(),
                 provided(DefaultHealthCheckConfig.class, DittoServiceConfig.class, DefaultUpdaterConfig.class,
-                        DefaultMongoDbConfig.class, DefaultSearchPersistenceConfig.class)
+                        DefaultMongoDbConfig.class, DefaultSearchPersistenceConfig.class,
+                        DefaultOperatorMetricsConfig.class)
                         .areAlsoImmutable(),
                 assumingFields("simpleFieldMappings").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements());
     }


### PR DESCRIPTION
- make a common metric prefix configurable for all gathered Ditto custom metrics

- [x] Add and apply configuration for "searches" which should provide "count" metrics as Gauges in search
- [x] Include a "default" search/count, counting all things
- [x] Add documentation and example
- [x] provide configuration of those metrics via Helm chart values

Resolves: #1806