### PR TITLE
#1883 return pre-authenticated configuration to location-snippet

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.4.2  # chart version is effectively set by release-job
+version: 3.4.3-0  # chart version is effectively set by release-job
 appVersion: 3.4.2
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/nginx-ingress.yaml
+++ b/deployment/helm/ditto/templates/nginx-ingress.yaml
@@ -132,6 +132,11 @@ data:
     # ignore X-Original-URI in the request
     proxy_hide_header X-Original-URI;
 
+
+    # set ditto-specific forwarded headers - needed in the location for registry.k8s.io/ingress-nginx/controller
+    proxy_set_header        X-Forwarded-User              $remote_user;
+    proxy_set_header        x-ditto-pre-authenticated     "nginx:$remote_user";
+
   proxy-connect-timeout: "10" # seconds, default: 60
   # timeouts are configured slightly higher than gateway read-timeout of 60 seconds
   proxy-send-timeout: "70" # seconds, default: 60


### PR DESCRIPTION
Necessary for the Ingress-Nginx Controller. Fixes #1833 