### PR TITLE
Integrate AWS IAM Role-based Authentication for MongoDB Atlas

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,6 +59,8 @@
         <!-- Keep these version consistent with pekko-persistence-mongodb.version's build.sbt -->
         <mongo-java-driver.version>5.1.1</mongo-java-driver.version>
 
+        <mongo-driver-sync.version>5.1.2</mongo-driver-sync.version>
+
         <jjwt.version>0.12.5</jjwt.version>
         <asm.version>9.2</asm.version>
         <qpid-jms-client.version>1.11.0</qpid-jms-client.version>
@@ -111,6 +113,7 @@
         <scalatest.version>3.2.17</scalatest.version>
         <docker-java.version>3.3.3</docker-java.version>
         <system-rules.version>1.19.0</system-rules.version>
+        <awssdk.version>2.26.21</awssdk.version>
     </properties>
 
     <dependencyManagement>
@@ -205,7 +208,11 @@
                 <artifactId>mongo-scala-driver_2.13</artifactId>
                 <version>${mongo-java-driver.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-sync</artifactId>
+                <version>${mongo-driver-sync.version}</version>
+            </dependency>
 
             <!-- Pekko Management -->
             <dependency>
@@ -801,6 +808,18 @@
                 <groupId>org.atteo.classindex</groupId>
                 <artifactId>classindex</artifactId>
                 <version>${classindex.version}</version>
+            </dependency>
+
+            <!-- ### aws sdk ### -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>sts</artifactId>
+                <version>${awssdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>auth</artifactId>
+                <version>${awssdk.version}</version>
             </dependency>
 
             <!-- ### Provided - own artifacts ### -->

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,6 +59,8 @@
         <!-- Keep these version consistent with pekko-persistence-mongodb.version's build.sbt -->
         <mongo-java-driver.version>5.1.1</mongo-java-driver.version>
 
+        <!-- AWS SDK version needed for MongoDB AWS IAM authentication -->
+        <awssdk.version>2.26.21</awssdk.version>
 
         <jjwt.version>0.12.5</jjwt.version>
         <asm.version>9.2</asm.version>
@@ -112,7 +114,6 @@
         <scalatest.version>3.2.17</scalatest.version>
         <docker-java.version>3.3.3</docker-java.version>
         <system-rules.version>1.19.0</system-rules.version>
-        <awssdk.version>2.26.21</awssdk.version>
     </properties>
 
     <dependencyManagement>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,6 @@
         <!-- Keep these version consistent with pekko-persistence-mongodb.version's build.sbt -->
         <mongo-java-driver.version>5.1.1</mongo-java-driver.version>
 
-        <mongo-driver-sync.version>5.1.2</mongo-driver-sync.version>
 
         <jjwt.version>0.12.5</jjwt.version>
         <asm.version>9.2</asm.version>
@@ -207,11 +206,6 @@
                 <groupId>org.mongodb.scala</groupId>
                 <artifactId>mongo-scala-driver_2.13</artifactId>
                 <version>${mongo-java-driver.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-sync</artifactId>
-                <version>${mongo-driver-sync.version}</version>
             </dependency>
 
             <!-- Pekko Management -->

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,8 +16,8 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.11  # chart version is effectively set by release-job
-appVersion: 3.5.10
+version: 3.5.12  # chart version is effectively set by release-job
+appVersion: 3.5.12
 keywords:
   - iot-chart
   - digital-twin

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
 version: 3.5.12  # chart version is effectively set by release-job
-appVersion: 3.5.12
+appVersion: 3.5.10
 keywords:
   - iot-chart
   - digital-twin

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,8 +16,8 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.10  # chart version is effectively set by release-job
-appVersion: 3.5.10
+version: 3.5.12  # chart version is effectively set by release-job
+appVersion: 3.5.12
 keywords:
   - iot-chart
   - digital-twin

--- a/deployment/helm/ditto/templates/_helpers.tpl
+++ b/deployment/helm/ditto/templates/_helpers.tpl
@@ -70,3 +70,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get IAM Role ARN from Values if USE_IAM_ROLE is true
+*/}}
+{{- define "ditto.iamRoleArn" -}}
+{{- if .Values.serviceAccount.isUseAwsIamRole -}}
+  {{ .Values.serviceAccount.roleArn }}
+{{- else -}}
+  ""
+{{- end -}}
+{{- end -}}

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -284,12 +284,12 @@ spec:
             {{- if .Values.connectivity.extraEnv }}
               {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
             {{- end }}
-            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.isUseAwsIamRole }}
             - name: AWS_ROLE_ARN
               value: "{{ .Values.serviceAccount.roleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
