### PR TITLE
fix performance regression with MongoDB 6 regarding snapshot aggregations

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -6,11 +6,20 @@ ditto {
     database = ${?MONGO_DB_DATABASE}
 
     read-journal {
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
       should-create-additional-snapshot-aggregation-index-pid-id = false
       should-create-additional-snapshot-aggregation-index-pid-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID}
 
-      should-create-additional-snapshot-aggregation-index-pid = false
-      should-create-additional-snapshot-aggregation-index-pid = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID}
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn = false
+      should-create-additional-snapshot-aggregation-index-pid-sn = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN}
+
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.9  # chart version is effectively set by release-job
+version: 3.5.10  # chart version is effectively set by release-job
 appVersion: 3.5.8
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -225,18 +225,20 @@ spec:
               value: "{{ .Values.connectivity.config.cleanup.deleteFinalDeletedSnapshot }}"
             - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID
               value: "{{ .Values.connectivity.config.readJournal.indexes.createSnapshotAggregationIndexPidId }}"
-            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID
-              value: "{{ .Values.connectivity.config.readJournal.indexes.createSnapshotAggregationIndexPid }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN
+              value: "{{ .Values.connectivity.config.readJournal.indexes.createSnapshotAggregationIndexPidSn }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID
+              value: "{{ .Values.connectivity.config.readJournal.indexes.createSnapshotAggregationIndexPidSnId }}"
             - name: MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY
