### PR TITLE
fix MongoReadJournalIT

### DIFF
--- a/internal/utils/persistence/src/test/resources/mongo-read-journal-test.conf
+++ b/internal/utils/persistence/src/test/resources/mongo-read-journal-test.conf
@@ -1,5 +1,6 @@
+// mongodb.uri needs to be some valid string
+ditto = { mongodb.uri = "" }
 // mongo URI set in test
-ditto = {}
 pekko.contrib.persistence.mongodb.mongo.mongouri = null
 
 pekko {


### PR DESCRIPTION
 - recent changes in MongoReadJournalIT caused the setup method to fail with NPE
 - added mongodb.uri as a valid string to fix that