### PR TITLE
enhance Helm chart to configure Ditto services via ConfigMap

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.6.1  # chart version is effectively set by release-job
+version: 3.6.2  # chart version is effectively set by release-job
 appVersion: 3.6.1
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/service-config/connectivity-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/connectivity-extension.conf.tpl
@@ -1,0 +1,14 @@
+# Ditto "Connectivity" configuration extension file to be placed at /opt/ditto/connectivity-extension.conf
+ditto {
+  connectivity {
+    connection {
+      event {
+        historical-headers-to-persist = [
+        {{- range $index, $header := .Values.connectivity.config.persistence.events.historicalHeadersToPersist }}
+          "{{$header}}"
+        {{- end }}
+        ]
+      }
+    }
+  }
+}

--- a/deployment/helm/ditto/service-config/gateway-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/gateway-extension.conf.tpl
@@ -1,0 +1,48 @@
+# Ditto "Gateway" configuration extension file to be placed at /opt/ditto/gateway-extension.conf
+ditto {
+  gateway {
+    authentication {
+      oauth {
+        openid-connect-issuers {
+        {{- range $key, $value := .Values.gateway.config.authentication.oauth.openidConnectIssuers }}
+          {{$key}} = {
+            issuer = "{{$value.issuer}}"
+            auth-subjects = [
+            {{- range $index, $subject := $value.authSubjects }}
+              "{{$subject}}"
+            {{- end }}
+            ]
+          }
+        {{- end }}
+        }
+      }
+
+      devops {
+        oauth {
+          openid-connect-issuers {
+          {{- range $key, $value := .Values.gateway.config.authentication.devops.oauth.openidConnectIssuers }}
+            {{$key}} = {
+              issuer = "{{$value.issuer}}"
+              auth-subjects = [
+              {{- range $index, $subject := $value.authSubjects }}
+                "{{$subject}}"
+              {{- end }}
+              ]
+            }
+          {{- end }}
+          }
+        }
+        devops-oauth2-subjects = [
+        {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.oauthSubjects }}
+          "{{$oauthSubject}}"
+        {{- end }}
+        ]
+        status-oauth2-subjects = [
+        {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.statusOauthSubjects }}
+          "{{$oauthSubject}}"
+        {{- end }}
+        ]
+      }
+    }
+  }
+}

--- a/deployment/helm/ditto/service-config/policies-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/policies-extension.conf.tpl
@@ -1,0 +1,50 @@
+# Ditto "Policies" configuration extension file to be placed at /opt/ditto/policies-extension.conf
+ditto {
+  entity-creation {
+    grant = [
+    {{- range $grantIdx, $grant := .Values.policies.config.entityCreation.grants }}
+      {
+        resource-types = ["policy"]
+        namespaces = [
+        {{- range $namespaceIdx, $namespace := $grant.namespaces }}
+          "{{$namespace}}"
+        {{- end }}
+        ]
+        auth-subjects = [
+        {{- range $subjectIdx, $subject := $grant.authSubjects }}
+          "{{$subject}}"
+        {{- end }}
+        ]
+      }
+    {{- end }}
+    ]
+    revoke = [
+    {{- range $revokeIdx, $revoke := .Values.policies.config.entityCreation.revokes }}
+      {
+        resource-types = ["policy"]
+        namespaces = [
+        {{- range $namespaceIdx, $namespace := $revoke.namespaces }}
+          "{{$namespace}}"
+        {{- end }}
+        ]
+        auth-subjects = [
+        {{- range $subjectIdx, $subject := $revoke.authSubjects }}
+          "{{$subject}}"
+        {{- end }}
+        ]
+      }
+    {{- end }}
+    ]
+  }
+  policies {
+    policy {
+      event {
+        historical-headers-to-persist = [
+        {{- range $index, $header := .Values.policies.config.persistence.events.historicalHeadersToPersist }}
+          "{{$header}}"
+        {{- end }}
+        ]
+      }
+    }
+  }
+}

