### PR TITLE
fix that "Incoming Thing Updates" always repeated the first entry

### DIFF
--- a/ui/modules/things/messagesIncoming.ts
+++ b/ui/modules/things/messagesIncoming.ts
@@ -125,14 +125,14 @@ function onSelectThingUpdateMessageContentSelect() {
 function onMessage(messageData) {
   messages.push(messageData);
   
-  const filteredMessage = dom.tableFilterMessagesIncoming.filterItems(messages);
+  const filteredMessage = dom.tableFilterMessagesIncoming.filterItems([messageData]);
   
   if (filteredMessage.length > 0) {
     filteredMessages.push(filteredMessage[0]);
     addTableRow(filteredMessage[0]);
   }
   
-  Utils.updateCounterBadge(dom.badgeMessageIncomingCount, messages, filteredMessage);
+  Utils.updateCounterBadge(dom.badgeMessageIncomingCount, messages, filteredMessages);
 }
 
 function addTableRow(messageData: any) {


### PR DESCRIPTION
* new entries to the table were not added correctly, but always only the first received entry was added again

@thfries I encountered that the "Incoming Thing Updates" table is broken - it only adds the first element of the `filteredMessage` array over and over again - and not the "latest one"

See e.g. screenshot: 
![image](https://github.com/eclipse-ditto/ditto/assets/1331526/c13f9955-1258-4df7-8a8b-d843b8cb952b)

Could you review this small fix?