-            {{ - end }}
+            {{- end }}
             - name: USE_AWS_IAM_ROLE
               value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -284,6 +284,14 @@ spec:
             {{- if .Values.connectivity.extraEnv }}
               {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
             {{- end }}
+            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.serviceAccount.roleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+            {{ - end }}
+            - name: USE_AWS_IAM_ROLE
+              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -268,12 +268,12 @@ spec:
             {{- if .Values.policies.extraEnv }}
               {{- toYaml .Values.policies.extraEnv | nindent 12 }}
             {{- end }}
-            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.isUseAwsIamRole }}
             - name: AWS_ROLE_ARN
               value: "{{ .Values.serviceAccount.roleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
-            {{ - end }}
+            {{- end }}
             - name: USE_AWS_IAM_ROLE
               value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -268,6 +268,14 @@ spec:
             {{- if .Values.policies.extraEnv }}
               {{- toYaml .Values.policies.extraEnv | nindent 12 }}
             {{- end }}
+            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.serviceAccount.roleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+            {{ - end }}
+            - name: USE_AWS_IAM_ROLE
+              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:
             - name: http
               containerPort: 8080

--- a/deployment/helm/ditto/templates/serviceaccount.yaml
+++ b/deployment/helm/ditto/templates/serviceaccount.yaml
@@ -17,8 +17,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "ditto.name" . }}
   annotations:
-    { { - if .Values.serviceAccount.isUseAwsIamRole } }
-    eks.amazonaws.com/role-arn: { { .Values.serviceAccount.roleArn } }
-    { { - end } }
+    {{- if .Values.serviceAccount.isUseAwsIamRole }}
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn }}
+    {{- end }}
 {{ include "ditto.labels" . | indent 4 }}
 {{- end -}}

--- a/deployment/helm/ditto/templates/serviceaccount.yaml
+++ b/deployment/helm/ditto/templates/serviceaccount.yaml
@@ -16,5 +16,9 @@ metadata:
   name: {{ template "ditto.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "ditto.name" . }}
+  annotations:
+    { { - if .Values.serviceAccount.isUseAwsIamRole } }
+    eks.amazonaws.com/role-arn: { { .Values.serviceAccount.roleArn } }
+    { { - end } }
 {{ include "ditto.labels" . | indent 4 }}
 {{- end -}}

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -275,12 +275,12 @@ spec:
             {{- if .Values.things.extraEnv }}
               {{- toYaml .Values.things.extraEnv | nindent 12 }}
             {{- end }}
-            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.isUseAwsIamRole }}
             - name: AWS_ROLE_ARN
               value: "{{ .Values.serviceAccount.roleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
-            {{ - end }}
+            {{- end }}
             - name: USE_AWS_IAM_ROLE
               value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -275,6 +275,14 @@ spec:
             {{- if .Values.things.extraEnv }}
               {{- toYaml .Values.things.extraEnv | nindent 12 }}
             {{- end }}
+            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.serviceAccount.roleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+            {{ - end }}
+            - name: USE_AWS_IAM_ROLE
+              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -271,7 +271,7 @@ spec:
             {{- end }}
             - name: USE_AWS_IAM_ROLE
               value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
