### PR TITLE
Provide same behavior for filtering in arrays via search's "filter" for specified "condition"

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/entity/metadata/ImmutableMetadata.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/entity/metadata/ImmutableMetadata.java
@@ -12,8 +12,8 @@
  */
 package org.eclipse.ditto.base.model.entity.metadata;
 
-import static org.eclipse.ditto.json.JsonFactory.newValue;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+import static org.eclipse.ditto.json.JsonFactory.newValue;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -38,7 +39,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * Immutable implementation of {@link org.eclipse.ditto.base.model.entity.metadata.Metadata}.
@@ -212,6 +212,11 @@ final class ImmutableMetadata implements Metadata {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return wrapped.containsFlatteningArrays(key);
+    }
+
+    @Override
     public JsonObject get(final JsonPointer pointer) {
         return wrapped.get(pointer);
     }
@@ -239,6 +244,11 @@ final class ImmutableMetadata implements Metadata {
     @Override
     public Optional<JsonValue> getValue(final CharSequence key) {
         return wrapped.getValue(key);
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
+        return wrapped.getValueFlatteningArrays(key);
     }
 
     @Override

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/entity/metadata/NullMetadata.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/entity/metadata/NullMetadata.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -35,7 +36,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * JSON NULL value version of {@link org.eclipse.ditto.base.model.entity.metadata.Metadata}.
@@ -191,7 +191,17 @@ final class NullMetadata implements Metadata {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return false;
+    }
+
+    @Override
     public Optional<JsonValue> getValue(final CharSequence name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
         return Optional.empty();
     }
 

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObjectNull.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObjectNull.java
@@ -113,6 +113,11 @@ final class ImmutableJsonObjectNull extends AbstractJsonValue implements JsonObj
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return false;
+    }
+
+    @Override
     public ImmutableJsonObjectNull get(final JsonPointer pointer) {
         return this;
     }
@@ -124,6 +129,11 @@ final class ImmutableJsonObjectNull extends AbstractJsonValue implements JsonObj
 
     @Override
     public Optional<JsonValue> getValue(final CharSequence key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
         return Optional.empty();
     }
 

