### PR TITLE
UI small fixes and improvements

### DIFF
--- a/ui/modules/api.ts
+++ b/ui/modules/api.ts
@@ -370,7 +370,7 @@ export async function callDittoREST(method,
       throw new Error('An error occurred: ' + response.status);
     }
   }
-  if (response.status !== 204) {
+  if (response.status !== 204 && response.status !== 202) {
     if (returnHeaders) {
       return response;
     } else {

--- a/ui/modules/connections/connections.html
+++ b/ui/modules/connections/connections.html
@@ -168,10 +168,11 @@
             </div>
             <table-filter id="tableFilterConnectionLogs"></table-filter>
             <div class="table-wrap">
-                <table class="table table-striped table-hover table-sm">
+                <table class="table table-striped table-hover table-sm" style="table-layout: fixed;">
                     <thead>
                         <tr>
                             <th>Timestamp</th>
+                            <th>Category</th>
                             <th>Type</th>
                             <th>Level</th>
                         </tr>

--- a/ui/modules/connections/connectionsCRUD.ts
+++ b/ui/modules/connections/connectionsCRUD.ts
@@ -96,8 +96,6 @@ function onConnectionEditorInput() {
 
 function onConnectionEditorChangeAnnotation() {
   hasErrors = connectionEditor.getSession().getAnnotations().filter((a) => a.type === 'error').length > 0;
-  incomingEditor.setReadOnly(hasErrors);
-  outgoingEditor.setReadOnly(hasErrors);
 }
 
 function onUpdateConnectionClick() {

--- a/ui/modules/connections/connectionsMonitor.ts
+++ b/ui/modules/connections/connectionsMonitor.ts
@@ -65,6 +65,7 @@ export async function ready() {
   Utils.getAllElementsById(dom);
 
   connectionLogDetail = Utils.createAceEditor('connectionLogDetail', 'ace/mode/json', true);
+  connectionLogDetail.session.setUseWrapMode(true);
   connectionStatusDetail = Utils.createAceEditor('connectionStatusDetail', 'ace/mode/json', true);
 
   // Status --------------
@@ -162,6 +163,7 @@ function fillConnectionLogsTable() {
     Utils.addTableRow(
         dom.tbodyConnectionLogs,
         Utils.formatDate(entry.timestamp, true), false, null,
+        entry.category,
         entry.type,
         entry.level
     );

--- a/ui/modules/things/messagesIncoming.ts
+++ b/ui/modules/things/messagesIncoming.ts
@@ -125,7 +125,7 @@ function onSelectThingUpdateMessageContentSelect() {
 function onMessage(messageData) {
   messages.push(messageData);
   
-  const filteredMessage = dom.tableFilterMessagesIncoming.filterItems([messageData]);
+  const filteredMessage = dom.tableFilterMessagesIncoming.filterItems(messages);
   
   if (filteredMessage.length > 0) {
     filteredMessages.push(filteredMessage[0]);


### PR DESCRIPTION
Hi @thjaeckle,

please find some small updates on the UI:
    - send message with timeout 0 and no payload showed incorrect error in the response field. Reason was that on 202 `response.json()` was called that throwed an error. I added now 202 as "no content" case.
    - added category column on connection logs, so you can distinguish source and target log entries
    - connections js editors had wrong read-only behavior
    - connection log details ace editor now with word wrap, otherwise it is hard to read long message in one line. Btw.: is there a way to avoid that ditto transfers all HTTP headers into the ditto headers? The messages by default look polluted and with a lot of overhead in size.
    - Bug: filter on incoming messages does not work on new incoming messages