--- a/deployment/helm/ditto/service-config/search-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/search-extension.conf.tpl
@@ -1,0 +1,87 @@
+# Ditto "Things Search" configuration extension file to be placed at /opt/ditto/search-extension.conf
+ditto {
+  {{- if .Values.thingsSearch.config.indexedFieldsLimiting.enabled }}
+  extensions {
+    caching-signal-enrichment-facade-provider = "org.eclipse.ditto.thingsearch.service.persistence.write.streaming.SearchIndexingSignalEnrichmentFacadeProvider"
+  }
+  {{- end }}
+
+  search {
+    {{- if .Values.thingsSearch.config.indexedFieldsLimiting.enabled }}
+    namespace-indexed-fields = [
+      {{- range $index, $value := .Values.thingsSearch.config.indexedFieldsLimiting.items }}
+      {
+        namespace-pattern = "{{$value.namespacePattern}}"
+        indexed-fields = [
+        {{- range $fieldIndex, $indexedField := $value.indexedFields }}
+         "{{$indexedField}}"
+        {{- end }}
+        ]
+      }
+      {{- end }}
+    ]
+    {{- end }}
+
+    operator-metrics {
+      custom-metrics {
+        {{- range $cmKey, $cmValue := .Values.thingsSearch.config.operatorMetrics.customMetrics }}
+        {{$cmKey}} = {
+          enabled = {{$cmValue.enabled}}
+          {{- if $cmValue.scrapeInterval }}
+          scrape-interval = "{{$cmValue.scrapeInterval}}"
+          {{- end }}
+          namespaces = [
+          {{- range $index, $namespace := $cmValue.namespaces }}
+            "{{$namespace}}"
+          {{- end }}
+          ]
+          filter = "{{$cmValue.filter}}"
+          tags {
+          {{- range $tagKey, $tagValue := $cmValue.tags }}
+            {{$tagKey}} = "{{$tagValue}}"
+          {{- end }}
+          }
+        }
+        {{- end }}
+      }
+
+      custom-aggregation-metrics {
+        {{- range $camKey, $camValue := .Values.thingsSearch.config.operatorMetrics.customAggregationMetrics }}
+        {{$camKey}} = {
+          enabled = {{$camValue.enabled}}
+          {{- if $camValue.scrapeInterval }}
+          scrape-interval = "{{$camValue.scrapeInterval}}"
+          {{- end }}
+          namespaces = [
+          {{- range $index, $namespace := $camValue.namespaces }}
+            "{{$namespace}}"
+          {{- end }}
+          ]
+          group-by {
+          {{- range $gbKey, $gbValue := $camValue.groupBy }}
+            {{$gbKey}} = "{{$gbValue}}"
+          {{- end }}
+          }
+          tags {
+          {{- range $tagKey, $tagValue := $camValue.tags }}
+            {{$tagKey}} = "{{$tagValue}}"
+          {{- end }}
+          }
+          filters {
+          {{- range $filterKey, $filterValue := $camValue.filters }}
+            {{$filterKey}} {
+              filter = "{{$filterValue.filter}}"
+              inline-placeholder-values {
+              {{- range $inlinePlaceholderKey, $inlinePlaceholderValue := $filterValue.inlinePlaceholderValues }}
+                {{$inlinePlaceholderKey}} = "{{$inlinePlaceholderValue}}"
+              {{- end }}
+              }
+            }
+          {{- end }}
+          }
+        }
+        {{- end }}
+      }
+    }
+  }
+}

