### PR TITLE
fix aggregation metrics config unnecessary force of tags

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.6.3  # chart version is effectively set by release-job
+version: 3.6.4  # chart version is effectively set by release-job
 appVersion: 3.6.3
 keywords:
   - iot-chart

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultCustomAggregationMetricConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultCustomAggregationMetricConfig.java
@@ -161,9 +161,16 @@ public final class DefaultCustomAggregationMetricConfig implements CustomAggrega
             });
 
             final Set<String> requiredGroupByPlaceholders = getDeclaredGroupByPlaceholdersExpressions(getTags());
-            if (!requiredGroupByPlaceholders.equals(getGroupBy().keySet())) {
-                throw new IllegalArgumentException("Custom search metric Gauge for metric <"
-                + metricName + "> must have the same groupBy fields as the configured placeholder expressions in tags. Required: " + requiredGroupByPlaceholders + " Configured: " + getGroupBy().keySet());
+            List<String> missing = new ArrayList<>();
+            requiredGroupByPlaceholders.forEach(placeholder -> {
+                if (!getGroupBy().containsKey(placeholder)) {
+                    missing.add(placeholder);
+                }
+            });
+            if (!missing.isEmpty()){
+                throw new IllegalArgumentException("Custom search metric Gauge for metric <" + metricName
+                        + "> must contain in the groupBy fields all of the fields used by placeholder expressions in tags. Missing: "
+                        + missing + " Configured: " + getGroupBy().keySet());
             }
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
@@ -75,7 +75,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
     private static final String METRIC_NAME = "metric-name";
 
     private final DittoDiagnosticLoggingAdapter log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
-    private final ActorRef thingsAggregatorActorSingletonProxy;
+    private final ActorRef aggregateThingsMetricsActorSingletonProxy;
     private final Map<String, CustomAggregationMetricConfig> customSearchMetricConfigMap;
     private final Map<GageIdentifier, TimestampedGauge> metricsGauges;
     private final Gauge customSearchMetricsGauge;
@@ -83,7 +83,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
 
     @SuppressWarnings("unused")
     private OperatorAggregateMetricsProviderActor(final SearchConfig searchConfig) {
-        this.thingsAggregatorActorSingletonProxy = initializeAggregationThingsMetricsActor(searchConfig);
+        this.aggregateThingsMetricsActorSingletonProxy = initializeAggregationThingsMetricsActor(searchConfig);
         this.customSearchMetricConfigMap = searchConfig.getOperatorMetricsConfig().getCustomAggregationMetricConfigs();
         this.metricsGauges = new HashMap<>();
         this.inlinePlaceholderResolvers = new LinkedHashMap<>();
@@ -150,7 +150,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
         final AggregateThingsMetrics
                 aggregateThingsMetrics = AggregateThingsMetrics.of(metricName, config.getGroupBy(), namedFilters,
                 Set.of(config.getNamespaces().toArray(new String[0])), dittoHeaders);
-        thingsAggregatorActorSingletonProxy.tell(aggregateThingsMetrics, getSelf());
+        aggregateThingsMetricsActorSingletonProxy.tell(aggregateThingsMetrics, getSelf());
     }
 
 


### PR DESCRIPTION
1.  Tags resolving relies on the fields configured in the group-by field of config but group-by does not rely on tags. 
Some times we may want to group by a field that we don't want as a tag so this fix removes the unwanted forcing af adding tags.

2.  Also renamed the variable of AggregateThingsMetricsActor to comply with the overall code pattern and to easily find the actor behind the ActorRef