### PR TITLE
#1869 use cache in order to load imported policies when policies are …

### DIFF
--- a/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/Cache.java
+++ b/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/Cache.java
@@ -77,10 +77,11 @@ public interface Cache<K, V> {
     boolean invalidate(K key);
 
     /**
-     * Invalidates the passed key from the cache if present. TODO TJ adjust docs
+     * Invalidates the passed key from the cache if present and the passed {@code valueCondition} evaluates to
+     * {@code true}.
      *
      * @param key the key to invalidate.
-     * @param valueCondition
+     * @param valueCondition the condition which has to pass in order to invalidate the key from the cache.
      * @return {@code true} if the entry was cached and is now invalidated, {@code false} otherwise.
      */
     boolean invalidateConditionally(K key, Predicate<V> valueCondition);

--- a/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/Cache.java
+++ b/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/Cache.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A general purpose cache for items which are associated with a key.
@@ -74,6 +75,15 @@ public interface Cache<K, V> {
      * @return {@code true} if the entry was cached and is now invalidated, {@code false} otherwise.
      */
     boolean invalidate(K key);
+
+    /**
+     * Invalidates the passed key from the cache if present. TODO TJ adjust docs
+     *
+     * @param key the key to invalidate.
+     * @param valueCondition
+     * @return {@code true} if the entry was cached and is now invalidated, {@code false} otherwise.
+     */
+    boolean invalidateConditionally(K key, Predicate<V> valueCondition);
 
     /**
      * Associates the {@code value} with the {@code key} in this cache.

--- a/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/ProjectedCache.java
+++ b/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/ProjectedCache.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A cache working on an embedded passed {@code cache} with values of type {@code <V>}, representing a projected cache
@@ -66,6 +67,11 @@ final class ProjectedCache<K, U, V> implements Cache<K, U> {
     @Override
     public boolean invalidate(final K key) {
         return cache.invalidate(key);
+    }
+
+    @Override
+    public boolean invalidateConditionally(final K key, final Predicate<U> valueCondition) {
+        return cache.invalidateConditionally(key, value -> valueCondition.test(project.apply(value)));
     }
 
     @Override

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImport.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImport.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.policies.model;
 
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.json.Jsonifiable;
@@ -35,9 +37,9 @@ public interface PolicyImport extends Jsonifiable.WithFieldSelectorAndPredicate<
      * @param importedPolicyId the {@link PolicyId} of the imported policy.
      * @param effectedImports the EffectedImports of the new PolicyImport to create.
      * @return the new {@code PolicyImport}.
-     * @throws NullPointerException if any argument is {@code null}.
+     * @throws NullPointerException if {@code importedPolicyId} is {@code null}.
      */
-    static PolicyImport newInstance(final PolicyId importedPolicyId, final EffectedImports effectedImports) {
+    static PolicyImport newInstance(final PolicyId importedPolicyId, @Nullable final EffectedImports effectedImports) {
         return PoliciesModelFactory.newPolicyImport(importedPolicyId, effectedImports);
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
@@ -27,6 +27,13 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.event.Logging;
+import org.apache.pekko.event.LoggingAdapter;
+import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.stream.SystemMaterializer;
+import org.apache.pekko.stream.javadsl.Source;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -71,13 +78,6 @@ import com.mongodb.reactivestreams.client.FindPublisher;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.event.Logging;
-import org.apache.pekko.event.LoggingAdapter;
-import org.apache.pekko.japi.pf.PFBuilder;
-import org.apache.pekko.stream.SystemMaterializer;
-import org.apache.pekko.stream.javadsl.Source;
 import scala.PartialFunction;
 
 /**
@@ -402,7 +402,7 @@ public final class MongoThingsSearchPersistence implements ThingsSearchPersisten
                         .map(dittoBsonJson::serialize)
                         .map(PolicyTag::fromJson)
                         .collect(Collectors.toSet());
-        return Metadata.of(thingId, thingRevision, thingPolicyTag, referencedPolicies, modified, null);
+        return Metadata.of(thingId, thingRevision, thingPolicyTag, null, referencedPolicies, modified, null);
     }
 
     private static AbstractWriteModel documentToWriteModel(final Document document) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
@@ -99,7 +99,7 @@ public final class EnforcedThingMapper {
                 .orElse(null);
 
         final var metadata =
-                Metadata.of(thingId, thingRevision, thingPolicyTag, allReferencedPolicies,
+                Metadata.of(thingId, thingRevision, thingPolicyTag, null, allReferencedPolicies,
                         Optional.ofNullable(oldMetadata).flatMap(Metadata::getModified).orElse(null),
                         Optional.ofNullable(oldMetadata).map(Metadata::getEvents).orElse(List.of()),
                         Optional.ofNullable(oldMetadata).map(Metadata::getTimers).orElse(List.of()),

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
@@ -24,7 +24,7 @@ import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConst
 import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_REVISION;
 import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_THING;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -82,7 +82,7 @@ public final class EnforcedThingMapper {
         final long thingRevision = thing.getValueOrThrow(Thing.JsonFields.REVISION);
         final var optionalPolicyId = thing.getValue(Thing.JsonFields.POLICY_ID).map(PolicyId::of);
 
-        final HashSet<PolicyTag> allReferencedPolicies = new HashSet<>(referencedPolicies);
+        final Set<PolicyTag> allReferencedPolicies = new LinkedHashSet<>(referencedPolicies);
         final List<PolicyTag> policyTagsOfDeletedButStillImportedPolicies =
                 Optional.ofNullable(oldMetadata).map(Metadata::getAllReferencedPolicyTags).orElseGet(Set::of).stream()
                         .filter(oldReferencedPolicyTag -> policy.getPolicyImports()

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
@@ -95,7 +95,8 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
-     * @param causingPolicyTag TODO TJ doc
+     * @param causingPolicyTag defines the policy which "caused" the update - this might e.g. be an "imported" policy
+     * when it differs to the provided {@code thingPolicy}.
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param timer an optional timer measuring the search updater's consistency lag.
      * @return the new Metadata object.
@@ -118,7 +119,8 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
-     * @param causingPolicyTag TODO TJ doc
+     * @param causingPolicyTag defines the policy which "caused" the update - this might e.g. be an "imported" policy
+     * when it differs to the provided {@code thingPolicy}.
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param timer an optional timer measuring the search updater's consistency lag.
      * @param ackRecipient the ackRecipient.
@@ -144,6 +146,8 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
+     * @param causingPolicyTag defines the policy which "caused" the update - this might e.g. be an "imported" policy
+     * when it differs to the provided {@code thingPolicy}.
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param modified the timestamp of the last change incorporated into the search index, or null if not known.
      * @param events the events included in the metadata causing the search update.
@@ -155,6 +159,7 @@ public final class Metadata {
     public static Metadata of(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyTag thingPolicy,
+            @Nullable final PolicyTag causingPolicyTag,
             final Collection<PolicyTag> allReferencedPolicies,
             @Nullable final Instant modified,
             final List<ThingEvent<?>> events,
@@ -162,7 +167,7 @@ public final class Metadata {
             final Collection<ActorSelection> ackRecipient,
             final Collection<UpdateReason> updateReasons) {
 
-        return new Metadata(thingId, thingRevision, thingPolicy, null/*TODO TJ */, allReferencedPolicies, modified, events, timers,
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified, events, timers,
                 ackRecipient, false, false, updateReasons);
     }
 
@@ -172,7 +177,8 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
-     * @param causingPolicyTag TODO TJ
+     * @param causingPolicyTag defines the policy which "caused" the update - this might e.g. be an "imported" policy
+     * when it differs to the provided {@code thingPolicy}.
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param modified the timestamp of the last change incorporated into the search index, or null if not known.
      * @param timer an optional timer measuring the search updater's consistency lag.
@@ -285,8 +291,8 @@ public final class Metadata {
     }
 
     /**
-     * TODO TJ doc
-     * @return
+     * @return the policy which "caused" the update - this might e.g. be an "imported" policy
+     * when it differs to the provided {@code getThingPolicyTag()}.
      */
     public Optional<PolicyTag> getCausingPolicyTag() {
         return Optional.ofNullable(causingPolicyTag);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
@@ -15,7 +15,7 @@ package org.eclipse.ditto.thingsearch.service.persistence.write.model;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -75,11 +75,11 @@ public final class Metadata {
         this.thingRevision = thingRevision;
         this.thingPolicy = thingPolicy;
         this.causingPolicyTag = causingPolicyTag;
-        final HashSet<PolicyTag> policyTags = new HashSet<>(allReferencedPolicies);
+        final Set<PolicyTag> policyTags = new LinkedHashSet<>(allReferencedPolicies);
         if (thingPolicy != null) {
             policyTags.add(thingPolicy);
         }
-        this.allReferencedPolicies = Set.copyOf(policyTags);
+        this.allReferencedPolicies = Collections.unmodifiableSet(policyTags);
         this.modified = modified;
         this.events = events;
         this.timers = List.copyOf(timers);
@@ -226,6 +226,16 @@ public final class Metadata {
     public Metadata invalidateCaches(final boolean invalidateThing, final boolean invalidatePolicy) {
         return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified, events, timers,
                 ackRecipients, invalidateThing, invalidatePolicy, updateReasons);
+    }
+
+    /**
+     * Create a copy of this metadata with {@code causingPolicyTag} replaced by the argument.
+     *
+     * @return the copy.
+     */
+    public Metadata withCausingPolicyTag(final PolicyTag causingPolicyTag) {
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified,
+                events, timers, ackRecipients, invalidateThing, invalidatePolicy, updateReasons);
     }
 
     /**

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
@@ -24,6 +24,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSelection;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -38,9 +40,6 @@ import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
 import org.eclipse.ditto.thingsearch.api.UpdateReason;
 
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSelection;
-
 /**
  * Data class holding information about a "thingEntities" database record.
  */
@@ -49,6 +48,7 @@ public final class Metadata {
     private final ThingId thingId;
     private final long thingRevision;
     @Nullable private final PolicyTag thingPolicy;
+    @Nullable private final PolicyTag causingPolicyTag;
     private final Set<PolicyTag> allReferencedPolicies;
     @Nullable private final Instant modified;
     private final List<ThingEvent<?>> events;
@@ -61,6 +61,7 @@ public final class Metadata {
     private Metadata(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyTag thingPolicy,
+            @Nullable final PolicyTag causingPolicyTag,
             final Collection<PolicyTag> allReferencedPolicies,
             @Nullable final Instant modified,
             final List<ThingEvent<?>> events,
@@ -73,6 +74,7 @@ public final class Metadata {
         this.thingId = thingId;
         this.thingRevision = thingRevision;
         this.thingPolicy = thingPolicy;
+        this.causingPolicyTag = causingPolicyTag;
         final HashSet<PolicyTag> policyTags = new HashSet<>(allReferencedPolicies);
         if (thingPolicy != null) {
             policyTags.add(thingPolicy);
@@ -93,6 +95,7 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
+     * @param causingPolicyTag TODO TJ doc
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param timer an optional timer measuring the search updater's consistency lag.
      * @return the new Metadata object.
@@ -100,10 +103,11 @@ public final class Metadata {
     public static Metadata of(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyTag thingPolicy,
+            @Nullable final PolicyTag causingPolicyTag,
             final Collection<PolicyTag> allReferencedPolicies,
             @Nullable final StartedTimer timer) {
 
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, null,
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, null,
                 List.of(), null != timer ? List.of(timer) : List.of(), List.of(), false, false,
                 List.of(UpdateReason.UNKNOWN));
     }
@@ -114,6 +118,7 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
+     * @param causingPolicyTag TODO TJ doc
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param timer an optional timer measuring the search updater's consistency lag.
      * @param ackRecipient the ackRecipient.
@@ -122,12 +127,13 @@ public final class Metadata {
     public static Metadata of(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyTag thingPolicy,
+            @Nullable final PolicyTag causingPolicyTag,
             final Collection<PolicyTag> allReferencedPolicies,
             final List<ThingEvent<?>> events,
             @Nullable final StartedTimer timer,
             @Nullable final ActorSelection ackRecipient) {
 
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, null, events,
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, null, events,
                 null != timer ? List.of(timer) : List.of(),
                 null != ackRecipient ? List.of(ackRecipient) : List.of(), false, false, List.of(UpdateReason.UNKNOWN));
     }
@@ -156,7 +162,7 @@ public final class Metadata {
             final Collection<ActorSelection> ackRecipient,
             final Collection<UpdateReason> updateReasons) {
 
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified, events, timers,
+        return new Metadata(thingId, thingRevision, thingPolicy, null/*TODO TJ */, allReferencedPolicies, modified, events, timers,
                 ackRecipient, false, false, updateReasons);
     }
 
@@ -166,6 +172,7 @@ public final class Metadata {
      * @param thingId the Thing ID.
      * @param thingRevision the Thing revision.
      * @param thingPolicy the policy directly referenced by the thing.
+     * @param causingPolicyTag TODO TJ
      * @param allReferencedPolicies the policy directly and indirectly (via policy import) referenced by the thing.
      * @param modified the timestamp of the last change incorporated into the search index, or null if not known.
      * @param timer an optional timer measuring the search updater's consistency lag.
@@ -174,11 +181,12 @@ public final class Metadata {
     public static Metadata of(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyTag thingPolicy,
+            @Nullable final PolicyTag causingPolicyTag,
             final Collection<PolicyTag> allReferencedPolicies,
             @Nullable final Instant modified,
             @Nullable final StartedTimer timer) {
 
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified,
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified,
                 List.of(), null != timer ? List.of(timer) : List.of(), List.of(), false, false,
                 List.of(UpdateReason.UNKNOWN));
     }
@@ -190,7 +198,7 @@ public final class Metadata {
      * @return the Metadata object.
      */
     public static Metadata ofDeleted(final ThingId thingId) {
-        return Metadata.of(thingId, -1, null, Set.of(), null);
+        return Metadata.of(thingId, -1, null, null, Set.of(), null);
     }
 
     /**
@@ -199,7 +207,7 @@ public final class Metadata {
      * @return the exported metadata.
      */
     public Metadata export() {
-        return Metadata.of(thingId, thingRevision, thingPolicy, allReferencedPolicies, null);
+        return Metadata.of(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, null);
     }
 
     /**
@@ -210,7 +218,7 @@ public final class Metadata {
      * @return the copy.
      */
     public Metadata invalidateCaches(final boolean invalidateThing, final boolean invalidatePolicy) {
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified, events, timers,
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified, events, timers,
                 ackRecipients, invalidateThing, invalidatePolicy, updateReasons);
     }
 
@@ -220,9 +228,8 @@ public final class Metadata {
      * @return the copy.
      */
     public Metadata withAckRecipient(final ActorSelection ackRecipient) {
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified, events, timers,
-                List.of(ackRecipient),
-                invalidateThing, invalidatePolicy, updateReasons);
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified,
+                events, timers, List.of(ackRecipient), invalidateThing, invalidatePolicy, updateReasons);
     }
 
     /**
@@ -231,8 +238,8 @@ public final class Metadata {
      * @return the copy.
      */
     public Metadata withUpdateReason(final UpdateReason reason) {
-        return new Metadata(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified, events, timers,
-                ackRecipients, invalidateThing, invalidatePolicy, List.of(reason));
+        return new Metadata(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified,
+                events, timers, ackRecipients, invalidateThing, invalidatePolicy, List.of(reason));
     }
 
     /**
@@ -275,6 +282,14 @@ public final class Metadata {
      */
     public Optional<PolicyTag> getThingPolicyTag() {
         return Optional.ofNullable(thingPolicy);
+    }
+
+    /**
+     * TODO TJ doc
+     * @return
+     */
+    public Optional<PolicyTag> getCausingPolicyTag() {
+        return Optional.ofNullable(causingPolicyTag);
     }
 
     /**
@@ -384,7 +399,8 @@ public final class Metadata {
         final List<UpdateReason> newReasons = Stream.concat(updateReasons.stream(), newMetadata.updateReasons.stream())
                 .toList();
         return new Metadata(newMetadata.thingId, newMetadata.thingRevision, newMetadata.thingPolicy,
-                newMetadata.allReferencedPolicies, newMetadata.modified, newEvents, newTimers, newAckRecipients,
+                newMetadata.causingPolicyTag, newMetadata.allReferencedPolicies, newMetadata.modified, newEvents,
+                newTimers, newAckRecipients,
                 invalidateThing || newMetadata.invalidateThing,
                 invalidatePolicy || newMetadata.invalidatePolicy,
                 newReasons);
@@ -435,6 +451,7 @@ public final class Metadata {
         final Metadata that = (Metadata) o;
         return thingRevision == that.thingRevision &&
                 Objects.equals(thingPolicy, that.thingPolicy) &&
+                Objects.equals(causingPolicyTag, that.causingPolicyTag) &&
                 Objects.equals(thingId, that.thingId) &&
                 Objects.equals(allReferencedPolicies, that.allReferencedPolicies) &&
                 Objects.equals(modified, that.modified) &&
@@ -448,8 +465,8 @@ public final class Metadata {
 
     @Override
     public int hashCode() {
-        return Objects.hash(thingId, thingRevision, thingPolicy, allReferencedPolicies, modified, events, timers,
-                ackRecipients, invalidateThing, invalidatePolicy, updateReasons);
+        return Objects.hash(thingId, thingRevision, thingPolicy, causingPolicyTag, allReferencedPolicies, modified,
+                events, timers, ackRecipients, invalidateThing, invalidatePolicy, updateReasons);
     }
 
     @Override
@@ -458,6 +475,7 @@ public final class Metadata {
                 "thingId=" + thingId +
                 ", thingRevision=" + thingRevision +
                 ", thingPolicy=" + thingPolicy +
+                ", causingPolicyTag=" + causingPolicyTag +
                 ", allReferencedPolicies=" + allReferencedPolicies +
                 ", modified=" + modified +
                 ", events=" + events +

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
@@ -121,7 +121,7 @@ public final class BackgroundSyncStream {
     }
 
     private static Metadata emptyMetadata() {
-        return Metadata.of(EMPTY_THING_ID, 0L, PolicyTag.of(EMPTY_POLICY_ID, 0L), Set.of(), null);
+        return Metadata.of(EMPTY_THING_ID, 0L, PolicyTag.of(EMPTY_POLICY_ID, 0L), null, Set.of(), null);
     }
 
     private Source<Metadata, NotUsed> filterForInconsistency(final Pair<Metadata, Metadata> pair) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -339,13 +340,15 @@ final class EnforcementFlow {
 
                                     // only invalidate causing policy tag once, e.g. when a massively imported policy is changed:
                                     metadata.getCausingPolicyTag()
+                                            .filter(Predicate.not(tag -> policyId.equals(tag.getEntityId())))
                                             .ifPresent(causingPolicyTag -> {
                                                 final boolean invalidated = policyEnforcerCache.invalidateConditionally(
                                                         causingPolicyTag.getEntityId(),
                                                         entry -> entry.exists() &&
                                                                 entry.getRevision() < causingPolicyTag.getRevision()
                                                 );
-                                                log.debug("Causing policy tag was invalidated conditionally: <{}>", invalidated);
+                                                log.debug("Causing policy tag was invalidated conditionally: <{}>",
+                                                        invalidated);
                                             });
 
                                     return readCachedEnforcer(metadata, policyId, iteration + 1)

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -18,12 +18,23 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Scheduler;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.pattern.AskTimeoutException;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Source;
 import org.eclipse.ditto.base.model.exceptions.AskException;
 import org.eclipse.ditto.internal.models.signalenrichment.CachingSignalEnrichmentFacade;
 import org.eclipse.ditto.internal.models.streaming.AbstractEntityIdWithRevision;
@@ -59,17 +70,6 @@ import org.eclipse.ditto.thingsearch.service.updater.actors.SearchUpdateObserver
 import org.eclipse.ditto.thingsearch.service.updater.actors.ThingUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Scheduler;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.japi.pf.PFBuilder;
-import org.apache.pekko.pattern.AskTimeoutException;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Converts Thing changes into write models by retrieving data and applying enforcement via an enforcer cache.
@@ -126,10 +126,14 @@ final class EnforcementFlow {
 
         final PolicyCacheLoader policyCacheLoader =
                 PolicyCacheLoader.getNewInstance(askWithRetryConfig, scheduler, policiesShardRegion);
-        final ResolvedPolicyCacheLoader resolvedPolicyCacheLoader = new ResolvedPolicyCacheLoader(policyCacheLoader);
+        final CompletableFuture<Cache<PolicyId, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture =
+                new CompletableFuture<>();
+        final ResolvedPolicyCacheLoader resolvedPolicyCacheLoader =
+                new ResolvedPolicyCacheLoader(policyCacheLoader, cacheFuture);
         final Cache<PolicyId, Entry<Pair<Policy, Set<PolicyTag>>>> policyEnforcerCache =
                 CacheFactory.createCache(resolvedPolicyCacheLoader, policyCacheConfig,
                         "things-search_enforcementflow_enforcer_cache_policy", policyCacheDispatcher);
+        cacheFuture.complete(policyEnforcerCache);
 
         final var thingCacheConfig = updaterStreamConfig.getThingCacheConfig();
         final var thingCacheDispatcher = actorSystem.dispatchers()
@@ -206,7 +210,7 @@ final class EnforcementFlow {
                             return computeWriteModel(data.metadata(), thing);
                         })
                         .flatMapConcat(writeModel -> mapper.processWriteModel(writeModel, data.lastWriteModel())
-                                .orElse(Source.lazily(() -> {
+                                .orElse(Source.lazySource(() -> {
                                     data.metadata().sendWeakAck(null);
                                     return Source.empty();
                                 })))
@@ -230,7 +234,7 @@ final class EnforcementFlow {
                                     return retrieveThingFromCachingFacade(thingId, metadata, leftRetryAttempts - 1);
                                 } else {
                                     log.warn("No retries left, try to SudoRetrieveThing via cache, therefore giving " +
-                                                    "up for thingId <{}>", thingId);
+                                            "up for thingId <{}>", thingId);
                                     return Source.empty();
                                 }
                             }
@@ -285,7 +289,8 @@ final class EnforcementFlow {
                                 final Throwable fetchErrorCause = entry.getFetchErrorCause().orElse(
                                         new IllegalStateException("No fetch error cause present when it should be")
                                 );
-                                log.warn("Computed - due to fetch error <{}: {}> on policy cache - 'no op' ThingWriteModel " +
+                                log.warn(
+                                        "Computed - due to fetch error <{}: {}> on policy cache - 'no op' ThingWriteModel " +
                                                 "for metadata <{}> and thing <{}>",
                                         fetchErrorCause.getClass().getSimpleName(), fetchErrorCause.getMessage(),
                                         metadata, thing, fetchErrorCause
@@ -294,7 +299,7 @@ final class EnforcementFlow {
                             } else {
                                 // no enforcer; "empty out" thing in search index
                                 log.warn("Computed - due to missing enforcer - 'emptied out' ThingWriteModel for " +
-                                                "metadata <{}> and thing <{}>", metadata, thing);
+                                        "metadata <{}> and thing <{}>", metadata, thing);
                                 return ThingWriteModel.ofEmptiedOut(metadata);
                             }
                         }
@@ -309,7 +314,8 @@ final class EnforcementFlow {
      * @param thing the thing
      * @return source of an enforcer or an empty source.
      */
-    private Source<Entry<Pair<Policy, Set<PolicyTag>>>, NotUsed> getPolicy(final Metadata metadata, final JsonObject thing) {
+    private Source<Entry<Pair<Policy, Set<PolicyTag>>>, NotUsed> getPolicy(final Metadata metadata,
+            final JsonObject thing) {
         try {
             return thing.getValue(Thing.JsonFields.POLICY_ID)
                     .map(PolicyId::of)
@@ -330,6 +336,18 @@ final class EnforcementFlow {
                                 if (shouldReloadCache(optionalEnforcerEntry.orElse(null), metadata, iteration)) {
                                     // invalid entry; invalidate and retry after delay
                                     policyEnforcerCache.invalidate(policyId);
+
+                                    // only invalidate causing policy tag once, e.g. when a massively imported policy is changed:
+                                    metadata.getCausingPolicyTag()
+                                            .ifPresent(causingPolicyTag -> {
+                                                final boolean invalidated = policyEnforcerCache.invalidateConditionally(
+                                                        causingPolicyTag.getEntityId(),
+                                                        entry -> entry.exists() &&
+                                                                entry.getRevision() < causingPolicyTag.getRevision()
+                                                );
+                                                log.debug("Causing policy tag was invalidated conditionally: <{}>", invalidated);
+                                            });
+
                                     return readCachedEnforcer(metadata, policyId, iteration + 1)
                                             .initialDelay(cacheRetryDelay);
                                 } else {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SearchUpdateMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SearchUpdateMapper.java
@@ -14,8 +14,11 @@ package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
-import org.eclipse.ditto.internal.utils.extension.DittoExtensionPoint;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.javadsl.Source;
 import org.eclipse.ditto.internal.utils.extension.DittoExtensionIds;
+import org.eclipse.ditto.internal.utils.extension.DittoExtensionPoint;
 import org.eclipse.ditto.internal.utils.metrics.instruments.timer.StartedTimer;
 import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
@@ -24,10 +27,6 @@ import org.eclipse.ditto.thingsearch.service.updater.actors.MongoWriteModel;
 import org.slf4j.Logger;
 
 import com.typesafe.config.Config;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Search Update Mapper to be loaded by reflection.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -16,7 +16,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -483,12 +483,12 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
                         return referencedPolicyTag;
                     }
                 })
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // Append policy tag in case it wasn't already present in the referenced policy tags.
         final Set<PolicyTag> allReferencedPolicyTags;
         if (!referencedPolicyTags.contains(policyTag)) {
-            allReferencedPolicyTags = new HashSet<>(referencedPolicyTags);
+            allReferencedPolicyTags = new LinkedHashSet<>(referencedPolicyTags);
             allReferencedPolicyTags.add(policyTag);
         } else {
             allReferencedPolicyTags = referencedPolicyTags;

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -444,8 +444,6 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
                     affectedOldPolicyTag);
         }
 
-        // TODO TJ invalidate cache entry??
-
         final var policyTag = policyReferenceTag.getPolicyTag();
         if (affectedOldPolicyTag == null || affectedOldPolicyTag.getRevision() < policyTag.getRevision()) {
             final PolicyTag thingPolicyTag = Optional.ofNullable(affectedOldPolicyTag)

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingsMetadataSource.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingsMetadataSource.java
@@ -18,6 +18,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.pattern.Patterns;
+import org.apache.pekko.stream.SourceRef;
+import org.apache.pekko.stream.javadsl.Source;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.models.streaming.LowerBound;
 import org.eclipse.ditto.internal.models.streaming.StreamedSnapshot;
@@ -31,12 +36,6 @@ import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingConstants;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.pattern.Patterns;
-import org.apache.pekko.stream.SourceRef;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Source of metadata streamed from things-service.
@@ -124,7 +123,8 @@ final class ThingsMetadataSource {
             final Instant modified = snapshot.getValue(Thing.JsonFields.MODIFIED).map(Instant::parse).orElse(null);
             // policy revision is not known from thing snapshot
             final Optional<PolicyTag> policyTag = optionalPolicyId.map(policyId -> PolicyTag.of(policyId, 0L));
-            return Optional.of(Metadata.of(thingId, thingRevision, policyTag.orElse(null), Set.of(), modified, null));
+            return Optional.of(
+                    Metadata.of(thingId, thingRevision, policyTag.orElse(null), null, Set.of(), modified, null));
         } catch (PolicyIdInvalidException e) {
             return Optional.empty();
         }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/read/SudoIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/read/SudoIT.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.pekko.stream.javadsl.Sink;
 import org.eclipse.ditto.base.service.config.limits.LimitsConfig;
 import org.eclipse.ditto.internal.models.streaming.LowerBound;
 import org.eclipse.ditto.json.JsonArray;
@@ -39,8 +40,6 @@ import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import org.apache.pekko.stream.javadsl.Sink;
 
 /**
  * Test sudo methods.
@@ -99,9 +98,9 @@ public final class SudoIT extends AbstractReadPersistenceITBase {
     @Test
     public void sudoStreamMetadata() {
         final Metadata metadata1 =
-                Metadata.of(THING1_ID, 1L, PolicyTag.of(PolicyId.of(THING1_ID), 0L), Set.of(), TIMESTAMP1, null);
+                Metadata.of(THING1_ID, 1L, PolicyTag.of(PolicyId.of(THING1_ID), 0L), null, Set.of(), TIMESTAMP1, null);
         final Metadata metadata2 =
-                Metadata.of(THING2_ID, 2L, PolicyTag.of(PolicyId.of(THING2_ID), 0L), Set.of(), TIMESTAMP2, null);
+                Metadata.of(THING2_ID, 2L, PolicyTag.of(PolicyId.of(THING2_ID), 0L), null, Set.of(), TIMESTAMP2, null);
         assertThat(waitFor(readPersistence.sudoStreamMetadata(LowerBound.emptyEntityId(ThingConstants.ENTITY_TYPE))))
                 .containsExactly(metadata1, metadata2);
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
@@ -18,6 +18,10 @@ import static org.eclipse.ditto.policies.model.PoliciesResourceType.THING;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.codecs.DecoderContext;
@@ -41,11 +45,6 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 
 import com.mongodb.reactivestreams.client.MongoCollection;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
 
 /**
  * Tests incremental update.
@@ -105,7 +104,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing2(); // Thing1 with some fields updated
@@ -140,7 +139,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing1();
@@ -175,7 +174,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing2();
@@ -210,7 +209,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing6(); // identical to Thing1 with property deleted
@@ -247,7 +246,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing4(); // identical to Thing1 with an extra fields with empty object as value
@@ -284,7 +283,7 @@ abstract class BsonDiffVisitorIT {
 
         final Metadata metadata =
                 Metadata.of(ThingId.of("solar.system:pluto"), 23L,
-                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), Set.of(), null, null);
+                        PolicyTag.of(PolicyId.of("solar.system:pluto"), 45L), null, Set.of(), null, null);
 
         final JsonObject prevThing = getThing1();
         final JsonObject nextThing = getThing5(); // Thing1 with string field updated to begin with '$' and end with '.'

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/MetadataTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/MetadataTest.java
@@ -17,14 +17,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.pekko.actor.ActorSelection;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.testkit.TestProbe;
 import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.things.model.ThingId;
 import org.junit.Test;
 
-import org.apache.pekko.actor.ActorSelection;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.testkit.TestProbe;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
@@ -51,15 +51,15 @@ public final class MetadataTest extends AbstractWithActorSystemTest {
 
         final Set<PolicyTag> expectedReferencedPolicyTags = Set.of(policyTag, referencedPolicyTag);
 
-        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, Set.of(referencedPolicyTag), null)
+        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, null, Set.of(referencedPolicyTag), null)
                 .getAllReferencedPolicyTags())
                 .containsExactlyInAnyOrderElementsOf(expectedReferencedPolicyTags);
 
-        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, Set.of(referencedPolicyTag), List.of(), null,
+        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, null, Set.of(referencedPolicyTag), List.of(), null,
                 null).getAllReferencedPolicyTags())
                 .containsExactlyInAnyOrderElementsOf(expectedReferencedPolicyTags);
 
-        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, Set.of(referencedPolicyTag), null, null)
+        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, null, Set.of(referencedPolicyTag), null, null)
                 .getAllReferencedPolicyTags())
                 .containsExactlyInAnyOrderElementsOf(expectedReferencedPolicyTags);
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/MetadataTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/MetadataTest.java
@@ -63,7 +63,7 @@ public final class MetadataTest extends AbstractWithActorSystemTest {
                 .getAllReferencedPolicyTags())
                 .containsExactlyInAnyOrderElementsOf(expectedReferencedPolicyTags);
 
-        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, Set.of(referencedPolicyTag), null, List.of(),
+        assertThat(Metadata.of(ThingId.generateRandom(), 1337L, policyTag, null, Set.of(referencedPolicyTag), null, List.of(),
                         List.of(), List.of(), List.of())
                 .getAllReferencedPolicyTags())
                 .containsExactlyInAnyOrderElementsOf(expectedReferencedPolicyTags);

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/ThingWriteModelIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/ThingWriteModelIT.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.Set;
 
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.bson.BsonDocument;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoLogger;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
@@ -31,9 +33,6 @@ import org.mongodb.scala.bson.BsonNumber;
 
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.reactivestreams.client.MongoCollection;
-
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Tests MongoDB interaction of {@link ThingWriteModel}.
@@ -111,7 +110,7 @@ public final class ThingWriteModelIT extends AbstractThingSearchPersistenceITBas
     }
 
     private static ThingWriteModel getWriteModel(final long sn, final int counterValue) {
-        final Metadata metadata = Metadata.of(ThingId.of("thing:id"), sn, null, Set.of(), null);
+        final Metadata metadata = Metadata.of(ThingId.of("thing:id"), sn, null, null, Set.of(), null);
         final BsonDocument thingDocument = new BsonDocument()
                 .append("_revision", BsonNumber.apply(sn))
                 .append("counter", BsonNumber.apply(counterValue));

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
@@ -20,6 +20,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
@@ -34,12 +39,6 @@ import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
 
 /**
  * Tests {@link BackgroundSyncStream}.
@@ -65,28 +64,28 @@ public final class BackgroundSyncStreamTest {
         final Duration toleranceWindow = Duration.ofHours(1L);
 
         final Source<Metadata, NotUsed> persisted = Source.from(List.of(
-                Metadata.of(ThingId.of("x:0-only-persisted"), 1L, PolicyTag.of(PolicyId.of("x:0"), 0L), Set.of(), null),
-                Metadata.of(ThingId.of("x:2-within-tolerance"), 3L, null, Set.of(), null),
-                Metadata.of(ThingId.of("x:3-revision-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:3"), 0L), Set.of(),
+                Metadata.of(ThingId.of("x:0-only-persisted"), 1L, PolicyTag.of(PolicyId.of("x:0"), 0L), null, Set.of(), null),
+                Metadata.of(ThingId.of("x:2-within-tolerance"), 3L, null, null, Set.of(), null),
+                Metadata.of(ThingId.of("x:3-revision-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:3"), 0L), null, Set.of(),
                         null),
-                Metadata.of(ThingId.of("x:4-policy-id-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:4"), 0L), Set.of(),
+                Metadata.of(ThingId.of("x:4-policy-id-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:4"), 0L), null, Set.of(),
                         null),
-                Metadata.of(ThingId.of("x:5-policy-revision-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:5"), 0L),
+                Metadata.of(ThingId.of("x:5-policy-revision-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:5"), 0L), null,
                         Set.of(), null),
-                Metadata.of(ThingId.of("x:6-all-up-to-date"), 3L, PolicyTag.of(PolicyId.of("x:6"), 0L), Set.of(), null),
-                Metadata.of(ThingId.of("x:7-policy-deleted"), 7L, PolicyTag.of(PolicyId.of("x:7"), 0L), Set.of(), null)
+                Metadata.of(ThingId.of("x:6-all-up-to-date"), 3L, PolicyTag.of(PolicyId.of("x:6"), 0L), null, Set.of(), null),
+                Metadata.of(ThingId.of("x:7-policy-deleted"), 7L, PolicyTag.of(PolicyId.of("x:7"), 0L), null, Set.of(), null)
         ));
 
         final Source<Metadata, NotUsed> indexed = Source.from(List.of(
-                Metadata.of(ThingId.of("x:1-only-indexed"), 1L, null, Set.of(), null),
-                Metadata.of(ThingId.of("x:2-within-tolerance"), 1L, null, Set.of(), Instant.now(), null),
-                Metadata.of(ThingId.of("x:3-revision-mismatch"), 2L, PolicyTag.of(PolicyId.of("x:3"), 1L), Set.of(),
+                Metadata.of(ThingId.of("x:1-only-indexed"), 1L, null, null, Set.of(), null),
+                Metadata.of(ThingId.of("x:2-within-tolerance"), 1L, null, null, Set.of(), Instant.now(), null),
+                Metadata.of(ThingId.of("x:3-revision-mismatch"), 2L, PolicyTag.of(PolicyId.of("x:3"), 1L), null, Set.of(),
                         null),
                 Metadata.of(ThingId.of("x:4-policy-id-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:mismatched"), 0L),
-                        Set.of(), null),
+                        null, Set.of(), null),
                 Metadata.of(ThingId.of("x:5-policy-revision-mismatch"), 3L, PolicyTag.of(PolicyId.of("x:5"), 3L),
-                        Set.of(), null),
-                Metadata.of(ThingId.of("x:6-all-up-to-date"), 5L, PolicyTag.of(PolicyId.of("x:6"), 6L), Set.of(), null)
+                        null, Set.of(), null),
+                Metadata.of(ThingId.of("x:6-all-up-to-date"), 5L, PolicyTag.of(PolicyId.of("x:6"), 6L), null, Set.of(), null)
         ));
 
         new TestKit(actorSystem) {{

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
@@ -20,6 +20,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.TestProbe;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.eclipse.ditto.base.model.common.HttpStatus;
@@ -42,13 +48,6 @@ import com.mongodb.ServerAddress;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.BulkWriteUpsert;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.TestProbe;
-import org.apache.pekko.testkit.javadsl.TestKit;
 
 /**
  * Tests {@link BulkWriteResultAckFlow}.
@@ -202,7 +201,7 @@ public final class BulkWriteResultAckFlowTest {
             final long policyRevision = i * 100L;
             final PolicyTag policyTag = policyId == null ? null : PolicyTag.of(policyId, policyRevision);
             final Metadata metadata =
-                    Metadata.of(thingId, thingRevision, policyTag, Set.of(), List.of(), null,
+                    Metadata.of(thingId, thingRevision, policyTag, null, Set.of(), List.of(), null,
                             actorSystem.actorSelection(probes.get(i).ref().path()));
             final AbstractWriteModel abstractModel;
             if (i % 2 == 0) {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -22,6 +22,17 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.KillSwitches;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.testkit.TestPublisher;
+import org.apache.pekko.stream.testkit.TestSubscriber;
+import org.apache.pekko.stream.testkit.javadsl.TestSink;
+import org.apache.pekko.stream.testkit.javadsl.TestSource;
+import org.apache.pekko.testkit.TestActor;
+import org.apache.pekko.testkit.TestProbe;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonObject;
@@ -57,17 +68,6 @@ import org.junit.runners.MethodSorters;
 
 import com.typesafe.config.ConfigFactory;
 
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.KillSwitches;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.testkit.TestPublisher;
-import org.apache.pekko.stream.testkit.TestSubscriber;
-import org.apache.pekko.stream.testkit.javadsl.TestSink;
-import org.apache.pekko.stream.testkit.javadsl.TestSource;
-import org.apache.pekko.testkit.TestActor;
-import org.apache.pekko.testkit.TestProbe;
-import org.apache.pekko.testkit.javadsl.TestKit;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -105,7 +105,7 @@ public final class EnforcementFlowTest {
             final ThingId thingId = ThingId.of("thing:id");
             final PolicyId policyId = PolicyId.of("policy:id");
             final Metadata metadata =
-                    Metadata.of(thingId, thingRev1, PolicyTag.of(policyId, policyRev1), Set.of(), null);
+                    Metadata.of(thingId, thingRev1, PolicyTag.of(policyId, policyRev1), null, Set.of(), null);
             final Collection<Metadata> input = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -157,7 +157,7 @@ public final class EnforcementFlowTest {
         final long policyRev2 = 98L;
         final ThingId thingId = ThingId.of("thing:id");
         final PolicyId policyId = PolicyId.of("policy:id");
-        final Metadata metadata1 = Metadata.of(thingId, thingRev1, PolicyTag.of(policyId, policyRev1), Set.of(), null);
+        final Metadata metadata1 = Metadata.of(thingId, thingRev1, PolicyTag.of(policyId, policyRev1), null, Set.of(), null);
 
         final TestProbe thingsProbe = TestProbe.apply(system);
         final TestProbe policiesProbe = TestProbe.apply(system);
@@ -233,7 +233,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 5L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 5L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -301,7 +301,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 5L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 5L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -357,7 +357,7 @@ public final class EnforcementFlowTest {
                     AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
             );
 
-            final Metadata metadata = Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null)
+            final Metadata metadata = Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null)
                     .invalidateCaches(true, true);
             final List<Metadata> inputMap = List.of(metadata);
 
@@ -404,7 +404,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 7L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 7L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -449,7 +449,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -493,7 +493,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -561,7 +561,7 @@ public final class EnforcementFlowTest {
             );
 
             final Metadata metadata =
-                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                    Metadata.of(thingId, 6L, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             final List<Metadata> inputMap = List.of(metadata);
 
             final TestProbe thingsProbe = TestProbe.apply(system);
@@ -618,7 +618,7 @@ public final class EnforcementFlowTest {
                 final ThingId thingId = ThingId.of("thing:" + i);
                 final Thing ithThing = thing.toBuilder().setId(thingId).setRevision(i).build();
                 final List<ThingEvent<?>> events = List.of(ThingModified.of(ithThing, i, null, headers, null));
-                return Metadata.of(thingId, i, PolicyTag.of(policyId, 1L), Set.of(), events, null, null);
+                return Metadata.of(thingId, i, PolicyTag.of(policyId, 1L), null, Set.of(), events, null, null);
             }).toList());
 
             final TestProbe thingsProbe = TestProbe.apply(system);

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
@@ -16,6 +16,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.javadsl.Source;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.policies.api.PolicyTag;
@@ -33,9 +35,6 @@ import org.eclipse.ditto.thingsearch.service.updater.actors.ThingUpdater;
 
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import com.typesafe.config.ConfigFactory;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Run parts of the updater stream for unit tests.
@@ -99,7 +98,7 @@ public final class TestSearchUpdaterStream {
     public Source<WriteResultAndErrors, NotUsed> delete(final ThingId thingId, final long revision,
             @Nullable final PolicyId policyId, final long policyRevision) {
         return delete(Metadata.of(thingId, revision, policyId == null ? null : PolicyTag.of(policyId, policyRevision),
-                Set.of(), null));
+                null, Set.of(), null));
     }
 
     /**

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -20,6 +20,24 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.MergeHub;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.scaladsl.BroadcastHub;
+import org.apache.pekko.stream.testkit.TestPublisher;
+import org.apache.pekko.stream.testkit.TestSubscriber;
+import org.apache.pekko.stream.testkit.javadsl.TestSink;
+import org.apache.pekko.stream.testkit.javadsl.TestSource;
+import org.apache.pekko.testkit.TestProbe;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
@@ -29,8 +47,8 @@ import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.internal.utils.pekko.ActorSystemResource;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.ActorSystemResource;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracingInitResource;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -58,24 +76,6 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.UpdateOneModel;
 import com.typesafe.config.ConfigFactory;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Props;
-import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.MergeHub;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.scaladsl.BroadcastHub;
-import org.apache.pekko.stream.testkit.TestPublisher;
-import org.apache.pekko.stream.testkit.TestSubscriber;
-import org.apache.pekko.stream.testkit.javadsl.TestSink;
-import org.apache.pekko.stream.testkit.javadsl.TestSource;
-import org.apache.pekko.testkit.TestProbe;
-import org.apache.pekko.testkit.javadsl.TestKit;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
@@ -169,7 +169,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, null, Set.of(), null));
             assertThat(data.metadata().getTimers()).hasSize(1);
             assertThat(data.metadata().getAckRecipients()).isEmpty();
             assertThat(data.lastWriteModel()).isEqualTo(getThingWriteModel());
@@ -193,7 +193,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, null, Set.of(), null));
             assertThat(data.metadata().getTimers()).hasSize(1);
             assertThat(data.metadata().getAckRecipients()).containsOnly(getSystem().actorSelection(getRef().path()));
             assertThat(data.lastWriteModel()).isEqualTo(getThingWriteModel());
@@ -266,7 +266,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, null, Set.of(), null));
             assertThat(data.metadata().getTimers()).hasSize(1);
             assertThat(data.metadata().getAckRecipients()).isEmpty();
             assertThat(data.lastWriteModel()).isEqualTo(getThingWriteModel());
@@ -281,7 +281,7 @@ public final class ThingUpdaterTest {
 
             // THEN: next update is processed regularly
             final var data2 = inletProbe.expectNext();
-            assertThat(data2.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, Set.of(), null));
+            assertThat(data2.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, null, Set.of(), null));
             assertThat(data2.metadata().getTimers()).hasSize(1);
             assertThat(data2.metadata().getAckRecipients()).isEmpty();
             assertThat(data2.lastWriteModel()).isEqualTo(
@@ -397,7 +397,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, null, Set.of(), null));
             assertThat(data.metadata().getTimers()).hasSize(2);
             assertThat(data.metadata().getEvents()).hasSize(2);
             assertThat(data.lastWriteModel()).isEqualTo(getThingWriteModel());
@@ -429,7 +429,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data1 = inletProbe.expectNext();
-            assertThat(data1.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, Set.of(), null));
+            assertThat(data1.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, null, Set.of(), null));
             underTest.tell(event2, ActorRef.noSender());
 
             // THEN: no second update is sent until the first event is persisted
@@ -439,7 +439,7 @@ public final class ThingUpdaterTest {
             outletProbe.expectRequest();
             outletProbe.sendNext(getOKResult(REVISION + 1));
             final var data2 = inletProbe.expectNext(TEN_SECONDS);
-            assertThat(data2.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, Set.of(), null));
+            assertThat(data2.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 2, null, null, Set.of(), null));
         }};
     }
 
@@ -461,7 +461,7 @@ public final class ThingUpdaterTest {
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
             assertThat(data.metadata().export()).isEqualTo(
-                    Metadata.of(THING_ID, REVISION, null, Set.of(PolicyTag.of(policyId, 1L)), null));
+                    Metadata.of(THING_ID, REVISION, null, null, Set.of(PolicyTag.of(policyId, 1L)), null));
             assertThat(data.metadata().getUpdateReasons()).contains(UpdateReason.POLICY_UPDATE);
             assertThat(data.metadata().getTimers()).isEmpty();
         }};
@@ -480,7 +480,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION, null, null, Set.of(), null));
             assertThat(data.metadata().getTimers()).isEmpty();
             assertThat(data.lastWriteModel()).isEqualTo(getThingWriteModel());
         }};
@@ -491,7 +491,7 @@ public final class ThingUpdaterTest {
         new TestKit(system) {{
             final Props props =
                     ThingUpdater.props(flow, id -> Source.single(getThingWriteModel()), SEARCH_CONFIG, getTestActor());
-            final var expectedMetadata = Metadata.of(THING_ID, REVISION, null, Set.of(), null);
+            final var expectedMetadata = Metadata.of(THING_ID, REVISION, null, null, Set.of(), null);
             final ActorRef underTest = watch(childActorOf(props, ACTOR_NAME));
 
             final var command = SudoUpdateThing.of(THING_ID, UpdateReason.MANUAL_REINDEXING, DittoHeaders.newBuilder()
@@ -527,7 +527,7 @@ public final class ThingUpdaterTest {
             inletProbe.ensureSubscription();
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
-            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, Set.of(), null));
+            assertThat(data.metadata().export()).isEqualTo(Metadata.of(THING_ID, REVISION + 1, null, null, Set.of(), null));
             assertThat(data.metadata().getUpdateReasons()).contains(UpdateReason.THING_UPDATE);
             assertThat(data.metadata().getEvents()).hasOnlyElementsOfType(ThingDeleted.class);
             assertThat(data.metadata().getTimers()).hasSize(1);
@@ -622,7 +622,7 @@ public final class ThingUpdaterTest {
             );
 
             final Props props =
-                    ThingUpdater.props(flow, id -> Source.single(ThingDeleteModel.of(Metadata.of(THING_ID, -1, null,
+                    ThingUpdater.props(flow, id -> Source.single(ThingDeleteModel.of(Metadata.of(THING_ID, -1, null, null,
                                     Set.of(), null))), SEARCH_CONFIG,
                             TestProbe.apply(system).ref());
             final ActorRef underTest = watch(childActorOf(props, ACTOR_NAME));
@@ -657,7 +657,7 @@ public final class ThingUpdaterTest {
                 .append("f", new BsonArray())
                 .append("t", new BsonDocument().append("attributes",
                         new BsonDocument().append("x", BsonInt32.apply(5))));
-        return ThingWriteModel.of(Metadata.of(THING_ID, revision, null, Set.of(), null), document);
+        return ThingWriteModel.of(Metadata.of(THING_ID, revision, null, null, Set.of(), null), document);
     }
 
     private static String getActorName(final String name) {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -461,7 +461,7 @@ public final class ThingUpdaterTest {
             inletProbe.request(16);
             final var data = inletProbe.expectNext();
             assertThat(data.metadata().export()).isEqualTo(
-                    Metadata.of(THING_ID, REVISION, null, null, Set.of(PolicyTag.of(policyId, 1L)), null));
+                    Metadata.of(THING_ID, REVISION, null, policyTag.getPolicyTag(), Set.of(PolicyTag.of(policyId, 1L)), null));
             assertThat(data.metadata().getUpdateReasons()).contains(UpdateReason.POLICY_UPDATE);
             assertThat(data.metadata().getTimers()).isEmpty();
         }};


### PR DESCRIPTION
…loaded after invalidation in search

This fixes an issue we encountered when using policy imports, when importing from a single policy a lot (thousands of policies importing from that one) and changing this policy, no cache was used and it was tried to load the imported policy thousands times. 

* cache is used in ResolvedPolicyCacheLoader
* it is now added that an invalidation caused by a policy contains the "causingPolicyTag" - which is then also invalidated
* however, the "causingPolicyTag" is only invalidated once (per search cluster node) to not overwhelm the cluster again due to too many invalidations