### PR TITLE
fixed tracing and moving traces to their correct parent in many places

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DittoGatewayAuthenticationDirectiveFactory.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/auth/DittoGatewayAuthenticationDirectiveFactory.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Executor;
 
+import javax.annotation.Nullable;
+
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationChain;
 import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationFailureAggregator;
@@ -32,7 +34,6 @@ import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.mongodb.lang.Nullable;
 import com.typesafe.config.Config;
 
 /**

--- a/internal/models/signalenrichment/pom.xml
+++ b/internal/models/signalenrichment/pom.xml
@@ -46,6 +46,10 @@
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-internal-models-signal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-internal-utils-tracing</artifactId>
+        </dependency>
 
         <!-- test-only -->
         <dependency>

--- a/internal/models/signalenrichment/src/test/java/org/eclipse/ditto/internal/models/signalenrichment/AbstractSignalEnrichmentFacadeTest.java
+++ b/internal/models/signalenrichment/src/test/java/org/eclipse/ditto/internal/models/signalenrichment/AbstractSignalEnrichmentFacadeTest.java
@@ -24,6 +24,9 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.eclipse.ditto.base.model.entity.metadata.MetadataModelFactory;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.DittoTestSystem;
+import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
+import org.eclipse.ditto.internal.utils.tracing.config.TracingConfig;
+import org.eclipse.ditto.internal.utils.tracing.filter.AcceptAllTracingFilter;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -34,7 +37,10 @@ import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThing;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThingResponse;
 import org.eclipse.ditto.things.model.signals.events.AttributeModified;
 import org.eclipse.ditto.things.model.signals.events.ThingDeleted;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Abstract base test for different {@link SignalEnrichmentFacade} implementations.
@@ -54,6 +60,20 @@ abstract class AbstractSignalEnrichmentFacadeTest {
             MetadataModelFactory.newMetadataBuilder()
                     .set("type", "x attribute")
                     .build());
+
+    @BeforeClass
+    public static void beforeClass() {
+        final TracingConfig tracingConfigMock = Mockito.mock(TracingConfig.class);
+        Mockito.when(tracingConfigMock.isTracingEnabled()).thenReturn(true);
+        Mockito.when(tracingConfigMock.getPropagationChannel()).thenReturn("default");
+        Mockito.when(tracingConfigMock.getTracingFilter()).thenReturn(AcceptAllTracingFilter.getInstance());
+        DittoTracing.init(tracingConfigMock);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        DittoTracing.reset();
+    }
 
     @Test
     public void success() {

--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
@@ -33,6 +33,7 @@ import org.apache.pekko.serialization.ByteBufferSerializer;
 import org.apache.pekko.serialization.SerializerWithStringManifest;
 import org.eclipse.ditto.base.model.exceptions.DittoJsonException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
@@ -210,7 +211,11 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
             final DittoHeaders dittoHeaders,
             final StartedSpan startedSpan
     ) {
-        final var dittoHeadersWithSpanContext = DittoHeaders.of(startedSpan.propagateContext(dittoHeaders));
+        final var dittoHeadersWithSpanContext = DittoHeaders.of(startedSpan.propagateContext(
+                dittoHeaders.toBuilder()
+                        .removeHeader(DittoHeaderDefinition.W3C_TRACEPARENT.getKey())
+                        .build()
+        ));
         return dittoHeadersWithSpanContext.toJson();
     }
 
@@ -330,7 +335,11 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
                 beforeDeserializeInstant
         );
         final var result =
-                deserializeJson(payload, manifest, DittoHeaders.of(startedSpan.propagateContext(dittoHeaders)));
+                deserializeJson(payload, manifest, DittoHeaders.of(startedSpan.propagateContext(
+                        dittoHeaders.toBuilder()
+                                .removeHeader(DittoHeaderDefinition.W3C_TRACEPARENT.getKey())
+                                .build()
+                )));
         try {
             return result;
         } finally {

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/EmptyResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/EmptyResult.java
@@ -15,7 +15,10 @@ package org.eclipse.ditto.internal.utils.persistentactors.results;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Result without content.
@@ -38,8 +41,11 @@ public final class EmptyResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public void accept(final ResultVisitor<E> visitor) {
+    public void accept(final ResultVisitor<E> visitor, @Nullable final StartedSpan startedSpan) {
         visitor.onEmpty();
+        if (startedSpan != null) {
+            startedSpan.finish();
+        }
     }
 
     @Override

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ErrorResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ErrorResult.java
@@ -15,9 +15,12 @@ package org.eclipse.ditto.internal.utils.persistentactors.results;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Result signifying an error.
@@ -41,8 +44,11 @@ public final class ErrorResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public void accept(final ResultVisitor<E> visitor) {
+    public void accept(final ResultVisitor<E> visitor, @Nullable final StartedSpan startedSpan) {
         visitor.onError(dittoRuntimeException, errorCausingCommand);
+        if (startedSpan != null) {
+            startedSpan.tagAsFailed(dittoRuntimeException).finish();
+        }
     }
 
     @Override

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/MutationResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/MutationResult.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Result that demands persistence of a mutation event.
@@ -52,11 +53,11 @@ public final class MutationResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public void accept(final ResultVisitor<E> visitor) {
+    public void accept(final ResultVisitor<E> visitor, @Nullable final StartedSpan startedSpan) {
         if (eventToPersistStage != null && responseStage != null) {
-            visitor.onStagedMutation(command, eventToPersistStage, responseStage, becomeCreated, becomeDeleted);
+            visitor.onStagedMutation(command, eventToPersistStage, responseStage, becomeCreated, becomeDeleted, startedSpan);
         } else {
-            visitor.onMutation(command, eventToPersist, response, becomeCreated, becomeDeleted);
+            visitor.onMutation(command, eventToPersist, response, becomeCreated, becomeDeleted, startedSpan);
         }
     }
 

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/QueryResult.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/QueryResult.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Result for query commands.
@@ -50,11 +51,14 @@ public final class QueryResult<E extends Event<?>> implements Result<E> {
     }
 
     @Override
-    public void accept(final ResultVisitor<E> visitor) {
+    public void accept(final ResultVisitor<E> visitor, @Nullable final StartedSpan startedSpan) {
         if (responseStage != null) {
-            visitor.onStagedQuery(command, responseStage);
+            visitor.onStagedQuery(command, responseStage, startedSpan);
         } else {
             visitor.onQuery(command, response);
+            if (startedSpan != null) {
+                startedSpan.finish();
+            }
         }
     }
 

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/Result.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/Result.java
@@ -15,7 +15,10 @@ package org.eclipse.ditto.internal.utils.persistentactors.results;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * The result of applying the strategy to the given command.
@@ -26,8 +29,9 @@ public interface Result<E extends Event<?>> {
      * Evaluate the result by a visitor.
      *
      * @param visitor the visitor to evaluate the result, typically the persistent actor itself.
+     * @param startedSpan the tracing span started for the command before applying the strategy.
      */
