### PR TITLE
Add possibility to customize image used for pod-deletion-cost annotation patching job

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.7  # chart version is effectively set by release-job
+version: 3.5.8  # chart version is effectively set by release-job
 appVersion: 3.5.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/hooks/pod-deletion-cost-cron-job.yaml
+++ b/deployment/helm/ditto/templates/hooks/pod-deletion-cost-cron-job.yaml
@@ -38,10 +38,15 @@ spec:
           {{- if .Values.rbac.enabled }}
           serviceAccountName: {{ template "ditto.serviceAccountName" . }}
           {{- end }}
+          {{- with .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           containers:
             - name: {{ .Chart.Name }}-pod-deletion-cost-cronjob
-              image: "public.ecr.aws/h0h9t7p1/alpine-bash-curl-jq:latest"
+              image: {{ printf "%s:%s" .Values.global.podDeletionCostPatching.image.repository ( default .Values.global.podDeletionCostPatching.image.tag "latest" ) }}
+              imagePullPolicy: {{ .Values.global.podDeletionCostPatching.image.pullPolicy }}
               command:
                 - /bin/sh
                 - -c

--- a/deployment/helm/ditto/templates/hooks/pre-upgrade-job.yaml
+++ b/deployment/helm/ditto/templates/hooks/pre-upgrade-job.yaml
@@ -39,10 +39,15 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "ditto.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
         - name: {{ .Chart.Name }}-pod-deletion-cost-pre-upgrade-hook
-          image: "public.ecr.aws/h0h9t7p1/alpine-bash-curl-jq:latest"
+          image: {{ printf "%s:%s" .Values.global.podDeletionCostPatching.image.repository ( default .Values.global.podDeletionCostPatching.image.tag "latest" ) }}
+          imagePullPolicy: {{ .Values.global.podDeletionCostPatching.image.pullPolicy }}
           command:
             - /bin/sh
             - -c

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -181,6 +181,13 @@ global:
     enabled: true
     # annotations defines k8s annotations to add to corresponding jobs
     annotations: {}
+    image:
+      # repository for the pod-deletion-cost annotation patching job docker image
+      repository: public.ecr.aws/h0h9t7p1/alpine-bash-curl-jq
+      # tag for the pod-deletion-cost annotation patching job docker image
+      tag: latest
+      # pullPolicy for the pod-deletion-cost annotation patching job docker image
+      pullPolicy: IfNotPresent
 
 
 ## ----------------------------------------------------------------------------


### PR DESCRIPTION
Hi, I would like to add possibility for using custom images and private docker registries also for pod-deletion-cost annotation patching jobs. It works similar way as for Ditto deployments. Image is still the same by default so it is backwards compatible.
Thank you.