### PR TITLE
#1946 fix that alternative OIDC provider for "devops" authorization could not be configured

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.7-0  # chart version is effectively set by release-job
+version: 3.5.9-0  # chart version is effectively set by release-job
 appVersion: 3.5.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.6  # chart version is effectively set by release-job
+version: 3.5.7-0  # chart version is effectively set by release-job
 appVersion: 3.5.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -149,6 +149,12 @@ spec:
                 "{{ printf "%s%s%s%d=%s" "-Dditto.gateway.authentication.devops.oauth.openid-connect-issuers." $key ".auth-subjects." $index $subject }}"
                 {{- end }}
                 {{- end }}
+                {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.oauthSubjects }}
+                "{{ printf "%s%d=%s" "-Dditto.gateway.authentication.devops.devops-oauth2-subjects." $index $oauthSubject }}"
+                {{- end }}
+                {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.statusOauthSubjects }}
+                "{{ printf "%s%d=%s" "-Dditto.gateway.authentication.devops.status-oauth2-subjects." $index $oauthSubject }}"
+                {{- end }}
                 {{ join " " .Values.gateway.systemProps }}
             - name: CLUSTER_BS_REQUIRED_CONTACTS
               value: "{{ .Values.global.cluster.requiredContactPoints }}"
@@ -191,10 +197,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.gateway.config.authentication.devops.existingSecret | default ( printf "%s-gateway-secret" ( include "ditto.fullname" . )) }}
                   key: devops-password
-            {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.oauthSubjects }}
-            - name: DEVOPS_OAUTH2_SUBJECTS.{{ $index }}
-              value: "{{ $oauthSubject }}"
-            {{- end }}
             - name: DEVOPS_STATUS_SECURED
               value: "{{ .Values.gateway.config.authentication.devops.statusSecured }}"
             - name: STATUS_AUTHENTICATION_METHOD
@@ -204,10 +206,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.gateway.config.authentication.devops.existingSecret | default ( printf "%s-gateway-secret" ( include "ditto.fullname" . )) }}
                   key: status-password
-            {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.statusOauthSubjects }}
-            - name: STATUS_OAUTH2_SUBJECTS.{{ $index }}
-              value: "{{ $oauthSubject }}"
-            {{- end }}
             - name: WS_SUBSCRIBER_BACKPRESSURE
               value: "{{ .Values.gateway.config.websocket.subscriber.backpressureQueueSize }}"
             - name: WS_PUBLISHER_BACKPRESSURE

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevOpsBasicAuthenticationDirective.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevOpsBasicAuthenticationDirective.java
@@ -20,20 +20,21 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.pekko.http.javadsl.server.Directives;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.http.javadsl.server.directives.SecurityDirectives;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.pekko.logging.ThreadSafeDittoLogger;
 
 /**
  * Custom Pekko Http directive performing basic auth for a defined {@link #USER_DEVOPS devops user}.
  */
 public final class DevOpsBasicAuthenticationDirective implements DevopsAuthenticationDirective {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DevOpsBasicAuthenticationDirective.class);
+    private static final ThreadSafeDittoLogger LOGGER =
+            DittoLoggerFactory.getThreadSafeLogger(DevOpsBasicAuthenticationDirective.class);
 
     private static final String USER_DEVOPS = "devops";
 
@@ -65,15 +66,9 @@ public final class DevOpsBasicAuthenticationDirective implements DevopsAuthentic
         return new DevOpsBasicAuthenticationDirective(devOpsConfig.getPassword(), devOpsConfig.getStatusPassword());
     }
 