--- a/json/src/main/java/org/eclipse/ditto/json/JsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonObject.java
@@ -221,6 +221,37 @@ public interface JsonObject extends JsonValue, JsonValueContainer<JsonField> {
     boolean contains(CharSequence key);
 
     /**
+     * Indicates whether this JSON object contains a field at the key defined location. When encountering a
+     * {@link JsonArray}, its contents, if those are {@link JsonObject}s themselves, are "flattened", effectively
+     * treating JsonArrays as invisible wrapper for JsonObjects.
+     * If, for example, on the following JSON object
+     * <pre>
+     *    {
+     *       "thingId": "myThing",
+     *       "attributes": {
+     *          "someArr": [
+     *             {
+     *                "subsel": 42
+     *             },
+     *             {
+     *                "subsel": 90
+     *             }
+     *          ],
+     *          "anotherAttr": "baz"
+     *       }
+     *    }
+     * </pre>
+     * <p>
+     * this method with the pointer {@code "attributes/someArr/subsel"} is called, the response would be {@code true}.
+     * </p>
+     * @return {@code true} if this JSON object contains a field at {@code key}
+     * (flattening JsonArrays in the hierarchy), {@code false} else.
+     * @throws NullPointerException if {@code key} is {@code null}.
+     * @since 3.5.0
+     */
+    boolean containsFlatteningArrays(CharSequence key);
+
+    /**
      * Returns a new JSON object containing the whole object hierarchy of the value which is defined by the given
      * pointer. If, for example, on the following JSON object
      * <pre>
@@ -321,8 +352,9 @@ public interface JsonObject extends JsonValue, JsonValueContainer<JsonField> {
      *       }
      *    }
      * </pre>
-     * this method is called with key {@code "attributes/someAttr/subsel"} an empty Optional is returned. Is the key
-     * {@code "thingId"} used instead the returned Optional would contain {@code "myThing"}.
+     * this method is called with key {@code "attributes/someAttr/subsel"}, the JsonValue {@code 42} will be contained
+     * in the returned Optional. If the key {@code "thingId"} used instead the returned Optional would
+     * contain {@code "myThing"}.
      * If the specified key is empty or {@code "/"} this object reference is returned within the result.
      *
      * @param key defines which value to get.
@@ -330,6 +362,35 @@ public interface JsonObject extends JsonValue, JsonValueContainer<JsonField> {
      * @throws NullPointerException if {@code key} is {@code null}.
      */
     Optional<JsonValue> getValue(CharSequence key);
+
+    /**
+     * Returns the value which is associated with the specified key. This method is similar to {@link #get(JsonPointer)}
+     * however it does not maintain any hierarchy but returns simply the value. If, for example, on the following JSON
+     * object
+     * <pre>
+     *    {
+     *       "thingId": "myThing",
+     *       "attributes": {
+     *          "someArr": [
+     *             {
+     *                "subsel": 42
+     *             },
+     *             {
+     *                "subsel": 90
+     *             }
+     *          ],
+     *          "anotherAttr": "baz"
+     *       }
+     *    }
+     * </pre>
+     * this method is called with key {@code "attributes/someArr/subsel"}, the JsonArray with 2 JsonValues {@code 42}
+     * and  {@code 90} will be contained in the returned Optional.
+     *
+     * @param key defines which value to get.
+     * @return the JSON value at the key-defined location within this object, flattening encountered JsonArrays.
+     * @since 3.5.0
+     */
+    Optional<JsonValue> getValueFlatteningArrays(CharSequence key);
 
     /**
      * Returns the plain Java typed value of the field whose location is defined by the JsonPointer of the specified

--- a/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/ThingPredicatePredicateVisitorTest.java
+++ b/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/ThingPredicatePredicateVisitorTest.java
@@ -330,6 +330,45 @@ public final class ThingPredicatePredicateVisitorTest {
                 .isFalse();
     }
 
+    @Test
+    public void matchingIntegerArrayEq() {
+        doTest(sut.visitEq(7),
+                JsonArray.of(JsonValue.of(1), JsonValue.of(3), JsonValue.of(7))
+        ).isTrue();
+    }
+
+    @Test
+    public void matchingStringArrayIn() {
+        doTest(sut.visitIn(Collections.singletonList("this-is-some-content")),
+                JsonArray.of(
+                        JsonValue.of("hello"),
+                        JsonValue.of("world"),
+                        JsonValue.of("this-is-some-content")
+                )
+        ).isTrue();
+    }
+
+    @Test
+    public void matchingStringArrayNe() {
+        doTest(sut.visitNe("orl"),
+                JsonArray.of(
+                        JsonValue.of("hello"),
+                        JsonValue.of("world")
+                )
+        ).isTrue();
+    }
+
+    @Test
+    public void matchingStringArrayILike() {
+        // the sut already works on regex Pattern - the translation from "*" to ".*" followed by case insensitivity is done in LikePredicateImpl
+        doTest(sut.visitILike(".*or.?d"),
+                JsonArray.of(
+                        JsonValue.of("hello"),
+                        JsonValue.of("world")
+                )
+        ).isTrue();
+    }
+
     private static AbstractBooleanAssert<?> doTest(final Function<String, Predicate<Thing>> functionToTest,
             final JsonValue actualValue) {
         return doTest(functionToTest, "attributes/some-attr", actualValue);

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableAttributes.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableAttributes.java
@@ -221,7 +221,7 @@ final class ImmutableAttributes implements Attributes {
 
     @Override
     public boolean containsFlatteningArrays(final CharSequence key) {
-        return wrapped.contains(key);
+        return wrapped.containsFlatteningArrays(key);
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableAttributes.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableAttributes.java
@@ -13,8 +13,8 @@
 package org.eclipse.ditto.things.model;
 
 
-import static org.eclipse.ditto.json.JsonFactory.newValue;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+import static org.eclipse.ditto.json.JsonFactory.newValue;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -40,7 +41,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * An immutable implementation of {@link Attributes}.
@@ -220,6 +220,11 @@ final class ImmutableAttributes implements Attributes {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return wrapped.contains(key);
+    }
+
+    @Override
     public JsonObject get(final JsonPointer pointer) {
         return wrapped.get(pointer);
     }
@@ -247,6 +252,11 @@ final class ImmutableAttributes implements Attributes {
     @Override
     public Optional<JsonValue> getValue(final CharSequence key) {
         return wrapped.getValue(key);
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
+        return wrapped.getValueFlatteningArrays(key);
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureProperties.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureProperties.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -38,7 +39,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * An immutable implementation of {@link FeatureProperties}.
@@ -213,8 +213,18 @@ final class ImmutableFeatureProperties implements FeatureProperties {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return wrapped.contains(key);
+    }
+
+    @Override
     public Optional<JsonValue> getValue(final CharSequence key) {
         return wrapped.getValue(key);
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
+        return wrapped.getValueFlatteningArrays(key);
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureProperties.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureProperties.java
@@ -214,7 +214,7 @@ final class ImmutableFeatureProperties implements FeatureProperties {
 
     @Override
     public boolean containsFlatteningArrays(final CharSequence key) {
-        return wrapped.contains(key);
+        return wrapped.containsFlatteningArrays(key);
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/NullAttributes.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/NullAttributes.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -35,7 +36,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * JSON NULL value version of {@link Attributes}.
@@ -191,7 +191,17 @@ final class NullAttributes implements Attributes {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return false;
+    }
+
+    @Override
     public Optional<JsonValue> getValue(final CharSequence name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
         return Optional.empty();
     }
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/NullFeatureProperties.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/NullFeatureProperties.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -35,7 +36,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 
 /**
  * A null implementation of {@link FeatureProperties}.
@@ -207,6 +207,11 @@ final class NullFeatureProperties implements FeatureProperties {
     }
 
     @Override
+    public boolean containsFlatteningArrays(final CharSequence key) {
+        return false;
+    }
+
+    @Override
     public JsonObject get(final JsonPointer pointer) {
         return this;
     }
@@ -218,6 +223,11 @@ final class NullFeatureProperties implements FeatureProperties {
 
     @Override
     public Optional<JsonValue> getValue(final CharSequence name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
         return Optional.empty();
     }
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/TypedJsonObject.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/TypedJsonObject.java
@@ -104,6 +104,11 @@ interface TypedJsonObject<T extends JsonObject> extends JsonObject {
     }
 
     @Override
+    default boolean containsFlatteningArrays(final CharSequence key) {
+        return getWrappedObject().containsFlatteningArrays(key);
+    }
+
+    @Override
     default JsonObject get(final JsonPointer pointer) {
         return getWrappedObject().get(pointer);
     }
@@ -121,6 +126,11 @@ interface TypedJsonObject<T extends JsonObject> extends JsonObject {
     @Override
     default Optional<JsonValue> getValue(final CharSequence key) {
         return getWrappedObject().getValue(key);
+    }
+
+    @Override
+    default Optional<JsonValue> getValueFlatteningArrays(final CharSequence key) {
+        return getWrappedObject().getValueFlatteningArrays(key);
     }
 
     @Override


### PR DESCRIPTION
* applying the `condition` also on "any" elements of an array of JsonObjects
* providing new `JsonObject` APIs: `containsFlatteningArrays(key)` and `getValueFlatteningArrays`

As this also adds new public methods to `JsonObject` it cannot be a bugfix, but a feature intead :) 