### PR TITLE
provide AWS credential for MongoDB IAM authentication via supplier

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.14  # chart version is effectively set by release-job
+version: 3.5.16  # chart version is effectively set by release-job
 appVersion: 3.5.10
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/_helpers.tpl
+++ b/deployment/helm/ditto/templates/_helpers.tpl
@@ -70,25 +70,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Get IAM Role ARN from Values if USE_IAM_ROLE is true
-*/}}
-{{- define "ditto.iamRoleArn" -}}
-{{- if .Values.serviceAccount.isUseAwsIamRole -}}
-  {{ .Values.serviceAccount.roleArn }}
-{{- else -}}
-  ""
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get AWS session name from Values if USE_IAM_ROLE is true
-*/}}
-{{- define "ditto.awsSessionName" -}}
-{{- if .Values.serviceAccount.isUseAwsIamRole -}}
-  {{ .Values.serviceAccount.awsSessionName }}
-{{- else -}}
-  "defaultSessionName"
-{{- end -}}
-{{- end -}}

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -284,16 +284,18 @@ spec:
             {{- if .Values.connectivity.extraEnv }}
               {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
             {{- end }}
-            {{- if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.useAwsIamRole }}
+            - name: MONGO_DB_AWS_REGION
+              value: "{{ .Values.serviceAccount.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
-              value: "{{ .Values.serviceAccount.roleArn }}"
+              value: "{{ .Values.serviceAccount.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.serviceAccount.awsSessionName }}"
             {{- end }}
             - name: MONGO_DB_USE_AWS_IAM_ROLE
-              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
+              value: "{{ printf "%t" .Values.serviceAccount.useAwsIamRole }}"
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -268,16 +268,18 @@ spec:
             {{- if .Values.policies.extraEnv }}
               {{- toYaml .Values.policies.extraEnv | nindent 12 }}
             {{- end }}
-            {{- if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.useAwsIamRole }}
+            - name: MONGO_DB_AWS_REGION
+              value: "{{ .Values.serviceAccount.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
-              value: "{{ .Values.serviceAccount.roleArn }}"
+              value: "{{ .Values.serviceAccount.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.serviceAccount.awsSessionName }}"
             {{- end }}
             - name: MONGO_DB_USE_AWS_IAM_ROLE
-              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
+              value: "{{ printf "%t" .Values.serviceAccount.useAwsIamRole }}"
           ports:
             - name: http
               containerPort: 8080

--- a/deployment/helm/ditto/templates/serviceaccount.yaml
+++ b/deployment/helm/ditto/templates/serviceaccount.yaml
@@ -17,8 +17,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "ditto.name" . }}
   annotations:
-    {{- if .Values.serviceAccount.isUseAwsIamRole }}
-    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn }}
+    {{- if .Values.serviceAccount.useAwsIamRole }}
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.awsRoleArn }}
     {{- end }}
 {{ include "ditto.labels" . | indent 4 }}
 {{- end -}}

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -351,16 +351,18 @@ spec:
             {{- if .Values.things.extraEnv }}
               {{- toYaml .Values.things.extraEnv | nindent 12 }}
             {{- end }}
-            {{- if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.useAwsIamRole }}
+            - name: MONGO_DB_AWS_REGION
+              value: "{{ .Values.serviceAccount.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
-              value: "{{ .Values.serviceAccount.roleArn }}"
+              value: "{{ .Values.serviceAccount.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.serviceAccount.awsSessionName }}"
             {{- end }}
             - name: MONGO_DB_USE_AWS_IAM_ROLE