-    /**
-     * Authenticates the devops resources with the chosen authentication method.
-     *
-     * @param realm the realm to apply.
-     * @param inner the inner route, which will be performed on successful authentication.
-     * @return the inner route wrapped with authentication.
-     */
-    public Route authenticateDevOps(final String realm, final Route inner) {
-        LOGGER.debug("DevOps basic authentication is enabled for {}.", realm);
+    @Override
+    public Route authenticateDevOps(final String realm, final DittoHeaders dittoHeaders, final Route inner) {
+        LOGGER.withCorrelationId(dittoHeaders).debug("DevOps basic authentication is enabled for {}.", realm);
         return Directives.authenticateBasic(realm, new BasicAuthenticator(passwords), userName -> inner);
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevOpsInsecureAuthenticationDirective.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevOpsInsecureAuthenticationDirective.java
@@ -12,17 +12,17 @@
  */
 package org.eclipse.ditto.gateway.service.endpoints.directives.auth;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.pekko.http.javadsl.server.Route;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLogger;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 
 /**
  * Authentication directive which does not perform any authentication.
  */
 public final class DevOpsInsecureAuthenticationDirective implements DevopsAuthenticationDirective {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DevOpsInsecureAuthenticationDirective.class);
+    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(DevOpsInsecureAuthenticationDirective.class);
     private static final DevOpsInsecureAuthenticationDirective INSTANCE = new DevOpsInsecureAuthenticationDirective();
 
     private DevOpsInsecureAuthenticationDirective() {}
@@ -32,8 +32,8 @@ public final class DevOpsInsecureAuthenticationDirective implements DevopsAuthen
     }
 
     @Override
-    public Route authenticateDevOps(final String realm, final Route inner) {
-        LOGGER.warn("DevOps resource is not secured");
+    public Route authenticateDevOps(final String realm, final DittoHeaders dittoHeaders, final Route inner) {
+        LOGGER.withCorrelationId(dittoHeaders).warn("DevOps resource is not secured");
         return inner;
     }
 }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevopsAuthenticationDirective.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DevopsAuthenticationDirective.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.gateway.service.endpoints.directives.auth;
 
 import org.apache.pekko.http.javadsl.server.Route;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
 
 
 /**
@@ -21,6 +22,14 @@ import org.apache.pekko.http.javadsl.server.Route;
 @FunctionalInterface
 public interface DevopsAuthenticationDirective {
 
-    Route authenticateDevOps(final String realm, final Route inner);
+    /**
+     * Authenticates the devops resources with the chosen authentication method.
+     *
+     * @param realm the realm to apply.
+     * @param dittoHeaders the DittoHeaders to use for logging.
+     * @param inner the inner route, which will be performed on successful authentication.
+     * @return the inner route wrapped with authentication.
+     */
+    Route authenticateDevOps(String realm, DittoHeaders dittoHeaders, Route inner);
 
 }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRoute.java
@@ -24,6 +24,18 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.apache.pekko.http.javadsl.model.HttpHeader;
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.HttpResponse;
+import org.apache.pekko.http.javadsl.server.AllDirectives;
+import org.apache.pekko.http.javadsl.server.ExceptionHandler;
+import org.apache.pekko.http.javadsl.server.PathMatchers;
+import org.apache.pekko.http.javadsl.server.RejectionHandler;
+import org.apache.pekko.http.javadsl.server.RequestContext;
+import org.apache.pekko.http.javadsl.server.Route;
+import org.apache.pekko.http.javadsl.server.directives.RouteAdapter;
+import org.apache.pekko.http.scaladsl.server.RouteResult;
+import org.apache.pekko.japi.pf.PFBuilder;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -58,18 +70,6 @@ import org.eclipse.ditto.internal.utils.health.routes.StatusRoute;
 import org.eclipse.ditto.internal.utils.protocol.ProtocolAdapterProvider;
 import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
 
-import org.apache.pekko.http.javadsl.model.HttpHeader;
-import org.apache.pekko.http.javadsl.model.HttpRequest;
-import org.apache.pekko.http.javadsl.model.HttpResponse;
-import org.apache.pekko.http.javadsl.server.AllDirectives;
-import org.apache.pekko.http.javadsl.server.ExceptionHandler;
-import org.apache.pekko.http.javadsl.server.PathMatchers;
-import org.apache.pekko.http.javadsl.server.RejectionHandler;
-import org.apache.pekko.http.javadsl.server.RequestContext;
-import org.apache.pekko.http.javadsl.server.Route;
-import org.apache.pekko.http.javadsl.server.directives.RouteAdapter;
-import org.apache.pekko.http.scaladsl.server.RouteResult;
-import org.apache.pekko.japi.pf.PFBuilder;
 import scala.Function1;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