-              value: "{{ .Values.connectivity.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry }}"
+              value: {{ .Values.connectivity.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES
-              value: "{{ .Values.connectivity.config.readJournal.hints.listLatestJournalEntries }}"
+              value: {{ .Values.connectivity.config.readJournal.hints.listLatestJournalEntries | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID_ID
-              value: "{{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId }}"
+              value: {{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID
-              value: "{{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid }}"
+              value: {{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_ID
-              value: "{{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchId }}"
+              value: {{ .Values.connectivity.config.readJournal.hints.listNewestActiveSnapshotsByBatchId | default "null" | quote }}
             - name: CONNECTION_SNAPSHOT_INTERVAL
               value: "{{ .Values.connectivity.config.persistence.snapshots.interval }}"
             - name: CONNECTION_SNAPSHOT_THRESHOLD

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -243,18 +243,20 @@ spec:
               value: "{{ .Values.policies.config.cleanup.deleteFinalDeletedSnapshot }}"
             - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID
               value: "{{ .Values.policies.config.readJournal.indexes.createSnapshotAggregationIndexPidId }}"
-            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID
-              value: "{{ .Values.policies.config.readJournal.indexes.createSnapshotAggregationIndexPid }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN
+              value: "{{ .Values.policies.config.readJournal.indexes.createSnapshotAggregationIndexPidSn }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID
+              value: "{{ .Values.policies.config.readJournal.indexes.createSnapshotAggregationIndexPidSnId }}"
             - name: MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY
-              value: "{{ .Values.policies.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry }}"
+              value: {{ .Values.policies.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES
-              value: "{{ .Values.policies.config.readJournal.hints.listLatestJournalEntries }}"
+              value: {{ .Values.policies.config.readJournal.hints.listLatestJournalEntries | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID_ID
-              value: "{{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId }}"
+              value: {{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID
-              value: "{{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid }}"
+              value: {{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_ID
-              value: "{{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchId }}"
+              value: {{ .Values.policies.config.readJournal.hints.listNewestActiveSnapshotsByBatchId | default "null" | quote }}
             - name: POLICIES_PERSISTENCE_PING_RATE_FREQUENCY
               value: "{{ .Values.policies.config.persistence.pingRate.frequency }}"
             - name: POLICIES_PERSISTENCE_PING_RATE_ENTITIES

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -244,18 +244,20 @@ spec:
               value: "{{ .Values.things.config.cleanup.deleteFinalDeletedSnapshot }}"
             - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID
               value: "{{ .Values.things.config.readJournal.indexes.createSnapshotAggregationIndexPidId }}"
-            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID
-              value: "{{ .Values.things.config.readJournal.indexes.createSnapshotAggregationIndexPid }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN
+              value: "{{ .Values.things.config.readJournal.indexes.createSnapshotAggregationIndexPidSn }}"
+            - name: MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID
+              value: "{{ .Values.things.config.readJournal.indexes.createSnapshotAggregationIndexPidSnId }}"
             - name: MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY
-              value: "{{ .Values.things.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry }}"
+              value: {{ .Values.things.config.readJournal.hints.filterPidsThatDoesntContainTagInNewestEntry | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_LATEST_JOURNAL_ENTRIES
-              value: "{{ .Values.things.config.readJournal.hints.listLatestJournalEntries }}"
+              value: {{ .Values.things.config.readJournal.hints.listLatestJournalEntries | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID_ID
-              value: "{{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId }}"
+              value: {{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchPidId | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_PID
-              value: "{{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid }}"
+              value: {{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchPid | default "null" | quote }}
             - name: MONGODB_READ_JOURNAL_HINT_NAME_LIST_NEWEST_ACTIVE_SNAPSHOT_BY_BATCH_ID
-              value: "{{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchId }}"
+              value: {{ .Values.things.config.readJournal.hints.listNewestActiveSnapshotsByBatchId | default "null" | quote }}
             - name: THING_SNAPSHOT_INTERVAL
               value: "{{ .Values.things.config.persistence.snapshots.interval }}"
             - name: THING_SNAPSHOT_THRESHOLD

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -656,8 +656,10 @@ policies:
       indexes:
         # createSnapshotAggregationIndexPidId whether to create the "pid"+"_id" compound index on the snapshot collection
         createSnapshotAggregationIndexPidId: false
-        # createSnapshotAggregationIndexPid whether to create the "pid" compound index on the snapshot collection
-        createSnapshotAggregationIndexPid: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSn: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn"+"_id" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSnId: false
       # hints contains hint names to configure for different aggregation calls done in MongoReadJournal
       hints:
         # filterPidsThatDoesntContainTagInNewestEntry contains the hint name to use in the aggregation query
@@ -885,8 +887,10 @@ things:
       indexes:
         # createSnapshotAggregationIndexPidId whether to create the "pid"+"_id" compound index on the snapshot collection
         createSnapshotAggregationIndexPidId: false
-        # createSnapshotAggregationIndexPid whether to create the "pid" compound index on the snapshot collection
-        createSnapshotAggregationIndexPid: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSn: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn"+"_id" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSnId: false
       # hints contains hint names to configure for different aggregation calls done in MongoReadJournal
       hints:
         # filterPidsThatDoesntContainTagInNewestEntry contains the hint name to use in the aggregation query
@@ -1363,8 +1367,10 @@ connectivity:
       indexes:
         # createSnapshotAggregationIndexPidId whether to create the "pid"+"_id" compound index on the snapshot collection
         createSnapshotAggregationIndexPidId: false
-        # createSnapshotAggregationIndexPid whether to create the "pid" compound index on the snapshot collection
-        createSnapshotAggregationIndexPid: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSn: false
+        # createSnapshotAggregationIndexPidSn whether to create the "pid"+"sn"+"_id" compound index on the snapshot collection
+        createSnapshotAggregationIndexPidSnId: false
       # hints contains hint names to configure for different aggregation calls done in MongoReadJournal
       hints:
         # filterPidsThatDoesntContainTagInNewestEntry contains the hint name to use in the aggregation query
@@ -1691,7 +1697,7 @@ nginx:
     # repository for the nginx docker image
     repository: docker.io/nginx
     # tag for the nginx docker image
-    tag: 1.25
+    tag: 1.26
     # pullPolicy for the nginx docker image
     pullPolicy: IfNotPresent
   # extraEnv to add arbitrary environment variables to nginx container
@@ -1827,7 +1833,7 @@ swaggerui:
     # repository for the swagger ui docker image
     repository: docker.io/swaggerapi/swagger-ui
     # tag for the swagger ui docker image
-    tag: v5.9.1
+    tag: v5.17.14
     # pullPolicy for the swagger ui docker image
     pullPolicy: IfNotPresent
   # extraEnv to add arbitrary environment variable to swagger ui container

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoReadJournalConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoReadJournalConfig.java
@@ -33,7 +33,8 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
     private static final String CONFIG_PATH = "read-journal";
 
     private final boolean createAdditionalSnapshotAggregationIndexPidId;
-    private final boolean createAdditionalSnapshotAggregationIndexPid;
+    private final boolean createAdditionalSnapshotAggregationIndexPidSn;
+    private final boolean createAdditionalSnapshotAggregationIndexPidSnId;
     @Nullable private final String hintNameFilterPidsThatDoesntContainTagInNewestEntry;
     @Nullable private final String hintNameListLatestJournalEntries;
     @Nullable private final String listNewestActiveSnapshotsByBatchPidId;
@@ -44,8 +45,11 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
         createAdditionalSnapshotAggregationIndexPidId = config.getBoolean(
                 MongoReadJournalConfigValue.SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID.getConfigPath()
         );
-        createAdditionalSnapshotAggregationIndexPid = config.getBoolean(
-                MongoReadJournalConfigValue.SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID.getConfigPath()
+        createAdditionalSnapshotAggregationIndexPidSn = config.getBoolean(
+                MongoReadJournalConfigValue.SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN.getConfigPath()
+        );
+        createAdditionalSnapshotAggregationIndexPidSnId = config.getBoolean(
+                MongoReadJournalConfigValue.SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID.getConfigPath()
         );
         hintNameFilterPidsThatDoesntContainTagInNewestEntry = getNullableString(config,
                 MongoReadJournalConfigValue.HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY);
@@ -85,8 +89,13 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
     }
 
     @Override
-    public boolean shouldCreateAdditionalSnapshotAggregationIndexPid() {
-        return createAdditionalSnapshotAggregationIndexPid;
+    public boolean shouldCreateAdditionalSnapshotAggregationIndexPidSn() {
+        return createAdditionalSnapshotAggregationIndexPidSn;
+    }
+
+    @Override
+    public boolean shouldCreateAdditionalSnapshotAggregationIndexPidSnId() {
+        return createAdditionalSnapshotAggregationIndexPidSnId;
     }
 
     @Override
@@ -124,7 +133,9 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
         }
         final DefaultMongoReadJournalConfig that = (DefaultMongoReadJournalConfig) o;
         return createAdditionalSnapshotAggregationIndexPidId == that.createAdditionalSnapshotAggregationIndexPidId &&
-                createAdditionalSnapshotAggregationIndexPid == that.createAdditionalSnapshotAggregationIndexPid &&
+                createAdditionalSnapshotAggregationIndexPidSn == that.createAdditionalSnapshotAggregationIndexPidSn &&
+                createAdditionalSnapshotAggregationIndexPidSnId ==
+                        that.createAdditionalSnapshotAggregationIndexPidSnId &&
                 Objects.equals(hintNameFilterPidsThatDoesntContainTagInNewestEntry,
                         that.hintNameFilterPidsThatDoesntContainTagInNewestEntry) &&
                 Objects.equals(hintNameListLatestJournalEntries, that.hintNameListLatestJournalEntries) &&
@@ -133,7 +144,8 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
 
     @Override
     public int hashCode() {
-        return Objects.hash(createAdditionalSnapshotAggregationIndexPidId, createAdditionalSnapshotAggregationIndexPid,
+        return Objects.hash(createAdditionalSnapshotAggregationIndexPidId,
+                createAdditionalSnapshotAggregationIndexPidSn, createAdditionalSnapshotAggregationIndexPidSnId,
                 hintNameFilterPidsThatDoesntContainTagInNewestEntry, hintNameListLatestJournalEntries,
                 listNewestActiveSnapshotsByBatchPidId, listNewestActiveSnapshotsByBatchPid,
                 listNewestActiveSnapshotsByBatchId);
@@ -143,7 +155,8 @@ public final class DefaultMongoReadJournalConfig implements MongoReadJournalConf
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "createAdditionalSnapshotAggregationIndexPidId=" + createAdditionalSnapshotAggregationIndexPidId +
-                ", createAdditionalSnapshotAggregationIndexPid=" + createAdditionalSnapshotAggregationIndexPid +
+                ", createAdditionalSnapshotAggregationIndexPidSn=" + createAdditionalSnapshotAggregationIndexPidSn +
+                ", createAdditionalSnapshotAggregationIndexPidSnId=" + createAdditionalSnapshotAggregationIndexPidSnId +
                 ", hintNameFilterPidsThatDoesntContainTagInNewestEntry=" +
                 hintNameFilterPidsThatDoesntContainTagInNewestEntry +
                 ", hintNameListLatestJournalEntries=" + hintNameListLatestJournalEntries +

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
@@ -32,10 +32,16 @@ public interface MongoReadJournalConfig {
     boolean shouldCreateAdditionalSnapshotAggregationIndexPidId();
 
     /**
-     * @return whether additional index for "pid" should be created in order to speed up MongoReadJournal
+     * @return whether additional index for "pid" + "sn" should be created in order to speed up MongoReadJournal
      * aggregation queries on the snapshot collection.
      */
-    boolean shouldCreateAdditionalSnapshotAggregationIndexPid();
+    boolean shouldCreateAdditionalSnapshotAggregationIndexPidSn();
+
+    /**
+     * @return whether additional index for "pid" + "sn" + "_id" should be created in order to speed up MongoReadJournal
+     * aggregation queries on the snapshot collection.
+     */
+    boolean shouldCreateAdditionalSnapshotAggregationIndexPidSnId();
 
     /**
      * @return the optional hint name for aggregation done in {@code filterPidsThatDoesntContainTagInNewestEntry}.
@@ -78,10 +84,16 @@ public interface MongoReadJournalConfig {
         SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID("should-create-additional-snapshot-aggregation-index-pid-id", false),
 
         /**
-         * Whether additional index for "pid" should be created in order to speed up MongoReadJournal aggregation
+         * Whether additional index for "pid" + "sn" should be created in order to speed up MongoReadJournal aggregation
          * queries on the snapshot collection.
          */
-        SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID("should-create-additional-snapshot-aggregation-index-pid", false),
+        SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN("should-create-additional-snapshot-aggregation-index-pid-sn", false),
+
+        /**
+         * Whether additional index for "pid" + "sn" + "_id" should be created in order to speed up MongoReadJournal aggregation
+         * queries on the snapshot collection.
+         */
+        SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID("should-create-additional-snapshot-aggregation-index-pid-sn-id", false),
 
         /**
          * Hint name for aggregation done in {@code filterPidsThatDoesntContainTagInNewestEntry}.

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/cleanup/Cleanup.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/cleanup/Cleanup.java
@@ -59,7 +59,8 @@ final class Cleanup {
         this.deleteFinalDeletedSnapshot = deleteFinalDeletedSnapshot;
 
         readJournal.ensureSnapshotCollectionPidIdIndex()
-                .thenCompose(done -> readJournal.ensureSnapshotCollectionPidIndex())
+                .thenCompose(done -> readJournal.ensureSnapshotCollectionPidSnIndex())
+                .thenCompose(done -> readJournal.ensureSnapshotCollectionPidSnIdIndex())
                 .exceptionally(e -> {
                     logger.error(e, "Failed to create index for read journal snapshot aggregation queries");
                     return null;

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -20,11 +20,20 @@ ditto {
     database = ${?MONGO_DB_DATABASE}
 
     read-journal {
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
       should-create-additional-snapshot-aggregation-index-pid-id = false
       should-create-additional-snapshot-aggregation-index-pid-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID}
 
-      should-create-additional-snapshot-aggregation-index-pid = false
-      should-create-additional-snapshot-aggregation-index-pid = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID}
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn = false
+      should-create-additional-snapshot-aggregation-index-pid-sn = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN}
+
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -26,11 +26,20 @@ ditto {
     database = ${?MONGO_DB_DATABASE}
 
     read-journal {
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
       should-create-additional-snapshot-aggregation-index-pid-id = false
       should-create-additional-snapshot-aggregation-index-pid-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_ID}
 
-      should-create-additional-snapshot-aggregation-index-pid = false
-      should-create-additional-snapshot-aggregation-index-pid = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID}
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn = false
+      should-create-additional-snapshot-aggregation-index-pid-sn = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN}
+
+      # additional index which speeds up background (e.g. cleanup) aggregation queries
+      # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = ${?MONGODB_READ_JOURNAL_HINT_NAME_FILTER_PIDS_THAT_DOESNT_CONTAIN_TAG_IN_NEWEST_ENTRY}


### PR DESCRIPTION
* next round: a total of 3 additional indexes need to be in place to have MongoDB 6 aggregation queries perform the same as with MongoDB 5
* documented in "MongoDB tuning" section in documentation
* removed/replaced index which is not needed
* fixed Helm configuration which caused empty config values