### PR TITLE
Fix enrichment of ThingCreated events with _policy

### DIFF
--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
@@ -219,8 +219,9 @@ public final class DittoCachingSignalEnrichmentFacade implements CachingSignalEn
                 final var nextExpectedThingEventsParameters =
                         new CachingParameters(fieldSelector, thingEvents, invalidateCacheOnPolicyChange,
                                 cachingParameters.minAcceptableSeqNr);
-                result = handleNextExpectedThingEvents(cacheKey, JsonObject.empty(), nextExpectedThingEventsParameters)
-                        .toCompletableFuture();
+                result = doCacheLookup(cacheKey, dittoHeaders).thenCompose(
+                        cachedJsonObject -> handleNextExpectedThingEvents(cacheKey, cachedJsonObject,
+                                nextExpectedThingEventsParameters));
             } else {
                 // there are twin events; perform smart update
                 result = doCacheLookup(cacheKey, dittoHeaders).thenCompose(

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -253,6 +253,8 @@ public final class EnforcementFlowTest {
             sourceProbe.sendNext(inputMap);
             sourceProbe.sendComplete();
 
+            thingsProbe.expectMsgClass(Duration.apply(30, TimeUnit.SECONDS), SudoRetrieveThing.class);
+            thingsProbe.reply(SudoRetrieveThingResponse.of(JsonObject.empty(), DittoHeaders.empty()));
             // WHEN: policy is retrieved with up-to-date revisions
             policiesProbe.expectMsgClass(Duration.apply(30, TimeUnit.SECONDS), SudoRetrievePolicy.class);
             final var policy = Policy.newBuilder(policyId).setRevision(1).build();
@@ -318,6 +320,10 @@ public final class EnforcementFlowTest {
             assertThat(sourceProbe.expectRequest()).isEqualTo(16);
             sourceProbe.sendNext(inputMap);
             sourceProbe.sendComplete();
+
+            // WHEN
+            thingsProbe.expectMsgClass(Duration.apply(30, TimeUnit.SECONDS), SudoRetrieveThing.class);
+            thingsProbe.reply(SudoRetrieveThingResponse.of(JsonObject.empty(), DittoHeaders.empty()));
 
             // THEN: the write model contains up-to-date revisions
             final AbstractWriteModel deleteModel = sinkProbe.expectNext().get(0);


### PR DESCRIPTION
Makes it possible to enrich ThingCreated events with _policy. Since the policy is already created before the thing it makes no sense to be able to enrich with for example revision but not with _policy. Enriching consecutive events after the Thing is created with _policy was possible before this fix.