### PR TITLE
fix that non-successful message responses were not displayed in ACE editor

### DIFF
--- a/ui/modules/things/featureMessages.ts
+++ b/ui/modules/things/featureMessages.ts
@@ -124,10 +124,14 @@ function messageFeature() {
   }
   aceResponse.setValue('');
   API.callDittoREST('POST', '/things/' + Things.theThing.thingId +
-      '/features/' + theFeatureId +
-      '/inbox/messages/' + dom.inputMessageSubject.value +
-      '?timeout=' + dom.inputMessageTimeout.value,
-  payload,
+    '/features/' + theFeatureId +
+    '/inbox/messages/' + dom.inputMessageSubject.value +
+    '?timeout=' + dom.inputMessageTimeout.value,
+    payload,
+    null,
+    false,
+    false,
+    true
   ).then((data) => {
     dom.buttonMessageSend.classList.remove('busy');
     dom.buttonMessageSend.disabled = false;
@@ -137,7 +141,7 @@ function messageFeature() {
   }).catch((err) => {
     dom.buttonMessageSend.classList.remove('busy');
     dom.buttonMessageSend.disabled = false;
-    aceResponse.setValue('');
+    aceResponse.setValue(`Error: ${err}`);
   });
 }
 

--- a/ui/modules/things/thingMessages.ts
+++ b/ui/modules/things/thingMessages.ts
@@ -117,9 +117,13 @@ function messageThing() {
   }
   aceResponse.setValue('');
   API.callDittoREST('POST', '/things/' + Things.theThing.thingId +
-      '/inbox/messages/' + dom.inputThingMessageSubject.value +
-      '?timeout=' + dom.inputThingMessageTimeout.value,
-  payload,
+    '/inbox/messages/' + dom.inputThingMessageSubject.value +
+    '?timeout=' + dom.inputThingMessageTimeout.value,
+    payload,
+    null,
+    false,
+    false,
+    true
   ).then((data) => {
     dom.buttonThingMessageSend.classList.remove('busy');
     dom.buttonThingMessageSend.disabled = false;
@@ -129,7 +133,7 @@ function messageThing() {
   }).catch((err) => {
     dom.buttonThingMessageSend.classList.remove('busy');
     dom.buttonThingMessageSend.disabled = false;
-    aceResponse.setValue('');
+    aceResponse.setValue(`Error: ${err}`);
   });
 }
 


### PR DESCRIPTION
* only successful responses were displayed
* however, messages might e.g. be answered with a 400 (bad request) and useful information as response