-        ports:
+          ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}
               protocol: TCP

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -263,7 +263,15 @@ spec:
             {{- if .Values.thingsSearch.extraEnv }}
               {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
             {{- end }}
-          ports:
+            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.serviceAccount.roleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+            {{ - end }}
+            - name: USE_AWS_IAM_ROLE
+              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
+        ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}
               protocol: TCP

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -263,12 +263,12 @@ spec:
             {{- if .Values.thingsSearch.extraEnv }}
               {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
             {{- end }}
-            {{ - if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.isUseAwsIamRole }}
             - name: AWS_ROLE_ARN
               value: "{{ .Values.serviceAccount.roleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
-            {{ - end }}
+            {{- end }}
             - name: USE_AWS_IAM_ROLE
               value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
         ports:

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -19,7 +19,13 @@ serviceAccount:
   # name is the name of the service account to use
   #  If not set and create is true, a name is generated using the fullname template
   name:
+  # isUseAwsIamRole specifies whether to use an AWS IAM Role for Service Accounts (IRSA).
+  # Set to true to use IRSA, which allows the pod to assume an IAM role.
+  # When set to true, ensure that roleArn is specified.
   isUseAwsIamRole: false
+  # roleArn is the Amazon Resource Name (ARN) of the IAM role to be assumed by the service account.
+  # This is required if isUseAwsIamRole is set to true.
+  # Example: arn:aws:iam::<account-id>:role/<role-name>
   roleArn: ""
 
 rbac:

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -19,6 +19,8 @@ serviceAccount:
   # name is the name of the service account to use
   #  If not set and create is true, a name is generated using the fullname template
   name:
+  isUseAwsIamRole: false
+  roleArn: ""
 
 rbac:
   # enabled controls whether RBAC resources will be created

--- a/internal/utils/config/src/main/resources/ditto-mongo.conf
+++ b/internal/utils/config/src/main/resources/ditto-mongo.conf
@@ -50,6 +50,8 @@ ditto.mongodb {
     retryWrites = true
     retryWrites = ${?MONGO_DB_RETRY_WRITES}
 
+    # Determines whether to use AWS IAM roles for authentication with MongoDB.
+    # When set to true, MongoDB will use the AWS IAM role credentials.
     useAwsIamRole = false
     useAwsIamRole = ${?USE_AWS_IAM_ROLE}
 

--- a/internal/utils/config/src/main/resources/ditto-mongo.conf
+++ b/internal/utils/config/src/main/resources/ditto-mongo.conf
@@ -50,6 +50,9 @@ ditto.mongodb {
     retryWrites = true
     retryWrites = ${?MONGO_DB_RETRY_WRITES}
 
+    useAwsIamRole = false
+    useAwsIamRole = ${?USE_AWS_IAM_ROLE}
+
     // all options in the "extra-options" are simply added to the MongoDB URI
     // that way any available URI option may be added, even if not explicitly specified in Ditto's mongo config
     extra-uri-options {

--- a/internal/utils/persistence/pom.xml
+++ b/internal/utils/persistence/pom.xml
@@ -162,6 +162,18 @@
             <groupId>org.apache.pekko</groupId>
             <artifactId>pekko-persistence-query_${scala.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/internal/utils/persistence/pom.xml
+++ b/internal/utils/persistence/pom.xml
@@ -170,10 +170,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
@@ -25,7 +25,14 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.net.ssl.SSLContext;
 
-import com.mongodb.*;
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcern;
+import com.mongodb.MongoCredential;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
@@ -485,9 +492,9 @@ public final class MongoClientWrapper implements DittoMongoClient {
         }
 
         private void applyAwsIamRoleSettings() {
-            AwsCredentialsProvider credentialsProvider = getAwsCredentialsProvider();
-            AwsCredentials credentials = credentialsProvider.resolveCredentials();
-            MongoCredential credential = MongoCredential.createAwsCredential(
+            final AwsCredentialsProvider credentialsProvider = getAwsCredentialsProvider();
+            final AwsCredentials credentials = credentialsProvider.resolveCredentials();
+            final MongoCredential credential = MongoCredential.createAwsCredential(
                     credentials.accessKeyId(),
                     credentials.secretAccessKey().toCharArray()
             );

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
@@ -25,18 +25,12 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.net.ssl.SSLContext;
 
+import com.mongodb.*;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
 import org.reactivestreams.Publisher;
 
-import com.mongodb.ClientSessionOptions;
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoClientSettings;
-import com.mongodb.ReadConcern;
-import com.mongodb.ReadPreference;
-import com.mongodb.ServerAddress;
-import com.mongodb.WriteConcern;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.TransportSettings;
@@ -53,6 +47,9 @@ import com.mongodb.reactivestreams.client.MongoDatabase;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 /**
  * Default implementation of DittoMongoClient.
@@ -259,6 +256,7 @@ public final class MongoClientWrapper implements DittoMongoClient {
         @Nullable private ConnectionString connectionString;
         private String defaultDatabaseName;
         private boolean sslEnabled;
+        private boolean isUseAwsIamRole;
         @Nullable private EventLoopGroup eventLoopGroup;
 
         private MongoClientWrapperBuilder() {
@@ -307,12 +305,18 @@ public final class MongoClientWrapper implements DittoMongoClient {
 
             final MongoDbConfig.OptionsConfig optionsConfig = mongoDbConfig.getOptionsConfig();
             builder.enableSsl(optionsConfig.isSslEnabled());
+            builder.useAwsIamRole(optionsConfig.isUseAwsIamRole());
             builder.setReadPreference(optionsConfig.readPreference().getMongoReadPreference());
             builder.setReadConcern(optionsConfig.readConcern().getMongoReadConcern());
             builder.setWriteConcern(optionsConfig.writeConcern());
             builder.setRetryWrites(optionsConfig.isRetryWrites());
 
             return builder;
+        }
+
+        public MongoClientWrapperBuilder useAwsIamRole(boolean useAwsIamRole) {
+            this.isUseAwsIamRole = useAwsIamRole;
+            return this;
         }
 
         @Override
@@ -440,6 +444,10 @@ public final class MongoClientWrapper implements DittoMongoClient {
         public MongoClientWrapper build() {
             buildAndApplySslSettings();
 
+            if (isUseAwsIamRole) {
+                applyAwsIamRoleSettings();
+            }
+
             return new MongoClientWrapper(mongoClientSettingsBuilder.build(), defaultDatabaseName,
                     dittoMongoClientSettingsBuilder.build(), eventLoopGroup);
         }
@@ -476,6 +484,18 @@ public final class MongoClientWrapper implements DittoMongoClient {
             return result;
         }
 
-    }
+        private void applyAwsIamRoleSettings() {
+            AwsCredentialsProvider credentialsProvider = getAwsCredentialsProvider();
+            AwsCredentials credentials = credentialsProvider.resolveCredentials();
+            MongoCredential credential = MongoCredential.createAwsCredential(
+                    credentials.accessKeyId(),
+                    credentials.secretAccessKey().toCharArray()
+            );
+            mongoClientSettingsBuilder.credential(credential);
+        }
 
+        private static AwsCredentialsProvider getAwsCredentialsProvider() {
+            return DefaultCredentialsProvider.create();
+        }
+    }
 }

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -39,6 +39,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
      */
     static final String CONFIG_PATH = "options";
 
+    private final boolean useAwsIamRole;
     private final boolean sslEnabled;
     private final ReadPreference readPreference;
     private final ReadConcern readConcern;
@@ -47,6 +48,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     private final Map<String, Object> extraUriOptions;
 
     private DefaultOptionsConfig(final ScopedConfig config) {
+        useAwsIamRole = config.getBoolean(OptionsConfigValue.USE_AWS_IAM_ROLE.getConfigPath());
         sslEnabled = config.getBoolean(OptionsConfigValue.SSL_ENABLED.getConfigPath());
         final var readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
         readPreference = ReadPreference.ofReadPreference(readPreferenceString)
@@ -116,6 +118,11 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     @Override
     public boolean isRetryWrites() {
         return retryWrites;
+    }
+
+    @Override
+    public boolean isUseAwsIamRole() {
+        return useAwsIamRole;
     }
 
     @Override

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -139,7 +139,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
             return false;
         }
         final DefaultOptionsConfig that = (DefaultOptionsConfig) o;
-        return sslEnabled == that.sslEnabled && retryWrites == that.retryWrites &&
+        return useAwsIamRole == that.useAwsIamRole && sslEnabled == that.sslEnabled && retryWrites == that.retryWrites &&
                 readPreference == that.readPreference &&
                 readConcern == that.readConcern &&
                 Objects.equals(writeConcern, that.writeConcern) &&
@@ -148,13 +148,14 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sslEnabled, readPreference, readConcern, writeConcern, retryWrites, extraUriOptions);
+        return Objects.hash(useAwsIamRole, sslEnabled, readPreference, readConcern, writeConcern, retryWrites, extraUriOptions);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "sslEnabled=" + sslEnabled +
+                "useAwsIamRole=" + useAwsIamRole +
+                ", sslEnabled=" + sslEnabled +
                 ", readPreference=" + readPreference +
                 ", readConcern=" + readConcern +
                 ", writeConcern=" + writeConcern +

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
@@ -166,6 +166,13 @@ public interface MongoDbConfig {
         boolean isRetryWrites();
 
         /**
+         * Indicates whether to use AWS IAM role for authentication.
+         *
+         * @return {@code true} if IAM role should be used, {@code false} otherwise.
+         */
+        boolean isUseAwsIamRole();
+
+        /**
          * Gets the extra options to add to the configured MongoDB {@code uri}.
          *
          * @return the extra options.
@@ -202,6 +209,11 @@ public interface MongoDbConfig {
              * Determines the "retryWrites" setting used for MongoDB connections.
              */
             RETRY_WRITES("retryWrites", true),
+
+            /**
+             * Determines whether IAM role should be used for authentication.
+             */
+            USE_AWS_IAM_ROLE("useAwsIamRole", false),
 
             /**
              * The extra options to add to the configured MongoDB {@code uri}.


### PR DESCRIPTION
This PR introduces the integration of AWS IAM Role-based authentication for MongoDB Atlas in our application ([Passwordless authentication of MongoDB with AWS IAM](https://www.mongodb.com/docs/atlas/security/passwordless-authentication/)). By leveraging the AWS SDK's DefaultCredentialsProvider, we ensure secure and seamless authentication to MongoDB Atlas using the IAM role associated with the Kubernetes service account. The environment variables set by the service account are utilized to fetch the necessary credentials dynamically within the application. This implementation enhances security by eliminating the need for hardcoded credentials and leverages AWS's robust IAM policies for access control.