### PR TITLE
display attributes in UI in an aceEditor instead of a simple inputfield

### DIFF
--- a/ui/main.scss
+++ b/ui/main.scss
@@ -156,7 +156,7 @@ textarea {
 }
 
 h5, h6 {
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
     margin-bottom: 0.25rem;
 }
 

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -91,7 +91,7 @@
         id="badgeAttributeCount"></span></h5>
 <hr />
 <div class="collapse" id="collapseAttributes">
-    <div class="row">
+    <div class="row resizable_pane" style="height: 20vh;">
         <div class="col-md-7 resizable_flex_column" style="overflow-y:scroll;">
             <table class="table table-striped table-hover table-sm">
                 <thead>

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -48,7 +48,7 @@
                     </table>
                 </div>
             </div>
-            <div class="col-md-5 resizable_flex_column" id="details">
+            <div class="col-md-5 resizable_flex_column" style="height: auto" id="details">
                 <ul id="tabItemsThing" class="nav nav-tabs nav-fill">
                     <li class="nav-item">
                         <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabThingDetails">Details</a>
@@ -66,7 +66,7 @@
                                 </table>
                             </div>
                     </div>
-                    <div class="tab-pane fade container no-margin" style="height:100%;" id="tabModifyThing">
+                    <div class="tab-pane fade container no-margin" id="tabModifyThing">
                         <crud-toolbar id="crudThings" label="Thing ID">
                             <div class="input-group input-group-sm mb-1">
                                 <label class="input-group-text" id="labelX">Definition</label>
@@ -92,24 +92,26 @@
 <hr />
 <div class="collapse" id="collapseAttributes">
     <div class="row">
-        <div class="col-md-4" style="overflow-y:scroll;">
+        <div class="col-md-7 resizable_flex_column" style="overflow-y:scroll;">
             <table class="table table-striped table-hover table-sm">
+                <thead>
+                 <th class="col-3" style="visibility: hidden"></th>
+                 <th class="col-7" style="visibility: hidden"></th>
+                </thead>
                 <tbody id="tbodyAttributes"></tbody>
             </table>
         </div>
-        <div class="col-md-8">
-            <ul class="nav nav-tabs nav-fill">
+        <div class="col-md-5 resizable_flex_column" style="height: auto">
+            <ul class="nav nav-tabs nav-fill" id="tabItemsAttribute">
                 <li class="nav-item">
-                    <a class="nav-link active">Manage</a>
+                    <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#tabCrudAttribute">Manage</a>
                 </li>
             </ul>
-            <div class="tab-content">
-                <div class="tab-pane container active no-margin">
-                    <crud-toolbar id="crudAttribute" label="Path">
-                        <div class="input-group input-group-sm has-validation mb-1">
-                            <label class="input-group-text">Value</label>
-                            <input type="text" class="form-control form-control-sm" id="inputAttributeValue" disabled></input>
-                            <div class="invalid-feedback"></div>
+            <div class="tab-content" style="flex-grow: 1;" id="tabContentAttribute">
+                <div class="tab-pane container active no-margin" id="tabCrudAttribute">
+                    <crud-toolbar id="crudAttribute" label="Attribute key">
+                        <div class="ace_container mb-1" style="flex-grow: 1;">
+                            <div class="script_editor" id="attributeEditor"></div>
                         </div>
                     </crud-toolbar>
                 </div>


### PR DESCRIPTION
* for attributes which were JsonObjects or JsonArrays, displaying them in a single "input" field was very umcomfortable

This PR shows all attributes also in an aceEditor, while still showing the string representation in the attributes table.

@thfries I would appreciate if you could have a look