--- a/deployment/helm/ditto/service-config/things-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/things-extension.conf.tpl
@@ -1,0 +1,126 @@
+# Ditto "Things" configuration extension file to be placed at /opt/ditto/things-extension.conf
+ditto {
+  entity-creation {
+    grant = [
+    {{- range $grantIdx, $grant := .Values.things.config.entityCreation.grants }}
+      {
+        resource-types = ["thing"]
+        namespaces = [
+        {{- range $namespaceIdx, $namespace := $grant.namespaces }}
+          "{{$namespace}}"
+        {{- end }}
+        ]
+        auth-subjects = [
+        {{- range $subjectIdx, $subject := $grant.authSubjects }}
+          "{{$subject}}"
+        {{- end }}
+        ]
+      }
+    {{- end }}
+    ]
+    revoke = [
+    {{- range $revokeIdx, $revoke := .Values.things.config.entityCreation.revokes }}
+      {
+        resource-types = ["thing"]
+        namespaces = [
+        {{- range $namespaceIdx, $namespace := $revoke.namespaces }}
+          "{{$namespace}}"
+        {{- end }}
+        ]
+        auth-subjects = [
+        {{- range $subjectIdx, $subject := $revoke.authSubjects }}
+          "{{$subject}}"
+        {{- end }}
+        ]
+      }
+    {{- end }}
+    ]
+  }
+  things {
+    thing {
+      event {
+        historical-headers-to-persist = [
+        {{- range $index, $header := .Values.things.config.persistence.events.historicalHeadersToPersist }}
+          "{{$header}}"
+        {{- end }}
+        ]
+      }
+    }
+
+    wot {
+      to-thing-description {
+        json-template {{ .Values.things.config.wot.tdJsonTemplate | indent 8 }}
+      }
+
+      tm-model-validation {
+        dynamic-configuration = [
+        {{- range $dynConfIdx, $dynamicWotTmValidationConfig := .Values.things.config.wot.tmValidation.dynamicConfig }}
+          {
+            validation-context {
+            {{- if $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns }}
+            {{- if gt (len $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns) 0 }}
+              ditto-headers-patterns = [
+              {{- range $dhpIdx, $dittoHeadersPatterns := $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns }}
+                {
+                  {{- range $dhpKey, $dhpVal := $dittoHeadersPatterns }}
+                  {{$dhpKey}} = "{{$dhpVal}}"
+                  {{- end }}
+                }
+              {{- end }}
+              ]
+            {{- end }}
+            {{- end }}
+            {{- if $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns }}
+            {{- if gt (len $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns) 0 }}
+              thing-definition-patterns = [
+              {{- range $tdpIdx, $thingDefinitionPattern := $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns }}
+                "{{$thingDefinitionPattern}}"
+              {{- end }}
+              ]
+            }
+            {{- end }}
+            {{- end }}
+            {{- if $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns }}
+            {{- if gt (len $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns) 0 }}
+              feature-definition-patterns = [
+              {{- range $fdpIdx, $featureDefinitionPattern := $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns }}
+                "{{$featureDefinitionPattern}}"
+              {{- end }}
+              ]
+            }
+            {{- end }}
+            {{- end }}
+            config-overrides {
+            {{- range $configOverridesKey, $configOverridesValue := $dynamicWotTmValidationConfig.configOverrides }}
+            {{- if or (eq (kindOf $configOverridesValue) "map") (eq (kindOf $configOverridesValue) "slice") }}
+              {{$configOverridesKey}} {
+              {{- range $nested1ConfigOverridesKey, $nested1ConfigOverridesValue := $configOverridesValue }}
+              {{- if or (eq (kindOf $nested1ConfigOverridesValue) "map") (eq (kindOf $nested1ConfigOverridesValue) "slice") }}
+                {{$nested1ConfigOverridesKey}} {
+                {{- range $nested2ConfigOverridesKey, $nested2ConfigOverridesValue := $nested1ConfigOverridesValue }}
+                {{- if not (kindIs "invalid" $nested2ConfigOverridesValue) }}
+                  {{$nested2ConfigOverridesKey}} = {{$nested2ConfigOverridesValue}}
+                {{- end }}
+                {{- end }}
+                }
+              {{- else }}
+                {{- if not (kindIs "invalid" $nested1ConfigOverridesValue) }}
+                  {{$nested1ConfigOverridesKey}} = {{$nested1ConfigOverridesValue}}
+                {{- end }}
+              {{- end }}
+              {{- end }}
+              }
+            {{- else }}
+              {{- if not (kindIs "invalid" $configOverridesValue) }}
+              {{$configOverridesKey}} = {{$configOverridesValue}}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            }
+          }
+        {{- end }}
+        ]
+      }
+    }
+  }
+}