-              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
+              value: "{{ printf "%t" .Values.serviceAccount.useAwsIamRole }}"
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -263,16 +263,18 @@ spec:
             {{- if .Values.thingsSearch.extraEnv }}
               {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
             {{- end }}
-            {{- if .Values.serviceAccount.isUseAwsIamRole }}
+            {{- if .Values.serviceAccount.useAwsIamRole }}
+            - name: MONGO_DB_AWS_REGION
+              value: "{{ .Values.serviceAccount.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
-              value: "{{ .Values.serviceAccount.roleArn }}"
+              value: "{{ .Values.serviceAccount.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.serviceAccount.awsSessionName }}"
             {{- end }}
             - name: MONGO_DB_USE_AWS_IAM_ROLE
-              value: "{{ printf "%t" .Values.serviceAccount.isUseAwsIamRole }}"
+              value: "{{ printf "%t" .Values.serviceAccount.useAwsIamRole }}"
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -19,14 +19,16 @@ serviceAccount:
   # name is the name of the service account to use
   #  If not set and create is true, a name is generated using the fullname template
   name:
-  # isUseAwsIamRole specifies whether to use an AWS IAM Role for Service Accounts (IRSA).
+  # useAwsIamRole specifies whether to use an AWS IAM Role for Service Accounts (IRSA).
   # Set to true to use IRSA, which allows the pod to assume an IAM role.
-  # When set to true, ensure that roleArn is specified.
-  isUseAwsIamRole: false
-  # roleArn is the Amazon Resource Name (ARN) of the IAM role to be assumed by the service account.
-  # This is required if isUseAwsIamRole is set to true.
+  # When set to true, ensure that awsRoleArn is specified.
+  useAwsIamRole: false
+  # awsRegion
+  awsRegion: ""
+  # awsRoleArn is the Amazon Resource Name (ARN) of the IAM role to be assumed by the service account.
+  # This is required if useAwsIamRole is set to true.
   # Example: arn:aws:iam::<account-id>:role/<role-name>
-  roleArn: ""
+  awsRoleArn: ""
   # awsSessionName is the name of the session when assuming the AWS role.
   # This can be used to identify the session in logs or IAM policies.
   # Default is "dittoSession".

--- a/internal/utils/config/src/main/resources/ditto-mongo.conf
+++ b/internal/utils/config/src/main/resources/ditto-mongo.conf
@@ -55,6 +55,11 @@ ditto.mongodb {
     useAwsIamRole = false
     useAwsIamRole = ${?MONGO_DB_USE_AWS_IAM_ROLE}
 
+    # Specifies the AWS region - if this is an empty string, the AWS SDK will attempt to identify the
+    # region automatically based on the environment and eventually EC2 instances
+    awsRegion = ""
+    awsRegion = ${?MONGO_DB_AWS_REGION}
+
     # Specifies the ARN of the AWS IAM Role to be assumed for MongoDB authentication.
     awsRoleArn = ""
     awsRoleArn = ${?MONGO_DB_AWS_ROLE_ARN}

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -40,6 +40,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     static final String CONFIG_PATH = "options";
 
     private final boolean useAwsIamRole;
+    private final String awsRegion;
     private final String awsArnRole;
     private final String awsSessionName;
     private final boolean sslEnabled;
@@ -51,9 +52,10 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
 
     private DefaultOptionsConfig(final ScopedConfig config) {
         useAwsIamRole = config.getBoolean(OptionsConfigValue.USE_AWS_IAM_ROLE.getConfigPath());
+        awsRegion = config.getString(OptionsConfigValue.AWS_REGION.getConfigPath());
         awsArnRole = config.getString(OptionsConfigValue.AWS_ROLE_ARN.getConfigPath());
         sslEnabled = config.getBoolean(OptionsConfigValue.SSL_ENABLED.getConfigPath());
-        this.awsSessionName = config.getString(OptionsConfigValue.AWS_SESSION_NAME.getConfigPath());;
+        this.awsSessionName = config.getString(OptionsConfigValue.AWS_SESSION_NAME.getConfigPath());
         final var readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
         readPreference = ReadPreference.ofReadPreference(readPreferenceString)
                 .orElseThrow(() -> {
@@ -130,12 +132,17 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     }
 
     @Override
+    public String awsRegion() {
+        return awsRegion;
+    }
+
+    @Override
     public String awsRoleArn() {
         return awsArnRole;
     }
 
     @Override
-    public String awsSessionName() { return awsSessionName; }
+    public String awsSessionName() {return awsSessionName;}
 
     @Override
     public Map<String, Object> extraUriOptions() {
@@ -152,6 +159,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
         }
         final DefaultOptionsConfig that = (DefaultOptionsConfig) o;
         return useAwsIamRole == that.useAwsIamRole
+                && Objects.equals(awsRegion, that.awsRegion)
                 && Objects.equals(awsArnRole, that.awsArnRole)
                 && Objects.equals(awsSessionName, that.awsSessionName)
                 && sslEnabled == that.sslEnabled
@@ -164,13 +172,15 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(useAwsIamRole, awsArnRole, awsSessionName, sslEnabled, readPreference, readConcern, writeConcern, retryWrites, extraUriOptions);
+        return Objects.hash(useAwsIamRole, awsRegion, awsArnRole, awsArnRole, awsSessionName, sslEnabled,
+                readPreference, readConcern, writeConcern, retryWrites, extraUriOptions);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "useAwsIamRole=" + useAwsIamRole +
+                ", awsRegion=" + awsRegion +
                 ", awsArnRole=" + awsArnRole +
                 ", awsSessionName=" + awsSessionName +
                 ", sslEnabled=" + sslEnabled +

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
@@ -173,12 +173,20 @@ public interface MongoDbConfig {
         boolean isUseAwsIamRole();
 
         /**
+         * Retrieves the AWS region used for IAM authentication.
+         * If this is an empty string, the AWS SDK will attempt to identify the region automatically based on the
+         * environment and eventually EC2 instances.
+         *
+         * @return the AWS region as a String.
+         */
+        String awsRegion();
+
+        /**
          * Retrieves the AWS IAM Role ARN to be assumed for authentication.
          *
          * @return the aws role ARN as a String.
          */
         String awsRoleArn();
-
 
         /**
          * Retrieves the AWS session name to be used when assuming the IAM role.
@@ -229,6 +237,11 @@ public interface MongoDbConfig {
              * Determines whether IAM role should be used for authentication.
              */
             USE_AWS_IAM_ROLE("useAwsIamRole", false),
+
+            /**
+             * Specifies the region to use in AWS IAM based MongoDB authentication.
+             */
+            AWS_REGION("awsRegion", ""),
 
             /**
              * Specifies the ARN of the AWS IAM Role to be assumed for MongoDB authentication.


### PR DESCRIPTION
* in order to allow refreshing the credentials
* also make AWS region configurable

Follow-up of and related to #1987 and #1997