### PR TITLE
fix search background sync being stuck

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -12,7 +12,7 @@ version: '3.4'
 
 services:
   mongodb:
-    image: docker.io/mongo:6.0
+    image: docker.io/mongo:7.0
     deploy:
       resources:
         limits:

--- a/deployment/docker/sandbox/docker-compose.yml
+++ b/deployment/docker/sandbox/docker-compose.yml
@@ -12,7 +12,7 @@ version: '3.4'
 
 services:
   mongodb:
-    image: docker.io/mongo:6.0
+    image: docker.io/mongo:7.0
     deploy:
       resources:
         limits:

--- a/deployment/kubernetes/deploymentFiles/mongodb-statefulset/mongodb-statefulset.yaml
+++ b/deployment/kubernetes/deploymentFiles/mongodb-statefulset/mongodb-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: mongodb
-          image: docker.io/mongo:6.0
+          image: docker.io/mongo:7.0
           command:
             - mongod
             - --bind_ip

--- a/deployment/kubernetes/deploymentFiles/mongodb/mongodb.yaml
+++ b/deployment/kubernetes/deploymentFiles/mongodb/mongodb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: docker.io/mongo:6.0
+          image: docker.io/mongo:7.0
           command:
             - mongod
             - --storageEngine


### PR DESCRIPTION
* reason was a change in behavior of MongoDB reactive API which does no longer throw an exception for already created capped collections
* changed our logic to first lookup existing collections and only try creating the capped collection if it does not yet exist