-    void accept(ResultVisitor<E> visitor);
+    void accept(ResultVisitor<E> visitor, @Nullable StartedSpan startedSpan);
 
     /**
      * Convert the result with a function.

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultVisitor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/results/ResultVisitor.java
@@ -14,10 +14,13 @@ package org.eclipse.ditto.internal.utils.persistentactors.results;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Evaluator of results of command strategies.
@@ -41,8 +44,10 @@ public interface ResultVisitor<E extends Event<?>> {
      * @param response response of the command.
      * @param becomeCreated whether the actor should behave as if the entity is created.
      * @param becomeDeleted whether the actor should behave as if the entity is deleted.
+     * @param startedSpan the tracing span started for the command before applying the strategy.
      */
-    void onMutation(Command<?> command, E event, WithDittoHeaders response, boolean becomeCreated, boolean becomeDeleted);
+    void onMutation(Command<?> command, E event, WithDittoHeaders response, boolean becomeCreated, boolean becomeDeleted,
+            @Nullable StartedSpan startedSpan);
 
     /**
      * Evaluate a mutation result.
@@ -52,9 +57,10 @@ public interface ResultVisitor<E extends Event<?>> {
      * @param response response of the command.
      * @param becomeCreated whether the actor should behave as if the entity is created.
      * @param becomeDeleted whether the actor should behave as if the entity is deleted.
+     * @param startedSpan the tracing span started for the command before applying the strategy.
      */
     void onStagedMutation(Command<?> command, CompletionStage<E> event, CompletionStage<WithDittoHeaders> response,
-            boolean becomeCreated, boolean becomeDeleted);
+            boolean becomeCreated, boolean becomeDeleted, @Nullable StartedSpan startedSpan);
 
     /**
      * Evaluate a query result.
@@ -69,8 +75,10 @@ public interface ResultVisitor<E extends Event<?>> {
      *
      * @param command the query command.
      * @param response the response.
+     * @param startedSpan the tracing span started for the command before applying the strategy.
      */
