### PR TITLE
Fix performance regression issue when running against MongoDB 6

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -4,6 +4,17 @@ ditto {
   mongodb {
     database = "connectivity"
     database = ${?MONGO_DB_DATABASE}
+
+    read-journal {
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}
+
+      hint-name-listLatestJournalEntries = null
+      hint-name-listLatestJournalEntries = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES}
+
+      hint-name-listNewestActiveSnapshotsByBatch = "_id_"
+      hint-name-listNewestActiveSnapshotsByBatch = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH}
+    }
   }
 
   extensions {

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/AbstractPersistenceStreamingActor.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/AbstractPersistenceStreamingActor.java
@@ -18,19 +18,18 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.javadsl.Source;
 import org.eclipse.ditto.internal.models.streaming.BatchedEntityIdWithRevisions;
 import org.eclipse.ditto.internal.models.streaming.EntityIdWithRevision;
 import org.eclipse.ditto.internal.models.streaming.SudoStreamPids;
-import org.eclipse.ditto.internal.utils.pekko.streaming.AbstractStreamingActor;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.streaming.AbstractStreamingActor;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.DefaultMongoDbConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.PidWithSeqNr;
 import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
-
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.javadsl.Source;
 
 /**
  * Abstract implementation of an Actor that streams information about persisted entities modified in a time window in
@@ -64,7 +63,8 @@ public abstract class AbstractPersistenceStreamingActor<T extends EntityIdWithRe
         final MongoDbConfig mongoDbConfig =
                 DefaultMongoDbConfig.of(DefaultScopedConfig.dittoScoped(config));
         mongoClient = MongoClientWrapper.newInstance(mongoDbConfig);
-        readJournal = MongoReadJournal.newInstance(config, mongoClient, getContext().getSystem());
+        readJournal = MongoReadJournal.newInstance(config, mongoClient, mongoDbConfig.getReadJournalConfig(),
+                getContext().getSystem());
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/SnapshotStreamingActor.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/SnapshotStreamingActor.java
@@ -19,25 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.bson.Document;
-import org.eclipse.ditto.base.model.entity.id.AbstractNamespacedEntityId;
-import org.eclipse.ditto.base.model.entity.id.EntityId;
-import org.eclipse.ditto.base.model.entity.type.EntityType;
-import org.eclipse.ditto.internal.models.streaming.StreamedSnapshot;
-import org.eclipse.ditto.internal.models.streaming.SudoStreamSnapshots;
-import org.eclipse.ditto.internal.utils.pekko.actors.AbstractActorWithShutdownBehavior;
-import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
-import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
-import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
-import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
-import org.eclipse.ditto.internal.utils.persistence.mongo.config.DefaultMongoDbConfig;
-import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
-import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
-import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.SnapshotFilter;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
-
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorRef;
@@ -53,6 +34,24 @@ import org.apache.pekko.stream.SharedKillSwitch;
 import org.apache.pekko.stream.SourceRef;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.StreamRefs;
+import org.bson.Document;
+import org.eclipse.ditto.base.model.entity.id.AbstractNamespacedEntityId;
+import org.eclipse.ditto.base.model.entity.id.EntityId;
+import org.eclipse.ditto.base.model.entity.type.EntityType;
+import org.eclipse.ditto.internal.models.streaming.StreamedSnapshot;
+import org.eclipse.ditto.internal.models.streaming.SudoStreamSnapshots;
+import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
+import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.actors.AbstractActorWithShutdownBehavior;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.DefaultMongoDbConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
+import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.SnapshotFilter;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
 
 
 /**
@@ -103,7 +102,8 @@ public final class SnapshotStreamingActor extends AbstractActorWithShutdownBehav
         final MongoDbConfig mongoDbConfig =
                 DefaultMongoDbConfig.of(DefaultScopedConfig.dittoScoped(config));
         mongoClient = MongoClientWrapper.newInstance(mongoDbConfig);
-        readJournal = MongoReadJournal.newInstance(config, mongoClient, getContext().getSystem());
+        readJournal = MongoReadJournal.newInstance(config, mongoClient, mongoDbConfig.getReadJournalConfig(),
+                getContext().getSystem());
         pubSubMediator = DistributedPubSub.get(getContext().getSystem()).mediator();
     }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfig.java
@@ -41,6 +41,7 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
     private final DefaultConnectionPoolConfig connectionPoolConfig;
     private final DefaultCircuitBreakerConfig circuitBreakerConfig;
     private final DefaultMonitoringConfig monitoringConfig;
+    private final MongoReadJournalConfig readJournalConfig;
 
     private DefaultMongoDbConfig(final ConfigWithFallback config) {
         maxQueryTime = config.getNonNegativeAndNonZeroDurationOrThrow(MongoDbConfigValue.MAX_QUERY_TIME);
@@ -61,6 +62,7 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
         connectionPoolConfig = DefaultConnectionPoolConfig.of(config);
         circuitBreakerConfig = DefaultCircuitBreakerConfig.of(config);
         monitoringConfig = DefaultMonitoringConfig.of(config);
+        readJournalConfig = DefaultMongoReadJournalConfig.of(config);
     }
 
     /**
@@ -123,6 +125,11 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
     }
 
     @Override
+    public MongoReadJournalConfig getReadJournalConfig() {
+        return readJournalConfig;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -137,13 +144,14 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
                 Objects.equals(optionsConfig, that.optionsConfig) &&
                 Objects.equals(connectionPoolConfig, that.connectionPoolConfig) &&
                 Objects.equals(circuitBreakerConfig, that.circuitBreakerConfig) &&
+                Objects.equals(readJournalConfig, that.readJournalConfig) &&
                 Objects.equals(monitoringConfig, that.monitoringConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(mongoDbUri, maxQueryTime, documentDbCompatibilityMode, optionsConfig, connectionPoolConfig,
-                circuitBreakerConfig, monitoringConfig);
+                circuitBreakerConfig, monitoringConfig, readJournalConfig);
     }
 
     @Override
@@ -156,6 +164,7 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
                 ", connectionPoolConfig=" + connectionPoolConfig +
                 ", circuitBreakerConfig=" + circuitBreakerConfig +
                 ", monitoringConfig=" + monitoringConfig +
+                ", readJournalConfig=" + readJournalConfig +
                 "]";
     }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoReadJournalConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoReadJournalConfig.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class implements the config for the handling of event journal entries.
+ */
+@Immutable
+public final class DefaultMongoReadJournalConfig implements MongoReadJournalConfig {
+
+    private static final String CONFIG_PATH = "read-journal";
+
+    @Nullable private final String hintNameFilterPidsThatDoesntContainTagInNewestEntry;
+    @Nullable private final String hintNameListLatestJournalEntries;
+    @Nullable private final String listNewestActiveSnapshotsByBatch;
+
+    private DefaultMongoReadJournalConfig(final ScopedConfig config) {
+        hintNameFilterPidsThatDoesntContainTagInNewestEntry = getNullableString(config,
+                MongoReadJournalConfigValue.HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY);
+        hintNameListLatestJournalEntries = getNullableString(config,
+                MongoReadJournalConfigValue.HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES);
+        listNewestActiveSnapshotsByBatch = getNullableString(config,
+                MongoReadJournalConfigValue.HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH);
+    }
+
+    /**
+     * Returns an instance of the default mongo read journal config based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the mongo read journal config at {@value #CONFIG_PATH}.
+     * @return instance
+     * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultMongoReadJournalConfig of(final Config config) {
+        return new DefaultMongoReadJournalConfig(
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, MongoReadJournalConfigValue.values()));
+    }
+
+    @Nullable
+    private static String getNullableString(final Config config, final KnownConfigValue configValue) {
+        return config.getIsNull(configValue.getConfigPath()) ? null : config.getString(configValue.getConfigPath());
+    }
+
+    @Override
+    public Optional<String> getIndexNameHintForFilterPidsThatDoesntContainTagInNewestEntry() {
+        return Optional.ofNullable(hintNameFilterPidsThatDoesntContainTagInNewestEntry);
+    }
+
+    @Override
+    public Optional<String> getIndexNameHintForListLatestJournalEntries() {
+        return Optional.ofNullable(hintNameListLatestJournalEntries);
+    }
+
+    @Override
+    public Optional<String> getIndexNameHintForListNewestActiveSnapshotsByBatch() {
+        return Optional.ofNullable(listNewestActiveSnapshotsByBatch);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultMongoReadJournalConfig that = (DefaultMongoReadJournalConfig) o;
+        return Objects.equals(hintNameFilterPidsThatDoesntContainTagInNewestEntry,
+                that.hintNameFilterPidsThatDoesntContainTagInNewestEntry) &&
+                Objects.equals(hintNameListLatestJournalEntries, that.hintNameListLatestJournalEntries) &&
+                Objects.equals(listNewestActiveSnapshotsByBatch, that.listNewestActiveSnapshotsByBatch);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hintNameFilterPidsThatDoesntContainTagInNewestEntry, hintNameListLatestJournalEntries,
+                listNewestActiveSnapshotsByBatch);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "hintNameFilterPidsThatDoesntContainTagInNewestEntry=" +
+                hintNameFilterPidsThatDoesntContainTagInNewestEntry +
+                ", hintNameListLatestJournalEntries=" + hintNameListLatestJournalEntries +
+                ", listNewestActiveSnapshotsByBatch=" + listNewestActiveSnapshotsByBatch +
+                "]";
+    }
+
+}

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
@@ -78,6 +78,13 @@ public interface MongoDbConfig {
     MonitoringConfig getMonitoringConfig();
 
     /**
+     * Returns the configuration settings of the MongoReadJournal.
+     *
+     * @return the MongoReadJournal config.
+     */
+    MongoReadJournalConfig getReadJournalConfig();
+
+    /**
      * An enumeration of known value paths and associated default values of the MongoDbConfig.
      */
     enum MongoDbConfigValue implements KnownConfigValue {

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+/**
+ * Provides configuration settings for the {@code MongoReadJournal}.
+ */
+@Immutable
+public interface MongoReadJournalConfig {
+
+    /**
+     * @return the optional hint name for aggregation done in {@code filterPidsThatDoesntContainTagInNewestEntry}.
+     */
+    Optional<String> getIndexNameHintForFilterPidsThatDoesntContainTagInNewestEntry();
+
+    /**
+     * @return the optional hint name for aggregation done in {@code listLatestJournalEntries}.
+     */
+    Optional<String> getIndexNameHintForListLatestJournalEntries();
+
+    /**
+     * @return the optional hint name for aggregation done in {@code listNewestActiveSnapshotsByBatch}.
+     */
+    Optional<String> getIndexNameHintForListNewestActiveSnapshotsByBatch();
+
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values for
+     * {@code MongoReadJournalConfig}.
+     */
+    enum MongoReadJournalConfigValue implements KnownConfigValue {
+
+        /**
+         * Hint name for aggregation done in {@code filterPidsThatDoesntContainTagInNewestEntry}.
+         */
+        HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY("hint-name-filterPidsThatDoesntContainTagInNewestEntry", null),
+
+        /**
+         * Hint name for aggregation done in {@code listLatestJournalEntries}.
+         */
+        HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES("hint-name-listLatestJournalEntries", null),
+
+        /**
+         * Hint name for aggregation done in {@code listNewestActiveSnapshotsByBatch}.
+         */
+        HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH("hint-name-listNewestActiveSnapshotsByBatch", null);
+
+        private final String path;
+        private final Object defaultValue;
+
+        MongoReadJournalConfigValue(final String thePath, @Nullable final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+        }
+
+}

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/indices/IndexOperations.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/indices/IndexOperations.java
@@ -19,6 +19,10 @@ import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.stream.javadsl.Source;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,10 +32,6 @@ import com.mongodb.client.model.IndexModel;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.japi.pf.PFBuilder;
-import org.apache.pekko.stream.javadsl.Source;
 import scala.PartialFunction;
 
 /**
@@ -42,7 +42,7 @@ public final class IndexOperations {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexOperations.class);
 
-    private static final String DEFAULT_INDEX_NAME = "_id_";
+    public static final String DEFAULT_INDEX_NAME = "_id_";
 
     private final MongoDatabase db;
 

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
@@ -55,7 +55,8 @@ public final class DefaultMongoDbConfigTest {
                         DefaultOptionsConfig.class,
                         DefaultConnectionPoolConfig.class,
                         DefaultCircuitBreakerConfig.class,
-                        DefaultMonitoringConfig.class).areAlsoImmutable());
+                        DefaultMonitoringConfig.class,
+                        DefaultMongoReadJournalConfig.class).areAlsoImmutable());
     }
 
     @Test

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -18,6 +18,17 @@ ditto {
   mongodb {
     database = "policies"
     database = ${?MONGO_DB_DATABASE}
+
+    read-journal {
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}
+
+      hint-name-listLatestJournalEntries = null
+      hint-name-listLatestJournalEntries = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES}
+
+      hint-name-listNewestActiveSnapshotsByBatch = "_id_"
+      hint-name-listNewestActiveSnapshotsByBatch = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH}
+    }
   }
 
   persistence.operations.delay-after-persistence-actor-shutdown = 5s

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/starter/ThingsRootActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/starter/ThingsRootActor.java
@@ -14,10 +14,15 @@ package org.eclipse.ditto.things.service.starter;
 
 import static org.eclipse.ditto.things.api.ThingsMessagingConstants.CLUSTER_ROLE;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.event.DiagnosticLoggingAdapter;
+import org.apache.pekko.japi.pf.ReceiveBuilder;
+import org.apache.pekko.pattern.Patterns;
 import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveStatisticsDetails;
 import org.eclipse.ditto.base.service.RootChildActorStarter;
 import org.eclipse.ditto.base.service.actors.DittoRootActor;
-import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.cluster.RetrieveStatisticsDetailsResponseSupplier;
 import org.eclipse.ditto.internal.utils.cluster.ShardRegionCreator;
@@ -27,6 +32,7 @@ import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.internal.utils.health.DefaultHealthCheckingActorFactory;
 import org.eclipse.ditto.internal.utils.health.HealthCheckingActorOptions;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.persistence.mongo.MongoClientWrapper;
 import org.eclipse.ditto.internal.utils.persistence.mongo.MongoHealthChecker;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
@@ -48,13 +54,6 @@ import org.eclipse.ditto.things.service.persistence.actors.ThingPersistenceActor
 import org.eclipse.ditto.things.service.persistence.actors.ThingPersistenceOperationsActor;
 import org.eclipse.ditto.things.service.persistence.actors.ThingSupervisorActor;
 import org.eclipse.ditto.things.service.persistence.actors.ThingsPersistenceStreamingActorCreator;
-
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Props;
-import org.apache.pekko.event.DiagnosticLoggingAdapter;
-import org.apache.pekko.japi.pf.ReceiveBuilder;
-import org.apache.pekko.pattern.Patterns;
 
 /**
  * Our "Parent" Actor which takes care of supervision of all other Actors in our system.
@@ -186,7 +185,7 @@ public final class ThingsRootActor extends DittoRootActor {
         final var config = actorSystem.settings().config();
         final var mongoClient = MongoClientWrapper.newInstance(mongoDbConfig);
 
-        return MongoReadJournal.newInstance(config, mongoClient, actorSystem);
+        return MongoReadJournal.newInstance(config, mongoClient, mongoDbConfig.getReadJournalConfig(), actorSystem);
     }
 
 }

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -24,6 +24,17 @@ ditto {
   mongodb {
     database = "things"
     database = ${?MONGO_DB_DATABASE}
+
+    read-journal {
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
+      hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}
+
+      hint-name-listLatestJournalEntries = null
+      hint-name-listLatestJournalEntries = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES}
+
+      hint-name-listNewestActiveSnapshotsByBatch = "_id_"
+      hint-name-listNewestActiveSnapshotsByBatch = ${?MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH}
+    }
   }
 
   persistence.operations.delay-after-persistence-actor-shutdown = 5s


### PR DESCRIPTION
* providing the Mongo query planner an index hint for aggregation queries

I prepared basically all aggregation queries done in `MongoReadJournal` to provide an optional `hint` which index to choose.

We faced the issue that with MongoDB 5 the aggregation done in `listNewestActiveSnapshotsByBatch` was very quick, as the MongoDB query planner chose to use the default index `"_id_"`.  
However, after updating to MongoDB 6, the query planner chose to use another index: `things_snaps_index` (`{ pid: 1, sn: -1, ts: -1 } `). This turns out to be really bad when having much snapshot data.  
In our case, the query time with MongoDB 5 was ~200ms and with MongoDB 6 it e.g. was ~100.000ms.

Configuring a hint which index name to use should provide the option to fine-tune as needed.