@@ -170,8 +170,8 @@ public final class RootRoute extends AllDirectives {
                                         api(ctx, correlationId, queryParameters), // /api
                                         ws(ctx, correlationId, queryParameters), // /ws
                                         ownStatusRoute.buildStatusRoute(), // /status
-                                        overallStatusRoute.buildOverallStatusRoute(), // /overall
-                                        devopsRoute.buildDevOpsRoute(ctx, queryParameters) // /devops
+                                        overallStatusRoute.buildOverallStatusRoute(correlationId), // /overall
+                                        devopsRoute.buildDevOpsRoute(ctx, correlationId, queryParameters) // /devops
                                 )
                         )
                 )

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
@@ -23,6 +23,10 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.http.javadsl.model.MediaTypes;
+import org.apache.pekko.http.javadsl.server.PathMatchers;
+import org.apache.pekko.http.javadsl.server.RequestContext;
+import org.apache.pekko.http.javadsl.server.Route;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.connectivity.model.Connection;
@@ -55,11 +59,6 @@ import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
-
-import org.apache.pekko.http.javadsl.model.MediaTypes;
-import org.apache.pekko.http.javadsl.server.PathMatchers;
-import org.apache.pekko.http.javadsl.server.RequestContext;
-import org.apache.pekko.http.javadsl.server.Route;
 
 /**
  * Builder for creating Pekko HTTP routes for {@code /connections}.
@@ -107,8 +106,8 @@ public final class ConnectionsRoute extends AbstractRoute {
     public Route buildConnectionsRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
         return rawPathPrefix(PathMatchers.slash().concat(PATH_CONNECTIONS), () ->  // /connections
                 Optional.ofNullable(devOpsAuthenticationDirective)
-                        .orElse((realm, route) -> route)
-                        .authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS,
+                        .orElse((realm, dh, route) -> route)
+                        .authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS, dittoHeaders,
                                 concat(
                                         // /connections
                                         connections(ctx, dittoHeaders),

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
@@ -99,12 +99,14 @@ public final class DevOpsRoute extends AbstractRoute {
      * @return the {@code /devops} route.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public Route buildDevOpsRoute(final RequestContext ctx, final Map<String, String> queryParameters) {
+    public Route buildDevOpsRoute(final RequestContext ctx, final String correlationId,
+            final Map<String, String> queryParameters) {
         checkNotNull(ctx, "ctx");
         checkNotNull(queryParameters, "queryParameters");
 
         return rawPathPrefix(PathMatchers.slash().concat(PATH_DEVOPS), () ->  // /devops
                 devOpsAuthenticationDirective.authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS,
+                        DittoHeaders.newBuilder().correlationId(correlationId).build(),
                         concat(
                                 rawPathPrefix(PathMatchers.slash().concat(PATH_LOGGING),
                                         () -> // /devops/logging

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRoute.java
@@ -15,21 +15,6 @@ package org.eclipse.ditto.gateway.service.endpoints.routes.stats;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import org.eclipse.ditto.base.model.common.ConditionChecker;
-import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevOpsOAuth2AuthenticationDirective;
-import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirective;
-import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.base.model.common.HttpStatus;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
-import org.eclipse.ditto.gateway.service.endpoints.actors.AbstractHttpRequestActor;
-import org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute;
-import org.eclipse.ditto.thingsearch.api.commands.sudo.SudoCountThings;
-import org.eclipse.ditto.base.api.devops.signals.commands.DevOpsCommand;
-import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveStatistics;
-import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveStatisticsDetails;
-
 import org.apache.pekko.http.javadsl.model.ContentTypes;
 import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.http.javadsl.server.Directives;
@@ -41,6 +26,20 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
+import org.eclipse.ditto.base.api.devops.signals.commands.DevOpsCommand;
+import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveStatistics;
+import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveStatisticsDetails;
+import org.eclipse.ditto.base.model.common.ConditionChecker;
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.gateway.service.endpoints.actors.AbstractHttpRequestActor;
+import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevOpsOAuth2AuthenticationDirective;
+import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirective;
+import org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute;
+import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.thingsearch.api.commands.sudo.SudoCountThings;
 
 /**
  * Builder for Pekko HTTP route for providing statistics.
@@ -111,6 +110,7 @@ public final class StatsRoute extends AbstractRoute {
 
     private Route buildDetailsRoute(final RequestContext ctx, final CharSequence correlationId) {
         return devOpsAuthenticationDirective.authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS,
+                DittoHeaders.newBuilder().correlationId(correlationId).build(),
                 parameterList(ENTITY_PARAM, shardRegions ->
                         parameterList(NAMESPACE_PARAM, namespaces ->
                                 handleDevOpsPerRequest(ctx, RetrieveStatisticsDetails.of(shardRegions, namespaces,

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationFactory.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationFactory.java
@@ -16,12 +16,12 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import javax.annotation.Nullable;
 
+import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.gateway.service.util.config.security.OAuthConfig;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
-import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.internal.utils.http.HttpClientFacade;
 
-import org.apache.pekko.actor.ActorSystem;
+import com.typesafe.config.Config;
 
 /**
  * A factory for {@link org.eclipse.ditto.jwt.model.JsonWebToken} related security.
@@ -95,11 +95,10 @@ public final class JwtAuthenticationFactory {
         return jwtSubjectIssuersConfig;
     }
 
-    public JwtAuthenticationResultProvider newJwtAuthenticationResultProvider(final String configLevel) {
-        return JwtAuthenticationResultProvider.get(
-                actorSystem,
-                ScopedConfig.getOrEmpty(actorSystem.settings().config(), configLevel)
-        );
+    public JwtAuthenticationResultProvider newJwtAuthenticationResultProvider(final Config extensionConfig,
+            @Nullable final String role) {
+
+        return JwtAuthenticationResultProvider.get(actorSystem, extensionConfig, role);
     }
 
 }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationProvider.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationProvider.java
@@ -131,11 +131,12 @@ public final class JwtAuthenticationProvider extends TimeMeasuringAuthentication
     private CompletionStage<AuthenticationResult> getAuthenticationResult(final JsonWebToken jwt,
             final DittoHeaders dittoHeaders) {
 
+        final ThreadSafeDittoLogger logger = LOGGER.withCorrelationId(dittoHeaders);
         return jwtValidator.validate(jwt)
                 .thenCompose(validationResult -> {
                     if (!validationResult.isValid()) {
                         final Throwable reasonForInvalidity = validationResult.getReasonForInvalidity();
-                        LOGGER.withCorrelationId(dittoHeaders).debug("The JWT is invalid.", reasonForInvalidity);
+                        logger.debug("The JWT is invalid.", reasonForInvalidity);
                         final DittoRuntimeException reasonForFailure =
                                 buildJwtUnauthorizedException(dittoHeaders, reasonForInvalidity);
                         return CompletableFuture.completedFuture(
@@ -144,7 +145,7 @@ public final class JwtAuthenticationProvider extends TimeMeasuringAuthentication
                     return tryToGetAuthenticationResult(jwt, dittoHeaders);
                 })
                 .thenApply(authenticationResult -> {
-                    LOGGER.withCorrelationId(dittoHeaders).info("Completed JWT authentication successfully.");
+                    logger.info("Completed JWT authentication successfully.");
                     return authenticationResult;
                 });
     }

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -8,8 +8,26 @@ ditto {
       extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DefaultJwtAuthenticationResultProvider
       # The provider for JSON Web Token authorization subjects
       extension-config = {
+        role = regular
         jwt-authorization-subjects-provider = {
           extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DittoJwtAuthorizationSubjectsProvider
+          extension-config = {
+            role = regular
+          }
+        }
+      }
+    }
+    # The provider for JSON Web Token authentication results for "devops" and "connections" routes
+    jwt-authentication-result-provider-devops = {
+      extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DefaultJwtAuthenticationResultProvider
+      # The provider for JSON Web Token authorization subjects
+      extension-config = {
+        role = devops
+        jwt-authorization-subjects-provider = {
+          extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DittoJwtAuthorizationSubjectsProvider
+          extension-config = {
+            role = devops
+          }
         }
       }
     }

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/EndpointTestBase.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/EndpointTestBase.java
@@ -72,6 +72,7 @@ import org.eclipse.ditto.gateway.service.util.config.streaming.StreamingConfig;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.internal.utils.health.StatusInfo;
 import org.eclipse.ditto.internal.utils.health.cluster.ClusterStatus;
 import org.eclipse.ditto.internal.utils.http.DefaultHttpClientFacade;
@@ -127,9 +128,10 @@ public abstract class EndpointTestBase extends JUnitRouteTest {
 
     @BeforeClass
     public static void initTestFixture() {
-        final var dittoScopedConfig = DefaultScopedConfig.dittoScoped(createTestConfig());
+        final Config testConfig = createTestConfig();
+        final var dittoScopedConfig = DefaultScopedConfig.dittoScoped(testConfig);
         final var gatewayScopedConfig = DefaultScopedConfig.newInstance(dittoScopedConfig, "gateway");
-        final var actorSystem = ActorSystem.create(EndpointTestBase.class.getSimpleName(), createTestConfig());
+        final var actorSystem = ActorSystem.create(EndpointTestBase.class.getSimpleName(), testConfig);
         httpConfig = GatewayHttpConfig.of(gatewayScopedConfig);
         healthCheckConfig = DefaultHealthCheckConfig.of(gatewayScopedConfig);
         commandConfig = DefaultCommandConfig.of(gatewayScopedConfig);
@@ -144,7 +146,8 @@ public abstract class EndpointTestBase extends JUnitRouteTest {
         httpClientFacade =
                 DefaultHttpClientFacade.getInstance(actorSystem,
                         DefaultHttpProxyConfig.ofProxy(DefaultScopedConfig.empty("/")));
-        authorizationSubjectsProvider = JwtAuthorizationSubjectsProvider.get(actorSystem, ConfigFactory.empty());
+        authorizationSubjectsProvider = JwtAuthorizationSubjectsProvider.get(actorSystem,
+                ScopedConfig.dittoExtension(testConfig));
         jwtAuthenticationFactory = JwtAuthenticationFactory.newInstance(authConfig.getOAuthConfig(),
                 cacheConfig,
                 httpClientFacade,

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/RootRouteTest.java
@@ -24,6 +24,14 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.StatusCodes;
+import org.apache.pekko.http.javadsl.model.headers.Location;
+import org.apache.pekko.http.javadsl.model.headers.RawHeader;
+import org.apache.pekko.http.javadsl.testkit.TestRoute;
+import org.apache.pekko.http.javadsl.testkit.TestRouteResult;
+import org.apache.pekko.stream.SystemMaterializer;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
@@ -69,15 +77,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.typesafe.config.ConfigFactory;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.http.javadsl.model.HttpRequest;
-import org.apache.pekko.http.javadsl.model.StatusCodes;
-import org.apache.pekko.http.javadsl.model.headers.Location;
-import org.apache.pekko.http.javadsl.model.headers.RawHeader;
-import org.apache.pekko.http.javadsl.testkit.TestRoute;
-import org.apache.pekko.http.javadsl.testkit.TestRouteResult;
-import org.apache.pekko.stream.SystemMaterializer;
 
 /**
  * Tests {@link RootRoute}.
@@ -137,12 +136,12 @@ public final class RootRouteTest extends EndpointTestBase {
         final var statusAndHealthProvider = DittoStatusAndHealthProviderFactory.of(routeBaseProperties.getActorSystem(),
                 clusterStatusSupplier,
                 healthCheckConfig);
-        final var devopsAuthenticationDirectiveFactory =
-                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory,
-                        authConfig.getDevOpsConfig());
-        final var devOpsAuthenticationDirective = devopsAuthenticationDirectiveFactory.devops();
         final var dittoExtensionConfig =
                 ScopedConfig.dittoExtension(routeBaseProperties.getActorSystem().settings().config());
+        final var devopsAuthenticationDirectiveFactory =
+                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory,
+                        authConfig.getDevOpsConfig(), dittoExtensionConfig);
+        final var devOpsAuthenticationDirective = devopsAuthenticationDirectiveFactory.devops();
         final var rootRoute = RootRoute.getBuilder(httpConfig)
                 .statsRoute(new StatsRoute(routeBaseProperties, devOpsAuthenticationDirective))
                 .statusRoute(new StatusRoute(clusterStatusSupplier,

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRouteTest.java
@@ -20,6 +20,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.pekko.http.javadsl.model.ContentTypes;
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.StatusCodes;
+import org.apache.pekko.http.javadsl.server.Directives;
+import org.apache.pekko.http.javadsl.server.ExceptionHandler;
+import org.apache.pekko.http.javadsl.server.RejectionHandler;
+import org.apache.pekko.http.javadsl.server.Route;
+import org.apache.pekko.http.javadsl.testkit.TestRoute;
 import org.eclipse.ditto.base.model.auth.AuthorizationContext;
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
@@ -40,15 +48,6 @@ import org.eclipse.ditto.json.JsonValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import org.apache.pekko.http.javadsl.model.ContentTypes;
-import org.apache.pekko.http.javadsl.model.HttpRequest;
-import org.apache.pekko.http.javadsl.model.StatusCodes;
-import org.apache.pekko.http.javadsl.server.Directives;
-import org.apache.pekko.http.javadsl.server.ExceptionHandler;
-import org.apache.pekko.http.javadsl.server.RejectionHandler;
-import org.apache.pekko.http.javadsl.server.Route;
-import org.apache.pekko.http.javadsl.testkit.TestRoute;
 
 public final class ConnectionsRouteTest extends EndpointTestBase {
 
@@ -96,7 +95,7 @@ public final class ConnectionsRouteTest extends EndpointTestBase {
     public void setUp() {
         final DevopsAuthenticationDirective devopsAuthenticationDirective = Mockito.mock(
                 DevopsAuthenticationDirective.class);
-        Mockito.when(devopsAuthenticationDirective.authenticateDevOps(Mockito.any(), Mockito.any()))
+        Mockito.when(devopsAuthenticationDirective.authenticateDevOps(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenAnswer(a -> a.getArguments()[1]);
         final var connectionsRoute = new ConnectionsRoute(routeBaseProperties, devopsAuthenticationDirective);
         final Route route =

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRouteTest.java
@@ -96,7 +96,7 @@ public final class ConnectionsRouteTest extends EndpointTestBase {
         final DevopsAuthenticationDirective devopsAuthenticationDirective = Mockito.mock(
                 DevopsAuthenticationDirective.class);
         Mockito.when(devopsAuthenticationDirective.authenticateDevOps(Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenAnswer(a -> a.getArguments()[1]);
+                .thenAnswer(a -> a.getArguments()[2]);
         final var connectionsRoute = new ConnectionsRoute(routeBaseProperties, devopsAuthenticationDirective);
         final Route route =
                 extractRequestContext(ctx -> connectionsRoute.buildConnectionsRoute(ctx, dittoHeaders));

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRouteTest.java
@@ -14,19 +14,7 @@
 package org.eclipse.ditto.gateway.service.endpoints.routes.devops;
 
 import java.util.Collections;
-
-import org.eclipse.ditto.base.api.devops.signals.commands.ExecutePiggybackCommand;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
-import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirectiveFactory;
-import org.eclipse.ditto.gateway.service.util.config.security.DefaultDevOpsConfig;
-import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
-import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThing;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.typesafe.config.ConfigFactory;
+import java.util.UUID;
 
 import org.apache.pekko.http.javadsl.model.ContentTypes;
 import org.apache.pekko.http.javadsl.model.HttpEntities;
@@ -35,6 +23,19 @@ import org.apache.pekko.http.javadsl.model.RequestEntity;
 import org.apache.pekko.http.javadsl.model.StatusCodes;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.http.javadsl.testkit.TestRoute;
+import org.eclipse.ditto.base.api.devops.signals.commands.ExecutePiggybackCommand;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
+import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirectiveFactory;
+import org.eclipse.ditto.gateway.service.util.config.security.DefaultDevOpsConfig;
+import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThing;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
 
 /**
  * Unit test for {@link DevOpsRoute}.
@@ -47,11 +48,14 @@ public final class DevOpsRouteTest extends EndpointTestBase {
 
     @Before
     public void setUp() {
+        final var dittoExtensionConfig =
+                ScopedConfig.dittoExtension(routeBaseProperties.getActorSystem().settings().config());
         final var devopsAuthenticationDirectiveFactory =
-                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory, getInsecureDevopsConfig());
+                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory, getInsecureDevopsConfig(),
+                        dittoExtensionConfig);
         final var authenticationDirective = devopsAuthenticationDirectiveFactory.devops();
         devOpsRoute = new DevOpsRoute(routeBaseProperties, authenticationDirective);
-        final Route route = extractRequestContext(ctx -> devOpsRoute.buildDevOpsRoute(ctx, Collections.emptyMap()));
+        final Route route = extractRequestContext(ctx -> devOpsRoute.buildDevOpsRoute(ctx, UUID.randomUUID().toString(), Collections.emptyMap()));
         underTest = testRoute(route);
     }
 

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRouteTest.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationFactory;
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationProvider;
 import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.CountThingsResponse;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,8 +61,10 @@ public final class StatsRouteTest extends EndpointTestBase {
         final var devopsJwtAuthenticationFactory =
                 JwtAuthenticationFactory.newInstance(devOpsConfig.getOAuthConfig(), cacheConfig, httpClientFacade,
                         actorSystem);
+        final var dittoExtensionConfig =
+                ScopedConfig.dittoExtension(actorSystem.settings().config());
         final var jwtAuthenticationProvider = JwtAuthenticationProvider.newInstance(
-                devopsJwtAuthenticationFactory.newJwtAuthenticationResultProvider(ConfigFactory.empty(), null),
+                devopsJwtAuthenticationFactory.newJwtAuthenticationResultProvider(dittoExtensionConfig, null),
                 devopsJwtAuthenticationFactory.getJwtValidator());
         final var routeBaseProperties = RouteBaseProperties.newBuilder(this.routeBaseProperties)
                 .proxyActor(proxyActor)

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/stats/StatsRouteTest.java
@@ -18,6 +18,11 @@ import static org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants.
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.StatusCodes;
+import org.apache.pekko.http.javadsl.testkit.TestRoute;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
 import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
@@ -26,18 +31,11 @@ import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationFactory;
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationProvider;
 import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
-import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.CountThingsResponse;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.typesafe.config.ConfigFactory;
-
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.http.javadsl.model.HttpRequest;
-import org.apache.pekko.http.javadsl.model.StatusCodes;
-import org.apache.pekko.http.javadsl.testkit.TestRoute;
 
 /**
  * Tests {@link StatsRoute}.
@@ -63,7 +61,7 @@ public final class StatsRouteTest extends EndpointTestBase {
                 JwtAuthenticationFactory.newInstance(devOpsConfig.getOAuthConfig(), cacheConfig, httpClientFacade,
                         actorSystem);
         final var jwtAuthenticationProvider = JwtAuthenticationProvider.newInstance(
-                devopsJwtAuthenticationFactory.newJwtAuthenticationResultProvider(ScopedConfig.DITTO_EXTENSIONS_SCOPE),
+                devopsJwtAuthenticationFactory.newJwtAuthenticationResultProvider(ConfigFactory.empty(), null),
                 devopsJwtAuthenticationFactory.getJwtValidator());
         final var routeBaseProperties = RouteBaseProperties.newBuilder(this.routeBaseProperties)
                 .proxyActor(proxyActor)

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRouteTest.java
@@ -17,21 +17,20 @@ import static org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants.
 
 import java.util.function.Supplier;
 
-import org.eclipse.ditto.gateway.service.health.DittoStatusAndHealthProviderFactory;
-import org.eclipse.ditto.gateway.service.health.StatusAndHealthProvider;
-import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
-import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
-import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
-import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirective;
-import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirectiveFactory;
-import org.eclipse.ditto.internal.utils.health.cluster.ClusterStatus;
-import org.junit.Before;
-import org.junit.Test;
-
 import org.apache.pekko.http.javadsl.model.HttpRequest;
 import org.apache.pekko.http.javadsl.model.StatusCodes;
 import org.apache.pekko.http.javadsl.testkit.TestRoute;
 import org.apache.pekko.http.javadsl.testkit.TestRouteResult;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
+import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirective;
+import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthenticationDirectiveFactory;
+import org.eclipse.ditto.gateway.service.health.DittoStatusAndHealthProviderFactory;
+import org.eclipse.ditto.gateway.service.health.StatusAndHealthProvider;
+import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
+import org.eclipse.ditto.internal.utils.health.cluster.ClusterStatus;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests {@link OverallStatusRoute}.
@@ -59,7 +58,7 @@ public final class OverallStatusRouteTest extends EndpointTestBase {
         final DevopsAuthenticationDirective authenticationDirective = devopsAuthenticationDirectiveFactory.status();
         final OverallStatusRoute statusRoute =
                 new OverallStatusRoute(clusterStateSupplier, statusHealthProvider, authenticationDirective);
-        statusTestRoute = testRoute(statusRoute.buildOverallStatusRoute());
+        statusTestRoute = testRoute(statusRoute.buildOverallStatusRoute(correlationId));
     }
 
     @Test

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRouteTest.java
@@ -28,6 +28,7 @@ import org.eclipse.ditto.gateway.service.endpoints.directives.auth.DevopsAuthent
 import org.eclipse.ditto.gateway.service.health.DittoStatusAndHealthProviderFactory;
 import org.eclipse.ditto.gateway.service.health.StatusAndHealthProvider;
 import org.eclipse.ditto.gateway.service.util.config.security.DevOpsConfig;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.internal.utils.health.cluster.ClusterStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,16 +50,19 @@ public final class OverallStatusRouteTest extends EndpointTestBase {
 
     @Before
     public void setUp() {
+        final var dittoExtensionConfig =
+                ScopedConfig.dittoExtension(routeBaseProperties.getActorSystem().settings().config());
         final Supplier<ClusterStatus> clusterStateSupplier = createClusterStatusSupplierMock();
         final StatusAndHealthProvider statusHealthProvider =
                 DittoStatusAndHealthProviderFactory.of(system(), clusterStateSupplier, healthCheckConfig);
         final DevOpsConfig devOpsConfig = authConfig.getDevOpsConfig();
         final DevopsAuthenticationDirectiveFactory devopsAuthenticationDirectiveFactory =
-                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory, devOpsConfig);
+                DevopsAuthenticationDirectiveFactory.newInstance(jwtAuthenticationFactory, devOpsConfig,
+                        dittoExtensionConfig);
         final DevopsAuthenticationDirective authenticationDirective = devopsAuthenticationDirectiveFactory.status();
         final OverallStatusRoute statusRoute =
                 new OverallStatusRoute(clusterStateSupplier, statusHealthProvider, authenticationDirective);
-        statusTestRoute = testRoute(statusRoute.buildOverallStatusRoute(correlationId));
+        statusTestRoute = testRoute(statusRoute.buildOverallStatusRoute("correlationId"));
     }
 
     @Test

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtAuthenticationResultProviderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtAuthenticationResultProviderTest.java
@@ -23,6 +23,7 @@ import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationResult;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.jwt.model.ImmutableJsonWebToken;
 import org.eclipse.ditto.jwt.model.JsonWebToken;
 import org.junit.Test;
@@ -49,8 +50,10 @@ public final class DefaultJwtAuthenticationResultProviderTest {
 
     @Test
     public void getAuthorizationContext() {
+        final var dittoExtensionConfig =
+                ScopedConfig.dittoExtension(ACTOR_SYSTEM.settings().config());
         final JwtAuthenticationResultProvider underTest =
-                JwtAuthenticationResultProvider.get(ACTOR_SYSTEM, ConfigFactory.empty(), "regular");
+                JwtAuthenticationResultProvider.get(ACTOR_SYSTEM, dittoExtensionConfig, null);
         final JsonWebToken jsonWebToken = ImmutableJsonWebToken.fromToken(JwtTestConstants.VALID_JWT_TOKEN);
         final AuthorizationSubject myTestSubj = AuthorizationSubject.newInstance("example:myTestSubj");
 

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtAuthenticationResultProviderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtAuthenticationResultProviderTest.java
@@ -19,6 +19,7 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.util.UUID;
 
+import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationResult;
@@ -28,10 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
-import org.apache.pekko.actor.ActorSystem;
 
 /**
  * Unit test for {@link DefaultJwtAuthenticationResultProvider}.
@@ -52,7 +50,7 @@ public final class DefaultJwtAuthenticationResultProviderTest {
     @Test
     public void getAuthorizationContext() {
         final JwtAuthenticationResultProvider underTest =
-                JwtAuthenticationResultProvider.get(ACTOR_SYSTEM, ConfigFactory.empty());
+                JwtAuthenticationResultProvider.get(ACTOR_SYSTEM, ConfigFactory.empty(), "regular");
         final JsonWebToken jsonWebToken = ImmutableJsonWebToken.fromToken(JwtTestConstants.VALID_JWT_TOKEN);
         final AuthorizationSubject myTestSubj = AuthorizationSubject.newInstance("example:myTestSubj");
 

--- a/gateway/service/src/test/resources/test.conf
+++ b/gateway/service/src/test/resources/test.conf
@@ -133,14 +133,34 @@ ditto {
   extensions {
     jwt-authorization-subjects-provider = {
       extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DittoJwtAuthorizationSubjectsProvider
+      extension-config = {
+        role = regular
+      }
     }
     # The provider for JSON Web Token authentication results
     jwt-authentication-result-provider = {
       extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DefaultJwtAuthenticationResultProvider
       # The provider for JSON Web Token authorization subjects
       extension-config = {
+        role = regular
         jwt-authorization-subjects-provider = {
           extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DittoJwtAuthorizationSubjectsProvider
+          extension-config = {
+            role = regular
+          }
+        }
+      }
+    }
+    jwt-authentication-result-provider-devops = {
+      extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DefaultJwtAuthenticationResultProvider
+      # The provider for JSON Web Token authorization subjects
+      extension-config = {
+        role = devops
+        jwt-authorization-subjects-provider = {
+          extension-class = org.eclipse.ditto.gateway.service.security.authentication.jwt.DittoJwtAuthorizationSubjectsProvider
+          extension-config = {
+            role = devops
+          }
         }
       }
     }


### PR DESCRIPTION
* improved logging correlationId also for devops auth in gateway as well

Resolves: #1946