--- a/deployment/helm/ditto/templates/connectivity-configmap.yaml
+++ b/deployment/helm/ditto/templates/connectivity-configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-service-config-connectivity-extension-conf
+  labels:
+    app.kubernetes.io/name: {{ $name }}-service-config-connectivity-extension-conf
+{{ $labels | indent 4 }}
+data:
+  connectivity-extension.conf: |-
+{{ tpl ($root.Files.Get "service-config/connectivity-extension.conf.tpl") $ | indent 4 }}
+---

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         {{- end }}
         checksum/mongodb-config: {{ include (print $.Template.BasePath "/mongodb-secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/connectivity-configmap.yaml") . | sha256sum }}
         {{- with .Values.connectivity.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -139,9 +140,6 @@ spec:
                 {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
-                {{- end }}
-                {{- range $index, $header := .Values.connectivity.config.persistence.events.historicalHeadersToPersist }}
-                "{{ printf "%s%d=%s" "-Dditto.connectivity.connection.event.historical-headers-to-persist." $index $header }}"
                 {{- end }}
                 {{ join " " .Values.connectivity.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
@@ -295,12 +293,13 @@ spec:
               value: "{{ .Values.dbconfig.connectivity.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
               value: "{{ .Values.dbconfig.connectivity.awsRoleArn }}"
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.dbconfig.connectivity.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.dbconfig.connectivity.awsSessionName }}"
             {{- end }}
-
           ports:
             - name: remoting
               containerPort: {{ .Values.pekko.remoting.port }}
@@ -332,6 +331,9 @@ spec:
             successThreshold: {{ .Values.connectivity.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.connectivity.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: connectivity-extension-conf
+              mountPath: /opt/ditto/connectivity-extension.conf
+              subPath: connectivity-extension.conf
             {{- if .Values.global.logging.customConfigFile.enabled }}
             - name: ditto-custom-log-config
               mountPath: /opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
@@ -381,6 +383,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: connectivity-extension-conf
+          configMap:
+            name: {{ .Release.Name }}-service-config-connectivity-extension-conf
         {{- if .Values.global.logging.customConfigFile.enabled }}
         - name: ditto-custom-log-config
           configMap:

--- a/deployment/helm/ditto/templates/gateway-configmap.yaml
+++ b/deployment/helm/ditto/templates/gateway-configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-service-config-gateway-extension-conf
+  labels:
+    app.kubernetes.io/name: {{ $name }}-service-config-gateway-extension-conf
+{{ $labels | indent 4 }}
+data:
+  gateway-extension.conf: |-
+{{ tpl ($root.Files.Get "service-config/gateway-extension.conf.tpl") $ | indent 4 }}
+---

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         {{- end }}
         checksum/password-config: {{ include (print $.Template.BasePath "/gateway-secret.yaml") . | sha256sum }}
-        checksum/mongodb-config: {{ include (print $.Template.BasePath "/mongodb-secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/gateway-configmap.yaml") . | sha256sum }}
         {{- with .Values.gateway.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -140,24 +140,6 @@ spec:
                 {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
-                {{- end }}
-                {{- range $key, $value := .Values.gateway.config.authentication.oauth.openidConnectIssuers }}
-                "{{ printf "%s%s%s=%s" "-Dditto.gateway.authentication.oauth.openid-connect-issuers." $key ".issuer" $value.issuer }}"
-                {{- range $index, $subject := $value.authSubjects }}
-                "{{ printf "%s%s%s%d=%s" "-Dditto.gateway.authentication.oauth.openid-connect-issuers." $key ".auth-subjects." $index $subject }}"
-                {{- end }}
-                {{- end }}
-                {{- range $key, $value := .Values.gateway.config.authentication.devops.oauth.openidConnectIssuers }}
-                "{{ printf "%s%s%s=%s" "-Dditto.gateway.authentication.devops.oauth.openid-connect-issuers." $key ".issuer" $value.issuer }}"
-                {{- range $index, $subject := $value.authSubjects }}
-                "{{ printf "%s%s%s%d=%s" "-Dditto.gateway.authentication.devops.oauth.openid-connect-issuers." $key ".auth-subjects." $index $subject }}"
-                {{- end }}
-                {{- end }}
-                {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.oauthSubjects }}
-                "{{ printf "%s%d=%s" "-Dditto.gateway.authentication.devops.devops-oauth2-subjects." $index $oauthSubject }}"
-                {{- end }}
-                {{- range $index, $oauthSubject := .Values.gateway.config.authentication.devops.statusOauthSubjects }}
-                "{{ printf "%s%d=%s" "-Dditto.gateway.authentication.devops.status-oauth2-subjects." $index $oauthSubject }}"
                 {{- end }}
                 {{ join " " .Values.gateway.systemProps }}
             - name: CLUSTER_BS_REQUIRED_CONTACTS
@@ -267,6 +249,9 @@ spec:
             successThreshold: {{ .Values.gateway.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: gateway-extension-conf
+              mountPath: /opt/ditto/gateway-extension.conf
+              subPath: gateway-extension.conf
             {{- if .Values.global.logging.customConfigFile.enabled }}
             - name: ditto-custom-log-config
               mountPath: /opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
@@ -316,6 +301,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: gateway-extension-conf
+          configMap:
+            name: {{ .Release.Name }}-service-config-gateway-extension-conf
         {{- if .Values.global.logging.customConfigFile.enabled }}
         - name: ditto-custom-log-config
           configMap:

--- a/deployment/helm/ditto/templates/policies-configmap.yaml
+++ b/deployment/helm/ditto/templates/policies-configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-service-config-policies-extension-conf
+  labels:
+    app.kubernetes.io/name: {{ $name }}-service-config-policies-extension-conf
+{{ $labels | indent 4 }}
+data:
+  policies-extension.conf: |-
+{{ tpl ($root.Files.Get "service-config/policies-extension.conf.tpl") $ | indent 4 }}
+---

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         {{- end }}
         checksum/mongodb-config: {{ include (print $.Template.BasePath "/mongodb-secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/policies-configmap.yaml") . | sha256sum }}
         {{- with .Values.policies.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -139,27 +140,6 @@ spec:
                 {{- .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
-                {{- end }}
-                {{- range $index, $header := .Values.policies.config.persistence.events.historicalHeadersToPersist }}
-                "{{ printf "%s%d=%s" "-Dditto.policies.policy.event.historical-headers-to-persist." $index $header }}"
-                {{- end }}
-                {{- range $grantIdx, $grant := .Values.policies.config.entityCreation.grants }}
-                "{{ printf "%s%d%s=%s" "-Dditto.entity-creation.grant." $grantIdx ".resource-types.0" "policy" }}"
-                {{- range $namespaceIdx, $namespace := $grant.namespaces }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.grant." $grantIdx ".namespaces." $namespaceIdx $namespace }}"
-                {{- end }}
-                {{- range $subjectIdx, $subject := $grant.authSubjects }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.grant." $grantIdx ".auth-subjects." $subjectIdx $subject }}"
-                {{- end }}
-                {{- end }}
-                {{- range $revokeIdx, $revoke := .Values.policies.config.entityCreation.revokes }}
-                "{{ printf "%s%d%s=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".resource-types.0" "policy" }}"
-                {{- range $namespaceIdx, $namespace := $revoke.namespaces }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".namespaces." $namespaceIdx $namespace }}"
-                {{- end }}
-                {{- range $subjectIdx, $subject := $revoke.authSubjects }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".auth-subjects." $subjectIdx $subject }}"
-                {{- end }}
                 {{- end }}
                 {{ join " " .Values.policies.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
@@ -287,12 +267,13 @@ spec:
               value: "{{ .Values.dbconfig.policies.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
               value: "{{ .Values.dbconfig.policies.awsRoleArn }}"
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.dbconfig.policies.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
               value: "{{ .Values.dbconfig.policies.awsSessionName }}"
             {{- end }}
-
           ports:
             - name: http
               containerPort: 8080
@@ -327,6 +308,9 @@ spec:
             successThreshold: {{ .Values.policies.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.policies.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: policies-extension-conf
+              mountPath: /opt/ditto/policies-extension.conf
+              subPath: policies-extension.conf
             {{- if .Values.global.logging.customConfigFile.enabled }}
             - name: ditto-custom-log-config
               mountPath: /opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
@@ -376,6 +360,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: policies-extension-conf
+          configMap:
+            name: {{ .Release.Name }}-service-config-policies-extension-conf
         {{- if .Values.global.logging.customConfigFile.enabled }}
         - name: ditto-custom-log-config
           configMap:

--- a/deployment/helm/ditto/templates/things-configmap.yaml
+++ b/deployment/helm/ditto/templates/things-configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-service-config-things-extension-conf
+  labels:
+    app.kubernetes.io/name: {{ $name }}-service-config-things-extension-conf
+{{ $labels | indent 4 }}
+data:
+  things-extension.conf: |-
+{{ tpl ($root.Files.Get "service-config/things-extension.conf.tpl") $ | indent 4 }}
+---

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         {{- end }}
         checksum/mongodb-config: {{ include (print $.Template.BasePath "/mongodb-secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/things-configmap.yaml") . | sha256sum }}
         {{- with .Values.things.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -139,72 +140,6 @@ spec:
                 {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
-                {{- end }}
-                {{- range $index, $header := .Values.things.config.persistence.events.historicalHeadersToPersist }}
-                "{{ printf "%s%d=%s" "-Dditto.things.thing.event.historical-headers-to-persist." $index $header }}"
-                {{- end }}
-                {{- range $grantIdx, $grant := .Values.things.config.entityCreation.grants }}
-                "{{ printf "%s%d%s=%s" "-Dditto.entity-creation.grant." $grantIdx ".resource-types.0" "thing" }}"
-                {{- range $namespaceIdx, $namespace := $grant.namespaces }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.grant." $grantIdx ".namespaces." $namespaceIdx $namespace }}"
-                {{- end }}
-                {{- range $subjectIdx, $subject := $grant.authSubjects }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.grant." $grantIdx ".auth-subjects." $subjectIdx $subject }}"
-                {{- end }}
-                {{- end }}
-                {{- range $revokeIdx, $revoke := .Values.things.config.entityCreation.revokes }}
-                "{{ printf "%s%d%s=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".resource-types.0" "thing" }}"
-                {{- range $namespaceIdx, $namespace := $revoke.namespaces }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".namespaces." $namespaceIdx $namespace }}"
-                {{- end }}
-                {{- range $subjectIdx, $subject := $revoke.authSubjects }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.entity-creation.revoke." $revokeIdx ".auth-subjects." $subjectIdx $subject }}"
-                {{- end }}
-                {{- end }}
-                '-Dditto.things.wot.to-thing-description.json-template={{ .Values.things.config.wot.tdJsonTemplate | replace "\n" "" | replace "\\\"" "\"" }}'
-                {{- range $dynConfIdx, $dynamicWotTmValidationConfig := .Values.things.config.wot.tmValidation.dynamicConfig }}
-                  {{- if $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns }}
-                    {{- if gt (len $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns) 0 }}
-                        {{- range $dhpIdx, $dittoHeadersPatterns := $dynamicWotTmValidationConfig.validationContext.dittoHeadersPatterns }}
-                          {{- range $dhpKey, $dhpVal := $dittoHeadersPatterns }}
-                "{{ printf "%s%d%s%d%s%s=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".validation-context.ditto-headers-patterns." $dhpIdx "." $dhpKey $dhpVal }}"
-                          {{- end }}
-                        {{- end }}
-                    {{- end }}
-                  {{- end }}
-                  {{- if $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns }}
-                    {{- if gt (len $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns) 0 }}
-                      {{- range $tdpIdx, $thingDefinitionPattern := $dynamicWotTmValidationConfig.validationContext.thingDefinitionPatterns }}
-                "{{ printf "%s%d%s%d=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".validation-context.thing-definition-patterns." $tdpIdx $thingDefinitionPattern }}"
-                      {{- end }}
-                    {{- end }}
-                  {{- end }}
-                  {{- if $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns }}
-                    {{- if gt (len $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns) 0 }}
-                      {{- range $fdpIdx, $featureDefinitionPattern := $dynamicWotTmValidationConfig.validationContext.featureDefinitionPatterns }}
-                "{{ printf "%s%d%s%d=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".validation-context.feature-definition-patterns." $fdpIdx $featureDefinitionPattern }}"
-                      {{- end }}
-                    {{- end }}
-                  {{- end }}
-                  {{- range $configOverridesKey, $configOverridesValue := $dynamicWotTmValidationConfig.configOverrides }}
-                    {{- if or (eq (kindOf $configOverridesValue) "map") (eq (kindOf $configOverridesValue) "slice") }}
-                      {{- range $nested1ConfigOverridesKey, $nested1ConfigOverridesValue := $configOverridesValue }}
-                        {{- if or (eq (kindOf $nested1ConfigOverridesValue) "map") (eq (kindOf $nested1ConfigOverridesValue) "slice") }}
-                          {{- range $nested2ConfigOverridesKey, $nested2ConfigOverridesValue := $nested1ConfigOverridesValue }}
-                            {{- if not (kindIs "invalid" $nested2ConfigOverridesValue) }}
-                "{{ printf "%s%d%s%s%s%s%s%s=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".config-overrides." $configOverridesKey "." $nested1ConfigOverridesKey "." $nested2ConfigOverridesKey $nested2ConfigOverridesValue }}"
-                            {{- end }}
-                          {{- end }}
-                        {{- else }}
-                          {{- if not (kindIs "invalid" $nested1ConfigOverridesValue) }}
-                "{{ printf "%s%d%s%s%s%s=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".config-overrides." $configOverridesKey "." $nested1ConfigOverridesKey $nested1ConfigOverridesValue }}"
-                          {{- end }}
-                        {{- end }}
-                      {{- end }}
-                    {{- else }}
-                "{{ printf "%s%d%s%s=%v" "-Dditto.things.wot.tm-model-validation.dynamic-configuration." $dynConfIdx ".config-overrides." $configOverridesKey $configOverridesValue }}"
-                    {{- end }}
-                  {{- end }}
                 {{- end }}
                 {{ join " " .Values.things.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
@@ -320,6 +255,10 @@ spec:
               value: "{{ .Values.things.config.policiesEnforcer.cache.expireAfterAccess }}"
             - name: THINGS_WOT_TO_THING_DESCRIPTION_BASE_PREFIX
               value: "{{ .Values.things.config.wot.tdBasePrefix }}"
+            - name: THINGS_WOT_THING_MODEL_CACHE_SIZE
+              value: "{{ .Values.things.config.wot.cache.modelCacheSize }}"
+            - name: THINGS_WOT_THING_MODEL_CACHE_EXPIRE_AFTER_ACCESS
+              value: "{{ .Values.things.config.wot.cache.expireAfterAccess }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_ENABLED
               value: "{{ .Values.things.config.wot.tmValidation.enabled }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS
@@ -378,6 +317,8 @@ spec:
               value: "{{ .Values.dbconfig.things.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
               value: "{{ .Values.dbconfig.things.awsRoleArn }}"
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.dbconfig.things.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
@@ -414,6 +355,9 @@ spec:
             successThreshold: {{ .Values.things.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.things.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: things-extension-conf
+              mountPath: /opt/ditto/things-extension.conf
+              subPath: things-extension.conf
             {{- if .Values.global.logging.customConfigFile.enabled }}
             - name: ditto-custom-log-config
               mountPath: /opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
@@ -463,6 +407,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: things-extension-conf
+          configMap:
+            name: {{ .Release.Name }}-service-config-things-extension-conf
         {{- if .Values.global.logging.customConfigFile.enabled }}
         - name: ditto-custom-log-config
           configMap:

--- a/deployment/helm/ditto/templates/thingssearch-configmap.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-configmap.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+{{- $releaseName := .Release.Name -}}
+{{- $name := include "ditto.name" . -}}
+{{- $labels := include "ditto.labels" . -}}
+{{ $root := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $releaseName }}-service-config-search-extension-conf
+  labels:
+    app.kubernetes.io/name: {{ $name }}-service-config-search-extension-conf
+{{ $labels | indent 4 }}
+data:
+  search-extension.conf: |-
+{{ tpl ($root.Files.Get "service-config/search-extension.conf.tpl") $ | indent 4 }}
+---

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -44,6 +44,7 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         {{- end }}
         checksum/mongodb-config: {{ include (print $.Template.BasePath "/mongodb-secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/thingssearch-configmap.yaml") . | sha256sum }}
         {{- with .Values.thingsSearch.additionalAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -139,28 +140,6 @@ spec:
                 {{ .Values.global.pekkoOptions }}
                 {{- if .Values.global.logging.customConfigFile.enabled }}
                 -Dlogback.configurationFile=/opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
-                {{- end }}
-                {{- if .Values.thingsSearch.config.indexedFieldsLimiting.enabled }}
-                -Dditto.extensions.caching-signal-enrichment-facade-provider=org.eclipse.ditto.thingsearch.service.persistence.write.streaming.SearchIndexingSignalEnrichmentFacadeProvider
-                {{- range $index, $value := .Values.thingsSearch.config.indexedFieldsLimiting.items }}
-                "{{ printf "%s%d%s=%s" "-Dditto.search.namespace-indexed-fields." $index ".namespace-pattern" $value.namespacePattern }}"
-                {{- range $fieldIndex, $indexedField := $value.indexedFields }}
-                "{{ printf "%s%d%s%d=%s" "-Dditto.search.namespace-indexed-fields." $index ".indexed-fields." $fieldIndex $indexedField }}"
-                {{- end }}
-                {{- end }}
-                {{- end }}
-                {{- range $key, $value := .Values.thingsSearch.config.operatorMetrics.customMetrics }}
-                "{{ printf "%s%s%s=%t" "-Dditto.search.operator-metrics.custom-metrics." $key ".enabled" $value.enabled }}"
-                {{- if $value.scrapeInterval }}
-                "{{ printf "%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".scrape-interval" $value.scrapeInterval }}"
-                {{- end }}
-                {{- range $index, $namespace := $value.namespaces }}
-                "{{ printf "%s%s%s%d=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".namespaces." $index $namespace }}"
-                {{- end }}
-                "{{ printf "%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".filter" $value.filter }}"
-                {{- range $tagKey, $tagValue := $value.tags }}
-                "{{ printf "%s%s%s%s=%s" "-Dditto.search.operator-metrics.custom-metrics." $key ".tags." $tagKey $tagValue }}"
-                {{- end }}
                 {{- end }}
                 {{ join " " .Values.thingsSearch.systemProps }}
             - name: MONGO_DB_SSL_ENABLED
@@ -264,6 +243,8 @@ spec:
               value: "{{ .Values.dbconfig.thingsSearch.awsRegion }}"
             - name: MONGO_DB_AWS_ROLE_ARN
               value: "{{ .Values.dbconfig.thingsSearch.awsRoleArn }}"
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.dbconfig.thingsSearch.awsRoleArn }}"
             - name: AWS_WEB_IDENTITY_TOKEN_FILE
               value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
             - name: MONGO_DB_AWS_SESSION_NAME
@@ -300,6 +281,9 @@ spec:
             successThreshold: {{ .Values.thingsSearch.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.thingsSearch.livenessProbe.failureThreshold }}
           volumeMounts:
+            - name: search-extension-conf
+              mountPath: /opt/ditto/search-extension.conf
+              subPath: search-extension.conf
             {{- if .Values.global.logging.customConfigFile.enabled }}
             - name: ditto-custom-log-config
               mountPath: /opt/ditto/{{ .Values.global.logging.customConfigFile.fileName }}
@@ -349,6 +333,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: search-extension-conf
+          configMap:
+            name: {{ .Release.Name }}-service-config-search-extension-conf
         {{- if .Values.global.logging.customConfigFile.enabled }}
         - name: ditto-custom-log-config
           configMap:

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1070,6 +1070,12 @@ things:
     wot:
       # tdBasePrefix is the base to use where the Ditto endpoint is located in order to be injected into TDs:
       tdBasePrefix: "http://localhost:8080"
+      # cache contains the configuration for the things model cache
+      cache:
+        # modelCacheSize configures the amount of TMs to hold in the cache
+        modelCacheSize: 1000
+        # expireAfterAccess configures how long a single TM should remain cached after its last access
+        expireAfterAccess: 1d
       # tdJsonTemplate contains a json template added to generated TDs, e.g. containing security information:
       tdJsonTemplate: >-
         {
@@ -1393,6 +1399,23 @@ thingsSearch:
       #   filter: "eq(attributes/awesome,true)"
       #   tags:
       #     foo: bar
+      customAggregationMetrics:
+      # ditto_my_agg_awesome_things:
+      #   enabled: true
+      #   scrapeInterval: 5m
+      #   namespaces:
+      #     - "org.eclipse.ditto"
+      #   groupBy:
+      #     "location": "attributes/Info/location"
+      #   tags:
+      #     "online": "{{ inline:online_placeholder }}"
+      #     "hardcoded-tag": "value"
+      #     "location": "{{ group-by:location | fn:default('missing location') }}"
+      #   filters:
+      #     online_filter:
+      #       filter: "gt(features/ConnectionStatus/properties/status/readyUntil,time:now)"
+      #       inlinePlaceholderValues:
+      #         online_placeholder: true
 
 
 ## ----------------------------------------------------------------------------


### PR DESCRIPTION
* instead of configuring via System Properties

Right now, configuration of very dynamic settings (like e.g. custom metrics or entity creation) is done via SystemProperties in the Helm chart.
This can lead to some issues - e.g. if the command line arguments get too long, `trivy`, the wrapper process for starting the JVM can no longer handle those.
Or another problem is that the Kubernetes "Pods" HTTP API will return all environment variables and all system-properties as part of its response when querying for other Ditto pods during bootstrapping a cluster.

Moving the very dynamic configuration to config files (mounted via ConfigMaps) is an elegant solution for that.