### PR TITLE
fix weak eTag handling of If-Match and If-None-Match headers

### DIFF
--- a/internal/utils/conditional-headers/src/main/java/org/eclipse/ditto/internal/utils/headers/conditional/IfMatchPreconditionHeader.java
+++ b/internal/utils/conditional-headers/src/main/java/org/eclipse/ditto/internal/utils/headers/conditional/IfMatchPreconditionHeader.java
@@ -59,7 +59,13 @@ public final class IfMatchPreconditionHeader implements PreconditionHeader<Entit
             return false;
         }
 
-        return entityTagsToMatch.stream().anyMatch(entityTagToMatch -> entityTagToMatch.strongMatch(entityTag));
+        return entityTagsToMatch.stream().anyMatch(entityTagToMatch -> {
+            if (entityTag.isWeak()) {
+                return entityTagToMatch.weakMatch(entityTag);
+            } else {
+                return entityTagToMatch.strongMatch(entityTag);
+            }
+        });
     }
 
     /**

--- a/internal/utils/conditional-headers/src/main/java/org/eclipse/ditto/internal/utils/headers/conditional/IfNoneMatchPreconditionHeader.java
+++ b/internal/utils/conditional-headers/src/main/java/org/eclipse/ditto/internal/utils/headers/conditional/IfNoneMatchPreconditionHeader.java
@@ -56,7 +56,13 @@ public final class IfNoneMatchPreconditionHeader implements PreconditionHeader<E
             return true;
         }
 
-        return entityTagsToMatch.stream().noneMatch(entityTagToMatch -> entityTagToMatch.weakMatch(entityTag));
+        return entityTagsToMatch.stream().noneMatch(entityTagToMatch -> {
+            if (entityTag.isWeak()) {
+                return entityTagToMatch.weakMatch(entityTag);
+            } else {
+                return entityTagToMatch.strongMatch(entityTag);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
* they were not supporting both variants, but "If-Match" header assumed strong etags and "If-None-Match" assumed weak etags