### PR TITLE
Fix resolving WoT submodels from extended model

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -34,7 +34,7 @@
         <!-- ### Compile dependencies versions -->
         <minimal-json.version>0.9.5</minimal-json.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
-        <json-schema-validator.version>1.5.1</json-schema-validator.version>
+        <json-schema-validator.version>1.5.4</json-schema-validator.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <ssl-config-core.version>0.6.1</ssl-config-core.version>
         <kafka-client.version>3.7.1</kafka-client.version>


### PR DESCRIPTION
* right now Ditto `tm:extends` resolving does not preserve the "extended" submodels from a parent model because merging of arrays will replace array content
* this provides a fix to add special handling for merging the "links" array