### PR TITLE
#1931: fix that not all placeholders were supported in connection target filtering

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
@@ -26,13 +26,14 @@ import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.event.LoggingAdapter;
 import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
 import org.eclipse.ditto.base.model.acks.AcknowledgementLabelInvalidException;
 import org.eclipse.ditto.base.model.acks.AcknowledgementLabelNotUniqueException;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.connectivity.service.placeholders.ConnectivityPlaceholders;
 import org.eclipse.ditto.connectivity.model.ClientCertificateCredentials;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.ConnectionConfigurationInvalidException;
@@ -52,6 +53,10 @@ import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.config.mapping.MapperLimitsConfig;
 import org.eclipse.ditto.connectivity.service.messaging.internal.ssl.SSLContextCreator;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
+import org.eclipse.ditto.connectivity.service.placeholders.ConnectivityPlaceholders;
+import org.eclipse.ditto.edge.service.placeholders.EntityIdPlaceholder;
+import org.eclipse.ditto.edge.service.placeholders.FeaturePlaceholder;
+import org.eclipse.ditto.edge.service.placeholders.ThingPlaceholder;
 import org.eclipse.ditto.placeholders.ExpressionResolver;
 import org.eclipse.ditto.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.placeholders.TimePlaceholder;
@@ -59,9 +64,6 @@ import org.eclipse.ditto.protocol.placeholders.ResourcePlaceholder;
 import org.eclipse.ditto.protocol.placeholders.TopicPathPlaceholder;
 import org.eclipse.ditto.rql.parser.RqlPredicateParser;
 import org.eclipse.ditto.rql.query.filter.QueryFilterCriteriaFactory;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.event.LoggingAdapter;
 
 /**
  * Validate a connection according to its type.
@@ -83,7 +85,8 @@ public final class ConnectionValidator {
                 .collect(Collectors.toMap(AbstractProtocolValidator::type, Function.identity()));
         this.specMap = Collections.unmodifiableMap(theSpecMap);
         queryFilterCriteriaFactory = QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance(),
-                TopicPathPlaceholder.getInstance(), ResourcePlaceholder.getInstance(), TimePlaceholder.getInstance());
+                TopicPathPlaceholder.getInstance(), ResourcePlaceholder.getInstance(), TimePlaceholder.getInstance(),
+                EntityIdPlaceholder.getInstance(), ThingPlaceholder.getInstance(), FeaturePlaceholder.getInstance());
     }
 
     /**

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
@@ -142,6 +142,7 @@ import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThing;
 import org.eclipse.ditto.things.model.signals.events.FeatureDesiredPropertiesModified;
+import org.eclipse.ditto.things.model.signals.events.FeaturePropertiesModified;
 import org.eclipse.ditto.things.model.signals.events.ThingModified;
 import org.eclipse.ditto.things.model.signals.events.ThingModifiedEvent;
 import org.mockito.Mockito;
@@ -331,6 +332,8 @@ public final class TestConstants {
     public static final class Feature {
 
         public static final String FEATURE_ID = "Feature";
+        public static final FeatureProperties FEATURE_PROPERTIES = FeatureProperties.newBuilder()
+                .set("property", "test").build();
         public static final FeatureProperties FEATURE_DESIRED_PROPERTIES = FeatureProperties.newBuilder()
                 .set("property", "test").build();
 
@@ -996,8 +999,14 @@ public final class TestConstants {
                 TestConstants.INSTANT, dittoHeaders, TestConstants.METADATA);
     }
 
+    public static ThingModifiedEvent<?> featurePropertiesModified(Collection<AuthorizationSubject> readSubjects) {
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().readGrantedSubjects(readSubjects).build();
+        return FeaturePropertiesModified.of(Things.THING_ID, Feature.FEATURE_ID,
+                Feature.FEATURE_PROPERTIES, 1, null, dittoHeaders, null);
+    }
+
     public static ThingModifiedEvent<?> featureDesiredPropertiesModified(Collection<AuthorizationSubject> readSubjects) {
-        DittoHeaders dittoHeaders = DittoHeaders.newBuilder().readGrantedSubjects(readSubjects).build();
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().readGrantedSubjects(readSubjects).build();
         return FeatureDesiredPropertiesModified.of(Things.THING_ID, Feature.FEATURE_ID,
                 Feature.FEATURE_DESIRED_PROPERTIES, 1, null, dittoHeaders, null);
     }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/SignalFilterWithFilterTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/SignalFilterWithFilterTest.java
@@ -313,16 +313,36 @@ public final class SignalFilterWithFilterTest {
      */
     @Test
     public void applySignalFilterOnFeatureDesiredPropertiesModified() {
-        Target target = ConnectivityModelFactory.newTargetBuilder().address("address")
+        final Target target = ConnectivityModelFactory.newTargetBuilder().address("address")
                 .authorizationContext(newAuthContext(DittoAuthorizationContextType.UNSPECIFIED, AUTHORIZED))
                 .topics(ConnectivityModelFactory.newFilteredTopicBuilder(TWIN_EVENTS)
                         .withFilter("like(resource:path,'/features/" + TestConstants.Feature.FEATURE_ID + "*')")
                         .build()).build();
-        Connection connection = TestConstants.createConnection(CONNECTION_ID, target);
-        SignalFilter signalFilter = new SignalFilter(connection, connectionMonitorRegistry);
-        Signal<?> signal = TestConstants.featureDesiredPropertiesModified(Collections.singletonList(AUTHORIZED));
+        final Connection connection = TestConstants.createConnection(CONNECTION_ID, target);
+        final SignalFilter signalFilter = new SignalFilter(connection, connectionMonitorRegistry);
+        final Signal<?> signal = TestConstants.featureDesiredPropertiesModified(Collections.singletonList(AUTHORIZED));
 
-        List<Target> filteredTargets = signalFilter.filter(signal);
+        final List<Target> filteredTargets = signalFilter.filter(signal);
+        Assertions.assertThat(filteredTargets).hasSize(1).contains(target);
+    }
+
+    /**
+     * Test that target filtering works using feature:id placeholder
+     */
+    @Test
+    public void applySignalFilterWithFeatureIdPlaceholder() {
+        Target target = ConnectivityModelFactory.newTargetBuilder().address("address")
+                .authorizationContext(newAuthContext(DittoAuthorizationContextType.UNSPECIFIED, AUTHORIZED))
+                .topics(ConnectivityModelFactory.newFilteredTopicBuilder(TWIN_EVENTS)
+                        .withFilter("eq(feature:id,'Feature')")
+                        .build()
+                )
+                .build();
+        final Connection connection = TestConstants.createConnection(CONNECTION_ID, target);
+        final SignalFilter signalFilter = new SignalFilter(connection, connectionMonitorRegistry);
+        final Signal<?> signal = TestConstants.featurePropertiesModified(Collections.singletonList(AUTHORIZED));
+
+        final List<Target> filteredTargets = signalFilter.filter(signal);
         Assertions.assertThat(filteredTargets).hasSize(1).contains(target);
     }
 }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/StreamingSessionActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/StreamingSessionActor.java
