### PR TITLE
Added option to add custom annotations to podDeletionCostPatching jobs.

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.4-0  # chart version is effectively set by release-job
+version: 3.5.5-0  # chart version is effectively set by release-job
 appVersion: 3.5.2
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/hooks/pod-deletion-cost-cron-job.yaml
+++ b/deployment/helm/ditto/templates/hooks/pod-deletion-cost-cron-job.yaml
@@ -30,6 +30,10 @@ spec:
             app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
             app.kubernetes.io/instance: {{ .Release.Name | quote }}
             helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+          {{- with .Values.global.podDeletionCostPatching.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         spec:
           {{- if .Values.rbac.enabled }}
           serviceAccountName: {{ template "ditto.serviceAccountName" . }}

--- a/deployment/helm/ditto/templates/hooks/pre-upgrade-job.yaml
+++ b/deployment/helm/ditto/templates/hooks/pre-upgrade-job.yaml
@@ -31,6 +31,10 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      {{- with .Values.global.podDeletionCostPatching.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -172,6 +172,9 @@ global:
   podDeletionCostPatching:
     # enabled whether the pod-deletion-cost annotation patching should be enabled
     enabled: true
+    # annotations defines k8s annotations to add to corresponding jobs
+    annotations: {}
+
 
 ## ----------------------------------------------------------------------------
 ## dbconfig for mongodb connections


### PR DESCRIPTION
Hi. I would like to add capability for adding custom annotation to new pod deleting hook jobs in Ditto Helm chart. Main use case is to be able to adjust configuration (e.g. disabling or configuring of Istio sidecars) to make job working properly in special setups.
Thank you.