### PR TITLE
removed X-Original-URI

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -94,7 +94,7 @@ jobs:
         k8s:
           - v1.26.6
           - v1.27.3
-          - v1.28.3
+          - v1.28.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.4.1  # chart version is effectively set by release-job
+version: 3.4.2  # chart version is effectively set by release-job
 appVersion: 3.4.1
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/nginx-ingress.yaml
+++ b/deployment/helm/ditto/templates/nginx-ingress.yaml
@@ -131,7 +131,6 @@ data:
 
     # ignore X-Original-URI in the request
     proxy_hide_header X-Original-URI;
-    proxy_set_header X-Original-URI $request_uri;
 
   proxy-connect-timeout: "10" # seconds, default: 60
   # timeouts are configured slightly higher than gateway read-timeout of 60 seconds


### PR DESCRIPTION
 - currently this header isn't handled by ditto
 - if someone were to make a large request with many thingIds in a GET request the X-Original-URI will be passed as a Ditto Header in the protocol message causing a DittoHeadersTooLarge exception -> http error 431