### PR TITLE
fix wrongly done invalidation of non-existing cached policy entry in search

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -342,7 +342,7 @@ final class EnforcementFlow {
                                             .ifPresent(causingPolicyTag -> {
                                                 final boolean invalidated = policyEnforcerCache.invalidateConditionally(
                                                         new PolicyIdResolvingImports(causingPolicyTag.getEntityId(), false),
-                                                        entry -> entry.exists() &&
+                                                        entry -> !entry.exists() ||
                                                                 entry.getRevision() < causingPolicyTag.getRevision()
                                                 );
                                                 log.debug("Causing policy tag was invalidated conditionally: <{}>",


### PR DESCRIPTION
* that could cause that e.g. a deleted imported policy which is re-added did not cause a reindexing of affected things