@@ -70,6 +70,8 @@ import org.eclipse.ditto.edge.service.acknowledgements.things.ThingCommandRespon
 import org.eclipse.ditto.edge.service.acknowledgements.things.ThingLiveCommandAckRequestSetter;
 import org.eclipse.ditto.edge.service.acknowledgements.things.ThingModifyCommandAckRequestSetter;
 import org.eclipse.ditto.edge.service.placeholders.EntityIdPlaceholder;
+import org.eclipse.ditto.edge.service.placeholders.FeaturePlaceholder;
+import org.eclipse.ditto.edge.service.placeholders.ThingPlaceholder;
 import org.eclipse.ditto.edge.service.streaming.StreamingSubscriptionManager;
 import org.eclipse.ditto.gateway.api.GatewayInternalErrorException;
 import org.eclipse.ditto.gateway.api.GatewayWebsocketSessionAbortedException;
@@ -93,6 +95,7 @@ import org.eclipse.ditto.internal.utils.pubsubthings.DittoProtocolSub;
 import org.eclipse.ditto.internal.utils.search.SubscriptionManager;
 import org.eclipse.ditto.jwt.model.ImmutableJsonWebToken;
 import org.eclipse.ditto.messages.model.signals.commands.MessageCommand;
+import org.eclipse.ditto.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.placeholders.TimePlaceholder;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.protocol.placeholders.ResourcePlaceholder;
@@ -799,8 +802,11 @@ final class StreamingSessionActor extends AbstractActorWithTimers {
                 RqlPredicateParser.getInstance(),
                 TopicPathPlaceholder.getInstance(),
                 EntityIdPlaceholder.getInstance(),
+                ThingPlaceholder.getInstance(),
+                FeaturePlaceholder.getInstance(),
                 ResourcePlaceholder.getInstance(),
-                TimePlaceholder.getInstance()
+                TimePlaceholder.getInstance(),
+                PlaceholderFactory.newHeadersPlaceholder()
         );
 
         return queryFilterCriteriaFactory.filterCriteria(filter, dittoHeaders);


### PR DESCRIPTION
Added support for placeholders in Connection "targets":
* `feature:id`
* `entity:id`
* `entity:namespace`
* `entity:name`
* `thing:id`
* `thing:namespace`
* `thing:name`

Resolves: #1931