-    void onStagedQuery(Command<?> command, CompletionStage<WithDittoHeaders> response);
+    void onStagedQuery(Command<?> command, CompletionStage<WithDittoHeaders> response,
+            @Nullable StartedSpan startedSpan);
 
     /**
      * Evaluate an error result.

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/DittoTracing.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/DittoTracing.java
@@ -112,7 +112,7 @@ public final class DittoTracing {
      * Resets DittoTracing to uninitialized state.
      * This is the inverse function of {@link DittoTracing#init(TracingConfig)}.
      */
-    static void reset() {
+    public static void reset() {
         final var instance = getInstance();
         instance.stateHolder.set(new UninitializedState(instance.stateHolder::set));
     }

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/TraceInformationGenerator.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/TraceInformationGenerator.java
@@ -53,7 +53,7 @@ public final class TraceInformationGenerator implements Function<String, TraceIn
     private static final String API_VERSION_GROUP = "apiVersion";
     private static final String API_VERSIONS =
             "(?<" + API_VERSION_GROUP + ">[" + FIRST_API_VERSION + "-" + LATEST_API_VERSION + "])";
-    private static final Set<String> SUB_PATHS_TO_SHORTEN = Set.of("things", "policies", "search/things");
+    private static final Set<String> SUB_PATHS_TO_SHORTEN = Set.of("things", "policies");
     private static final String PATHS_TO_SHORTEN_GROUP = "shorten";
     private static final String PATHS_TO_SHORTEN_REGEX_TEMPLATE = "(?<" + PATHS_TO_SHORTEN_GROUP + ">^/(api)/" +
             API_VERSIONS +
@@ -63,6 +63,8 @@ public final class TraceInformationGenerator implements Function<String, TraceIn
             "api/2/whoami",
             "api/2/checkPermissions",
             "api/2/cloudevents",
+            "api/2/search/things",
+            "api/2/search/things/count",
             "ws/2",
             "health",
             "status",
@@ -149,10 +151,11 @@ public final class TraceInformationGenerator implements Function<String, TraceIn
                     traceUri = URI.create(pathToShorten + MESSAGES_PATH_SUFFIX);
                     sanitizedUri = traceUri;
                 } else {
-                    traceUri = URI.create(pathToShorten + SHORTENED_PATH_SUFFIX);
-                    sanitizedUri = getMatcherValue("subEntityType", matcher)
-                            .map(s -> URI.create(traceUri + "/" + s + SHORTENED_PATH_SUFFIX))
-                            .orElse(traceUri);
+                    traceUri = getMatcherValue("subEntityType", matcher)
+                            .map(s ->
+                                    URI.create(pathToShorten + SHORTENED_PATH_SUFFIX + "/" + s + SHORTENED_PATH_SUFFIX))
+                            .orElseGet(() -> URI.create(pathToShorten + SHORTENED_PATH_SUFFIX));
+                    sanitizedUri = traceUri;
                 }
             } else {
                 final var pathFullLength = matcher.group(PATHS_EXACT_LENGTH_GROUP);

--- a/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/TraceInformationGeneratorTest.java
+++ b/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/TraceInformationGeneratorTest.java
@@ -60,7 +60,7 @@ public final class TraceInformationGeneratorTest {
         );
 
         assertThat(traceInformation)
-                .isEqualTo(TraceInformation.newInstance(traceUri, TagSet.ofTag(getRequestUriTag(sanitizedUri))));
+                .isEqualTo(TraceInformation.newInstance(sanitizedUri, TagSet.ofTag(getRequestUriTag(sanitizedUri))));
     }
 
     private static Tag getRequestUriTag(final URI requestUri) {
@@ -76,7 +76,7 @@ public final class TraceInformationGeneratorTest {
                 underTest.apply("/api/2/things/abc:1a4ed3df-308b-462e-9cfc-b78891f18c39/features/Vehicle/definition");
 
         assertThat(traceInformation)
-                .isEqualTo(TraceInformation.newInstance(traceUri, TagSet.ofTag(getRequestUriTag(sanitizedUri))));
+                .isEqualTo(TraceInformation.newInstance(sanitizedUri, TagSet.ofTag(getRequestUriTag(sanitizedUri))));
     }
 
     @Test
@@ -97,7 +97,7 @@ public final class TraceInformationGeneratorTest {
 
     @Test
     public void api2ThingsSearchCountUriIsShortened() {
-        final var expectedUri = URI.create("/api/2/search/things" + TraceInformationGenerator.SHORTENED_PATH_SUFFIX);
+        final var expectedUri = URI.create("/api/2/search/things/count");
 
         assertThat(underTest.apply("/api/2/search/things/count"))
                 .isEqualTo(TraceInformation.newInstance(expectedUri, TagSet.ofTag(getRequestUriTag(expectedUri))));

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
@@ -138,7 +138,7 @@ public abstract class AbstractCommandStrategyTest {
             final DittoRuntimeException expectedException) {
 
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
-        applyStrategy(underTest, getDefaultContext(), thing, command).accept(mock);
+        applyStrategy(underTest, getDefaultContext(), thing, command).accept(mock, null);
         verify(mock).onError(eq(expectedException), eq(command));
     }
 
@@ -159,7 +159,7 @@ public abstract class AbstractCommandStrategyTest {
 
         final Result<ThingEvent<?>> thingEventResult = applyStrategy(underTest, getDefaultContext(), thing, command);
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
-        thingEventResult.accept(mock);
+        thingEventResult.accept(mock, null);
         final ArgumentCaptor<CommandResponse<?>> captor = ArgumentCaptor.forClass(CommandResponse.class);
         verify(mock).onQuery(any(), captor.capture());
         commandResponseAssertions.accept(captor.getValue());
@@ -173,7 +173,7 @@ public abstract class AbstractCommandStrategyTest {
             final DittoRuntimeException expectedResponse) {
 
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
-        underTest.unhandled(getDefaultContext(), thing, NEXT_REVISION, command).accept(mock);
+        underTest.unhandled(getDefaultContext(), thing, NEXT_REVISION, command).accept(mock, null);
         verify(mock).onError(eq(expectedResponse), eq(command));
     }
 
@@ -186,9 +186,10 @@ public abstract class AbstractCommandStrategyTest {
 
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
 
-        result.accept(mock);
+        result.accept(mock, null);
 
-        verify(mock).onMutation(any(), event.capture(), eq(expectedResponse), anyBoolean(), eq(becomeDeleted));
+        verify(mock).onMutation(any(), event.capture(), eq(expectedResponse), anyBoolean(), eq(becomeDeleted),
+                eq(null));
         assertThat(event.getValue()).isInstanceOf(eventClazz);
         return event.getValue();
     }
@@ -203,9 +204,10 @@ public abstract class AbstractCommandStrategyTest {
 
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
 
-        result.accept(mock);
+        result.accept(mock, null);
 
-        verify(mock).onStagedMutation(any(), eventStage.capture(), responseStage.capture(), anyBoolean(), eq(becomeDeleted));
+        verify(mock).onStagedMutation(any(), eventStage.capture(), responseStage.capture(), anyBoolean(), eq(becomeDeleted),
+                eq(null));
         assertThat(eventStage.getValue()).isInstanceOf(CompletionStage.class);
         CompletableFutureAssert.assertThatCompletionStage(eventStage.getValue())
                 .isCompletedWithValueMatching(t -> eventClazz.isAssignableFrom(t.getClass()));
@@ -217,7 +219,7 @@ public abstract class AbstractCommandStrategyTest {
 
     private static void assertInfoResult(final Result<ThingEvent<?>> result, final WithDittoHeaders infoResponse) {
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
-        result.accept(mock);
+        result.accept(mock, null);
         verify(mock).onQuery(any(), eq(infoResponse));
     }
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ResultFactoryTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ResultFactoryTest.java
@@ -44,7 +44,7 @@ public final class ResultFactoryTest {
     @Test
     public void notifyQueryResponse() {
         final Result<ThingEvent<?>> result = ResultFactory.newQueryResult(thingQueryCommand, response);
-        result.accept(mock);
+        result.accept(mock, null);
         verify(mock).onQuery(eq(thingQueryCommand), eq(response));
     }
 
@@ -52,7 +52,7 @@ public final class ResultFactoryTest {
     public void notifyException() {
         final Command command = mock(Command.class);
         final Result<ThingEvent<?>> result = ResultFactory.newErrorResult(exception, command);
-        result.accept(this.mock);
+        result.accept(this.mock, null);
         verify(this.mock).onError(eq(exception), eq(command));
     }
 
@@ -76,9 +76,9 @@ public final class ResultFactoryTest {
                 ResultFactory.newMutationResult(thingModifyCommand, thingModifiedEvent, response,
                         becomeCreated,
                         becomeDeleted);
-        result.accept(mock);
+        result.accept(mock, null);
         verify(mock).onMutation(eq(thingModifyCommand), eq(thingModifiedEvent), eq(response), eq(becomeCreated),
-                eq(becomeDeleted));
+                eq(becomeDeleted), eq(null));
     }
 
     interface Dummy extends ResultVisitor<ThingEvent<?>> {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -35,6 +35,9 @@ import org.apache.pekko.testkit.TestProbe;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
+import org.eclipse.ditto.internal.utils.tracing.config.TracingConfig;
+import org.eclipse.ditto.internal.utils.tracing.filter.AcceptAllTracingFilter;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -64,10 +67,13 @@ import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingDeleteModel;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingWriteModel;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import org.mockito.Mockito;
 
 import com.typesafe.config.ConfigFactory;
 
@@ -85,6 +91,19 @@ public final class EnforcementFlowTest {
     private TestPublisher.Probe<Collection<Metadata>> sourceProbe;
     private TestSubscriber.Probe<List<AbstractWriteModel>> sinkProbe;
 
+    @BeforeClass
+    public static void beforeClass() {
+        final TracingConfig tracingConfigMock = Mockito.mock(TracingConfig.class);
+        Mockito.when(tracingConfigMock.isTracingEnabled()).thenReturn(true);
+        Mockito.when(tracingConfigMock.getPropagationChannel()).thenReturn("default");
+        Mockito.when(tracingConfigMock.getTracingFilter()).thenReturn(AcceptAllTracingFilter.getInstance());
+        DittoTracing.init(tracingConfigMock);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        DittoTracing.reset();
+    }
     @Before
     public void init() {
         system = ActorSystem.create("test", ConfigFactory.load("actors-test.conf"));


### PR DESCRIPTION
After enabling tracing in our Ditto installation, we found several places where spans are not correctly assigned to their parent spans and also where e.g. HTTP endpoints are reported falsely as `/other`.

This PR fixes that in a lot of encountered places.