### PR TITLE
#1882 fixed ResolvedPolicyCacheLoader loading policy imports transitively

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/PolicyIdResolvingImports.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/PolicyIdResolvingImports.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+
+/**
+ * Package private cache key for loading policies via {@link ResolvedPolicyCacheLoader} into a policy cache.
+ */
+record PolicyIdResolvingImports(PolicyId policyId, boolean resolveImports) {}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
 import org.apache.pekko.japi.Pair;
@@ -29,59 +30,70 @@ import org.eclipse.ditto.policies.model.PolicyRevision;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 
-final class ResolvedPolicyCacheLoader implements AsyncCacheLoader<PolicyId, Entry<Pair<Policy, Set<PolicyTag>>>> {
+final class ResolvedPolicyCacheLoader
+        implements AsyncCacheLoader<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> {
 
     private final PolicyCacheLoader policyCacheLoader;
-    private final CompletableFuture<Cache<PolicyId, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture;
+    private final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture;
 
     ResolvedPolicyCacheLoader(final PolicyCacheLoader policyCacheLoader,
-            final CompletableFuture<Cache<PolicyId, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture) {
+            final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture) {
         this.policyCacheLoader = policyCacheLoader;
         this.cacheFuture = cacheFuture;
     }
 
     @Override
-    public CompletableFuture<? extends Entry<Pair<Policy, Set<PolicyTag>>>> asyncLoad(final PolicyId policyId,
+    public CompletableFuture<? extends Entry<Pair<Policy, Set<PolicyTag>>>> asyncLoad(
+            final PolicyIdResolvingImports policyIdResolvingImports,
             final Executor executor) {
 
-        return policyCacheLoader.asyncLoad(policyId, executor)
+        return policyCacheLoader.asyncLoad(policyIdResolvingImports.policyId(), executor)
                 .thenCompose(policyEntry -> {
                     if (policyEntry.exists()) {
                         final Policy policy = policyEntry.getValueOrThrow();
+                        final long revision = policy.getRevision().map(PolicyRevision::toLong)
+                                .orElseThrow(
+                                        () -> new IllegalStateException("Bad SudoRetrievePolicyResponse: no revision"));
                         final Set<PolicyTag> referencedPolicies = new HashSet<>();
-                        return policy.withResolvedImports(
-                                        importedPolicyId -> cacheFuture
-                                                .thenCompose(cache -> cache.get(importedPolicyId))
-                                                .thenApply(entry -> entry.flatMap(Entry::get))
-                                                .thenApply(optionalReferencedPolicy -> {
-                                                    if (optionalReferencedPolicy.isPresent()) {
-                                                        final Policy referencedPolicy =
-                                                                optionalReferencedPolicy.get().first();
-                                                        final Optional<PolicyRevision> revision =
-                                                                referencedPolicy.getRevision();
-                                                        final Optional<PolicyId> entityId =
-                                                                referencedPolicy.getEntityId();
-                                                        if (revision.isPresent() && entityId.isPresent()) {
-                                                            referencedPolicies.add(
-                                                                    PolicyTag.of(entityId.get(),
-                                                                            revision.get().toLong())
-                                                            );
-                                                        }
-                                                    }
-                                                    return optionalReferencedPolicy.map(Pair::first);
-                                                }))
-                                .thenApply(resolvedPolicy -> {
-                                    final long revision = policy.getRevision().map(PolicyRevision::toLong)
-                                            .orElseThrow(
-                                                    () -> new IllegalStateException(
-                                                            "Bad SudoRetrievePolicyResponse: no revision"));
-                                    return Entry.of(revision, new Pair<>(resolvedPolicy, referencedPolicies));
-                                });
 
+                        if (policyIdResolvingImports.resolveImports()) {
+                            return cacheFuture.thenCompose(cache ->
+                                            resolvePolicyImports(cache, policy, referencedPolicies)
+                                    )
+                                    .thenApply(resolvedPolicy ->
+                                            Entry.of(revision, new Pair<>(resolvedPolicy, referencedPolicies))
+                                    );
+                        } else {
+                            return CompletableFuture.completedFuture(
+                                    Entry.of(revision, new Pair<>(policy, referencedPolicies))
+                            );
+                        }
                     } else {
                         return CompletableFuture.completedFuture(Entry.nonexistent());
                     }
                 });
+    }
+
+    private static CompletionStage<Policy> resolvePolicyImports(
+            final Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> cache,
+            final Policy policy,
+            final Set<PolicyTag> referencedPolicies) {
+
+        return policy.withResolvedImports(importedPolicyId ->
+                cache.get(new PolicyIdResolvingImports(importedPolicyId, false)) // don't transitively resolve imports, only 1 "level"
+                        .thenApply(entry -> entry.flatMap(Entry::get))
+                        .thenApply(optionalReferencedPolicy -> {
+                            if (optionalReferencedPolicy.isPresent()) {
+                                final Policy referencedPolicy = optionalReferencedPolicy.get().first();
+                                final Optional<PolicyRevision> refRevision = referencedPolicy.getRevision();
+                                final Optional<PolicyId> entityId = referencedPolicy.getEntityId();
+                                if (refRevision.isPresent() && entityId.isPresent()) {
+                                    referencedPolicies.add(PolicyTag.of(entityId.get(), refRevision.get().toLong()));
+                                }
+                            }
+                            return optionalReferencedPolicy.map(Pair::first);
+                        })
+        );
     }
 
 }


### PR DESCRIPTION
* cause was that by recursively using the cache, also policy imports were resolved transitively
* that could e.g. lead to a "PolicyLabelInvalidException" for scenarios with very nested policy import paths
* in either case, it was breaking the not available transitiveness of policy imports

Fixes: #1882