### PR TITLE
enhance "Incoming Thing Updates" in UI to provide more information at a glance

### DIFF
--- a/ui/modules/things/messagesIncoming.html
+++ b/ui/modules/things/messagesIncoming.html
@@ -15,7 +15,7 @@
 <hr />
 <div class="collapse" id="collapseMessages">
     <div class="row resizable_pane" style="height: 45vh;">
-        <div class="col-md-6 resizable_flex_column">
+        <div class="col-md-7 resizable_flex_column">
             <div class="input-group input-group-sm mb-1">
                 <button class="btn btn-outline-secondary btn-sm button_round_right" id="buttonResetMessagesIncoming"
                     data-bs-toggle="tooltip" title="Reset connection logs for the selected connection">
@@ -28,6 +28,8 @@
                     <thead>
                         <tr>
                             <th>Revision</th>
+                            <th>Action</th>
+                            <th>Path</th>
                             <th>Field(s)</th>
                             <th>Modified</th>
                         </tr>
@@ -36,8 +38,17 @@
                 </table>
             </div>
         </div>
-        <div class="col-md-6 resizable_flex_column">
+        <div class="col-md-5 resizable_flex_column">
             <h6>Thing Update Detail</h6>
+            <div class="input-group input-group-sm mb-1 mt-1">
+                <label class="input-group-text" for="selectThingUpdateMessageContent">Show</label>
+                <select class="form-select form-select-sm" id="selectThingUpdateMessageContent">
+                    <option value="FULL_THING_WITH_CONTEXT" selected>Full Thing JSON with context and metadata</option>
+                    <option value="FULL_THING">Only full Thing JSON</option>
+                    <option value="ONLY_CONTEXT_WITH_METADATA">Only context with metadata</option>
+                    <option value="ONLY_CONTEXT">Only context</option>
+                </select>
+            </div>
             <div class="ace_container" style="flex-grow: 1;">
                 <div class="script_editor" id="messageIncomingDetail"></div>
             </div>


### PR DESCRIPTION
* added 2 columns "Action" (e.g. showing "merged" or "modified") and "Path" (showing on which level) to the table
* prioritized "_context" over "features" and "attributes" to extract "Field(s)" from - only done for actions on path "/"
* added a selection to the "Thing Update Detail" view which information to display from the selected event

@thfries again, I would appreciate your input on this :)

I noticed you swapped reading from either "_context" or features/attributes in `getColumnValues()` method recently.
That does not work, for newer Ditto versions both are present, so we have to first check for existence of `["_context"].value` (which Ditto 3.4 provides) and can then fall-back to plain features/attributes to determining the updated "Field(s)".

This PR improves displaying "merge" and also "delete" events a lot - because "Action" and "Path" are shown in the table.