### PR TITLE
add securtyContext to dittoui-deployment.yaml

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.5.16  # chart version is effectively set by release-job
+version: 3.5.17  # chart version is effectively set by release-job
 appVersion: 3.5.10
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/dittoui-deployment.yaml
+++ b/deployment/helm/ditto/templates/dittoui-deployment.yaml
@@ -70,6 +70,10 @@ spec:
             limits:
               # cpu: # don't limit
               memory: {{ .Values.dittoui.resources.memoryMi }}Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
           volumeMounts:
             - name: dittoui-nginx-conf
               mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
 - necessary in order to remove security check warnings
 - I haven't added them configurable as I'm not sure if we should, but leave it up to your opinion @thjaeckle :)