### PR TITLE
Helm: fix hook scripts uses release name instead of fullname

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.2  # chart version is effectively set by release-job
+version: 3.5.3  # chart version is effectively set by release-job
 appVersion: 3.5.1
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/hooks/scripts-configmap.yaml
+++ b/deployment/helm/ditto/templates/hooks/scripts-configmap.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $releaseName }}-hook-scripts
+  name: {{ include "ditto.fullname" . }}-hook-scripts
   labels:
     app.kubernetes.io/name: {{ $name }}-hook-scripts
   annotations:


### PR DESCRIPTION
I found another small issue with the latest Helm Chart. The hook-scripts config map used the release name instead of the fullname.