### PR TITLE
downgrade Rhino version to latest stable

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -80,7 +80,7 @@
 
         <jsr305.version>3.0.2</jsr305.version>
 
-        <rhino.version>1.7.15</rhino.version>
+        <rhino.version>1.7.14</rhino.version>
         <!--
             be aware that connectivity mapping has a direct dependency on files inside this library.
             when updating this version, you should also check if the used paths and files still exist

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.6.0  # chart version is effectively set by release-job
+version: 3.6.1  # chart version is effectively set by release-job
 appVersion: 3.6.0
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -300,7 +300,6 @@ spec:
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.dbconfig.connectivity.awsSessionName }}"
             {{- end }}
-
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -292,7 +292,6 @@ spec:
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.dbconfig.policies.awsSessionName }}"
             {{- end }}
-
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
* with new Rhino version there seem to be a change in behavior of Java-type to JS-type mapping