### PR TITLE
add missing thingId to log of failed WoT validations

### DIFF
--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingCommandStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingCommandStrategy.java
@@ -95,7 +95,8 @@ abstract class AbstractThingCommandStrategy<C extends Command<C>>
             final long nextRevision, final C command) {
 
         final var dittoHeaders = command.getDittoHeaders();
-        final var dittoHeadersBuilder = dittoHeaders.toBuilder();
+        final var dittoHeadersBuilder = dittoHeaders.toBuilder()
+                .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), context.getState().toString());
         final var loggerWithCorrelationId = context.getLog().withCorrelationId(command);
         final var thingConditionFailed = dittoHeaders.getCondition()
                 .flatMap(condition -> ThingConditionValidator.validate(command, condition, entity));

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ETagTestUtils.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ETagTestUtils.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.things.service.persistence.actors;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.entity.Revision;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
 import org.eclipse.ditto.json.JsonFieldSelector;
@@ -71,14 +72,16 @@ public final class ETagTestUtils {
 
     public static RetrieveThingResponse retrieveThingResponse(final Thing expectedThing,
             @Nullable final JsonFieldSelector thingFieldSelector, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(expectedThing.getEntityId().get(),
+                expectedThing, dittoHeaders);
         return RetrieveThingResponse.of(expectedThing.getEntityId().get(), expectedThing, thingFieldSelector, null,
                 dittoHeadersWithETag);
     }
 
     public static RetrieveThingResponse retrieveThingResponse(final Thing expectedThing,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(expectedThing.getEntityId().get(),
+                expectedThing, dittoHeaders);
         return RetrieveThingResponse.of(expectedThing.getEntityId().get(),
                 expectedThing.toJsonString(dittoHeaders.getSchemaVersion().get()), dittoHeadersWithETag);
     }
@@ -91,7 +94,8 @@ public final class ETagTestUtils {
                         .orElseGet(() -> ThingRevision.newInstance(1L)))
                 .build();
         final DittoHeaders dittoHeadersWithETag =
-                appendETagToDittoHeaders(modifiedThingWithUpdatedRevision, dittoHeaders);
+                appendEntityIdAndETagToDittoHeaders(currentThing.getEntityId().get(),
+                        modifiedThingWithUpdatedRevision, dittoHeaders);
         return ModifyThingResponse.modified(modifiedThing.getEntityId().get(), dittoHeadersWithETag);
     }
 
@@ -103,14 +107,16 @@ public final class ETagTestUtils {
                         .orElseGet(() -> ThingRevision.newInstance(1L)))
                 .build();
         final DittoHeaders dittoHeadersWithETag =
-                appendETagToDittoHeaders(modifiedThingWithUpdatedRevision, dittoHeaders);
+                appendEntityIdAndETagToDittoHeaders(currentThing.getEntityId().get(),
+                        modifiedThingWithUpdatedRevision, dittoHeaders);
         final ThingId thingId = currentThing.getEntityId().orElseThrow();
         return MergeThingResponse.of(thingId, path, dittoHeadersWithETag);
     }
 
     public static SudoRetrieveThingResponse sudoRetrieveThingResponse(final Thing expectedThing,
             final JsonObject expectedJsonRepresentation, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(expectedThing.getEntityId().get(),
+                expectedThing, dittoHeaders);
         return SudoRetrieveThingResponse.of(expectedJsonRepresentation, dittoHeadersWithETag);
     }
 
@@ -118,7 +124,7 @@ public final class ETagTestUtils {
 
     public static ModifyFeaturesResponse modifyFeaturesResponse(final ThingId thingId, final Features modifiedFeatures,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(modifiedFeatures, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, modifiedFeatures, dittoHeaders);
         if (created) {
             return ModifyFeaturesResponse.created(thingId, modifiedFeatures, dittoHeadersWithETag);
         } else {
@@ -129,7 +135,7 @@ public final class ETagTestUtils {
     public static RetrieveFeaturesResponse retrieveFeaturesResponse(final ThingId thingId,
             final Features expectedFeatures,
             final JsonObject expectedJsonRepresentation, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedFeatures, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedFeatures, dittoHeaders);
         return RetrieveFeaturesResponse.of(thingId, expectedJsonRepresentation, dittoHeadersWithETag);
     }
 
@@ -137,14 +143,14 @@ public final class ETagTestUtils {
 
     public static RetrieveFeatureResponse retrieveFeatureResponse(final ThingId thingId, final Feature expectedFeature,
             final JsonObject expectedJsonRepresentation, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedFeature, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedFeature, dittoHeaders);
         return RetrieveFeatureResponse.of(thingId, expectedFeature.getId(), expectedJsonRepresentation,
                 dittoHeadersWithETag);
     }
 
     public static ModifyFeatureResponse modifyFeatureResponse(final ThingId thingId, final Feature feature,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(feature, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, feature, dittoHeaders);
         if (created) {
             return ModifyFeatureResponse.created(thingId, feature, dittoHeadersWithETag);
         } else {
@@ -157,7 +163,7 @@ public final class ETagTestUtils {
     public static ModifyFeatureDefinitionResponse modifyFeatureDefinitionResponse(final ThingId thingId,
             final String featureId, final FeatureDefinition definition, final DittoHeaders dittoHeaders,
             final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(definition, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, definition, dittoHeaders);
         if (created) {
             return ModifyFeatureDefinitionResponse.created(thingId, featureId, definition, dittoHeadersWithETag);
         } else {
@@ -168,7 +174,7 @@ public final class ETagTestUtils {
     public static RetrieveFeatureDefinitionResponse retrieveFeatureDefinitionResponse(final ThingId thingId,
             final String featureId, final FeatureDefinition expectedFeatureDefinition,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedFeatureDefinition, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedFeatureDefinition, dittoHeaders);
         return RetrieveFeatureDefinitionResponse.of(thingId, featureId, expectedFeatureDefinition,
                 dittoHeadersWithETag);
     }
@@ -178,7 +184,7 @@ public final class ETagTestUtils {
     public static ModifyFeaturePropertiesResponse modifyFeaturePropertiesResponse(final ThingId thingId,
             final String featureId, final FeatureProperties properties, final DittoHeaders dittoHeaders,
             final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(properties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, properties, dittoHeaders);
         if (created) {
             return ModifyFeaturePropertiesResponse.created(thingId, featureId, properties, dittoHeadersWithETag);
         } else {
@@ -189,7 +195,7 @@ public final class ETagTestUtils {
     public static RetrieveFeaturePropertiesResponse retrieveFeaturePropertiesResponse(final ThingId thingId,
             final String featureId, final FeatureProperties featureProperties,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(featureProperties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, featureProperties, dittoHeaders);
         return RetrieveFeaturePropertiesResponse.of(thingId, featureId, featureProperties,
                 dittoHeadersWithETag);
     }
@@ -198,7 +204,7 @@ public final class ETagTestUtils {
             final String featureId, final FeatureProperties featureProperties,
             final FeatureProperties expectedFeatureProperties,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(featureProperties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, featureProperties, dittoHeaders);
         return RetrieveFeaturePropertiesResponse.of(thingId, featureId, expectedFeatureProperties,
                 dittoHeadersWithETag);
     }
@@ -208,7 +214,7 @@ public final class ETagTestUtils {
     public static ModifyFeatureDesiredPropertiesResponse modifyFeatureDesiredPropertiesResponse(final ThingId thingId,
             final String featureId, final FeatureProperties properties, final DittoHeaders dittoHeaders,
             final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(properties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, properties, dittoHeaders);
         if (created) {
             return ModifyFeatureDesiredPropertiesResponse.created(thingId, featureId, properties, dittoHeadersWithETag);
         } else {
@@ -220,7 +226,7 @@ public final class ETagTestUtils {
             final ThingId thingId,
             final String featureId, final FeatureProperties featureProperties,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(featureProperties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, featureProperties, dittoHeaders);
         return RetrieveFeatureDesiredPropertiesResponse.of(thingId, featureId, featureProperties,
                 dittoHeadersWithETag);
     }
@@ -230,7 +236,7 @@ public final class ETagTestUtils {
             final String featureId, final FeatureProperties featureProperties,
             final FeatureProperties expectedFeatureProperties,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(featureProperties, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, featureProperties, dittoHeaders);
         return RetrieveFeatureDesiredPropertiesResponse.of(thingId, featureId, expectedFeatureProperties,
                 dittoHeadersWithETag);
     }
@@ -240,7 +246,7 @@ public final class ETagTestUtils {
     public static ModifyFeaturePropertyResponse modifyFeaturePropertyResponse(final ThingId thingId,
             final String featureId, final JsonPointer propertyPointer, final JsonValue propertyValue,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(propertyValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, propertyValue, dittoHeaders);
         if (created) {
             return ModifyFeaturePropertyResponse.created(thingId, featureId, propertyPointer, propertyValue,
                     dittoHeadersWithETag);
@@ -252,7 +258,7 @@ public final class ETagTestUtils {
     public static RetrieveFeaturePropertyResponse retrieveFeaturePropertyResponse(final ThingId thingId,
             final String featureId, final JsonPointer propertyPointer, final JsonValue propertyValue,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(propertyValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, propertyValue, dittoHeaders);
         return RetrieveFeaturePropertyResponse.of(thingId, featureId, propertyPointer, propertyValue,
                 dittoHeadersWithETag);
     }
@@ -262,7 +268,7 @@ public final class ETagTestUtils {
     public static ModifyFeatureDesiredPropertyResponse modifyFeatureDesiredPropertyResponse(final ThingId thingId,
             final String featureId, final JsonPointer propertyPointer, final JsonValue propertyValue,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(propertyValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, propertyValue, dittoHeaders);
         if (created) {
             return ModifyFeatureDesiredPropertyResponse.created(thingId, featureId, propertyPointer, propertyValue,
                     dittoHeadersWithETag);
@@ -275,7 +281,7 @@ public final class ETagTestUtils {
     public static RetrieveFeatureDesiredPropertyResponse retrieveFeatureDesiredPropertyResponse(final ThingId thingId,
             final String featureId, final JsonPointer propertyPointer, final JsonValue propertyValue,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(propertyValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, propertyValue, dittoHeaders);
         return RetrieveFeatureDesiredPropertyResponse.of(thingId, featureId, propertyPointer, propertyValue,
                 dittoHeadersWithETag);
     }
@@ -284,7 +290,7 @@ public final class ETagTestUtils {
 
     public static ModifyAttributesResponse modifyAttributeResponse(final ThingId thingId,
             final Attributes modifiedAttributes, final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(modifiedAttributes, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, modifiedAttributes, dittoHeaders);
         if (created) {
             return ModifyAttributesResponse.created(thingId, modifiedAttributes, dittoHeadersWithETag);
         } else {
@@ -295,7 +301,7 @@ public final class ETagTestUtils {
     public static RetrieveAttributesResponse retrieveAttributesResponse(final ThingId thingId,
             final Attributes expectedAttributes, final JsonObject expectedJsonRepresentation,
             final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedAttributes, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedAttributes, dittoHeaders);
         return RetrieveAttributesResponse.of(thingId, expectedJsonRepresentation, dittoHeadersWithETag);
     }
 
@@ -304,7 +310,7 @@ public final class ETagTestUtils {
     public static ModifyAttributeResponse modifyAttributeResponse(final ThingId thingId,
             final JsonPointer attributePointer, final JsonValue attributeValue, final DittoHeaders dittoHeaders,
             final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(attributeValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, attributeValue, dittoHeaders);
         if (created) {
             return ModifyAttributeResponse.created(thingId, attributePointer, attributeValue, dittoHeadersWithETag);
         } else {
@@ -314,7 +320,7 @@ public final class ETagTestUtils {
 
     public static RetrieveAttributeResponse retrieveAttributeResponse(final ThingId thingId,
             final JsonPointer attributePointer, final JsonValue attributeValue, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(attributeValue, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, attributeValue, dittoHeaders);
         return RetrieveAttributeResponse.of(thingId, attributePointer, attributeValue, dittoHeadersWithETag);
     }
 
@@ -322,7 +328,7 @@ public final class ETagTestUtils {
 
     public static ModifyPolicyIdResponse modifyPolicyIdResponse(final ThingId thingId, final PolicyId policyId,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(policyId, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, policyId, dittoHeaders);
         if (created) {
             return ModifyPolicyIdResponse.created(thingId, policyId, dittoHeadersWithETag);
         } else {
@@ -332,7 +338,7 @@ public final class ETagTestUtils {
 
     public static RetrievePolicyIdResponse retrievePolicyIdResponse(final ThingId thingId,
             final PolicyId expectedPolicyId, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedPolicyId, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedPolicyId, dittoHeaders);
         return RetrievePolicyIdResponse.of(thingId, expectedPolicyId, dittoHeadersWithETag);
     }
 
@@ -341,7 +347,7 @@ public final class ETagTestUtils {
     public static ModifyThingDefinitionResponse modifyThingDefinitionResponse(final ThingId thingId,
             final ThingDefinition definition,
             final DittoHeaders dittoHeaders, final boolean created) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(definition, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, definition, dittoHeaders);
         if (created) {
             return ModifyThingDefinitionResponse.created(thingId, definition, dittoHeadersWithETag);
         } else {
@@ -351,13 +357,18 @@ public final class ETagTestUtils {
 
     public static RetrieveThingDefinitionResponse retrieveDefinitionResponse(final ThingId thingId,
             final ThingDefinition expectedThingDefinition, final DittoHeaders dittoHeaders) {
-        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThingDefinition, dittoHeaders);
+        final DittoHeaders dittoHeadersWithETag = appendEntityIdAndETagToDittoHeaders(thingId, expectedThingDefinition, dittoHeaders);
         return RetrieveThingDefinitionResponse.of(thingId, expectedThingDefinition, dittoHeadersWithETag);
     }
 
 
-    protected static DittoHeaders appendETagToDittoHeaders(final Object object, final DittoHeaders dittoHeaders) {
-
-        return dittoHeaders.toBuilder().eTag(EntityTag.fromEntity(object).get()).build();
+    protected static DittoHeaders appendEntityIdAndETagToDittoHeaders(final ThingId thingId,
+            final Object object,
+            final DittoHeaders dittoHeaders
+    ) {
+        return dittoHeaders.toBuilder()
+                .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                .eTag(EntityTag.fromEntity(object).get())
+                .build();
     }
 }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorSnapshottingTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorSnapshottingTest.java
@@ -16,8 +16,12 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.PoisonPill;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.signals.events.EventsourcedEvent;
 import org.eclipse.ditto.internal.utils.config.DittoConfigError;
 import org.eclipse.ditto.internal.utils.test.Retry;
@@ -47,10 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
-
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.PoisonPill;
-import org.apache.pekko.testkit.javadsl.TestKit;
 
 /**
  * Unit test for the snapshotting functionality of {@link ThingPersistenceActor}.
@@ -101,7 +101,9 @@ public final class ThingPersistenceActorSnapshottingTest extends PersistenceActo
 
                 final DeleteThing deleteThing = DeleteThing.of(thingId, dittoHeadersV2);
                 underTest.tell(deleteThing, getRef());
-                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2));
+                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                        .build()));
 
                 final Thing expectedDeletedSnapshot = toDeletedThing(2);
                 assertSnapshots(thingId, Collections.singletonList(expectedDeletedSnapshot));

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorTest.java
@@ -595,7 +595,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
                 final DeleteThing deleteThing = DeleteThing.of(getIdOrThrow(thing), dittoHeadersV2);
                 underTest.tell(deleteThing, getRef());
-                expectMsgEquals(DeleteThingResponse.of(getIdOrThrow(thing), dittoHeadersV2));
+                expectMsgEquals(DeleteThingResponse.of(getIdOrThrow(thing), dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thing.getEntityId().get().toString())
+                        .build()));
             }
         };
     }
@@ -620,7 +622,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
                 final DeleteThing deleteThing = DeleteThing.of(thingId, dittoHeadersV2);
                 underTest.tell(deleteThing, getRef());
-                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2));
+                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                        .build()));
 
                 final Thing minimalThing = Thing.newBuilder()
                         .setId(thingId)
@@ -834,7 +838,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                 // Delete attribute as authorized subject.
                 final ThingCommand authorizedCommand = DeleteAttribute.of(thingId, attributeKey, dittoHeadersV2);
                 underTest.tell(authorizedCommand, getRef());
-                expectMsgEquals(DeleteAttributeResponse.of(thingId, attributeKey, dittoHeadersV2));
+                expectMsgEquals(DeleteAttributeResponse.of(thingId, attributeKey, dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                        .build()));
             }
         };
     }
@@ -857,7 +863,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                 assertThingInResponse(createThingResponse.getThingCreated().orElse(null), thing);
 
                 underTest.tell(deleteThingCommand, getRef());
-                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2));
+                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                        .build()));
 
                 underTest.tell(retrieveThingCommand, getRef());
                 expectMsgClass(ThingNotAccessibleException.class);
@@ -917,7 +925,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
                 final DeleteThing deleteThing = DeleteThing.of(thingId, dittoHeadersV2);
                 underTest.tell(deleteThing, getRef());
-                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2));
+                expectMsgEquals(DeleteThingResponse.of(thingId, dittoHeadersV2.toBuilder()
+                        .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), thingId.toString())
+                        .build()));
 
                 // restart actor to recover thing state
                 watch(underTest);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.assertj.core.api.CompletableFutureAssert;
 import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
@@ -175,6 +176,12 @@ public abstract class AbstractCommandStrategyTest {
         final ResultVisitor<ThingEvent<?>> mock = mock(Dummy.class);
         underTest.unhandled(getDefaultContext(), thing, NEXT_REVISION, command).accept(mock, null);
         verify(mock).onError(eq(expectedResponse), eq(command));
+    }
+
+    protected static DittoHeaders provideHeaders(final CommandStrategy.Context<ThingId> context) {
+        return DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(), context.getState().toString())
+                .build();
     }
 
     private static <T extends ThingModifiedEvent<?>> T assertModificationResult(final Result<ThingEvent<?>> result,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteAttributeStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteAttributeStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
@@ -49,7 +48,7 @@ public final class DeleteAttributeStrategyTest extends AbstractCommandStrategyTe
     public void successfullyDeleteAttribute() {
         final JsonPointer attrPointer = JsonFactory.newPointer("/location/longitude");
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, DittoHeaders.empty());
+        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 AttributeDeleted.class,
@@ -61,7 +60,7 @@ public final class DeleteAttributeStrategyTest extends AbstractCommandStrategyTe
     public void deleteAttributeFromThingWithoutAttributes() {
         final JsonPointer attrPointer = JsonFactory.newPointer("/location/longitude");
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, DittoHeaders.empty());
+        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributeNotFound(context.getState(), attrPointer, command.getDittoHeaders());
 
@@ -72,7 +71,7 @@ public final class DeleteAttributeStrategyTest extends AbstractCommandStrategyTe
     public void deleteAttributeFromThingWithoutThatAttribute() {
         final JsonPointer attrPointer = JsonFactory.newPointer("/location/longitude");
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, DittoHeaders.empty());
+        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributeNotFound(context.getState(), attrPointer, command.getDittoHeaders());
 
@@ -97,7 +96,7 @@ public final class DeleteAttributeStrategyTest extends AbstractCommandStrategyTe
         // if it was an object and the object did not contain "non", then the test would fail trivially.
         final JsonPointer attrPointer = JsonFactory.newPointer("/complex/nested/non/existent/path");
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, DittoHeaders.empty());
+        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributeNotFound(context.getState(), attrPointer, command.getDittoHeaders());
 
@@ -123,7 +122,7 @@ public final class DeleteAttributeStrategyTest extends AbstractCommandStrategyTe
 
         final JsonPointer attrPointer = JsonFactory.newPointer("/flat/non/existent/path");
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, DittoHeaders.empty());
+        final DeleteAttribute command = DeleteAttribute.of(context.getState(), attrPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributeNotFound(context.getState(), attrPointer, command.getDittoHeaders());
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteAttributesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteAttributesStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteAttributes;
@@ -43,7 +42,7 @@ public final class DeleteAttributesStrategyTest extends AbstractCommandStrategyT
     @Test
     public void successfullyDeleteAllAttributesFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttributes command = DeleteAttributes.of(context.getState(), DittoHeaders.empty());
+        final DeleteAttributes command = DeleteAttributes.of(context.getState(), provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 AttributesDeleted.class,
@@ -53,7 +52,7 @@ public final class DeleteAttributesStrategyTest extends AbstractCommandStrategyT
     @Test
     public void deleteAttributesFromThingWithoutAttributes() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteAttributes command = DeleteAttributes.of(context.getState(), DittoHeaders.empty());
+        final DeleteAttributes command = DeleteAttributes.of(context.getState(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributesNotFound(context.getState(), command.getDittoHeaders());
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDefinitionStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.ThingId;
@@ -48,7 +47,7 @@ public final class DeleteFeatureDefinitionStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final String featureId = FLUX_CAPACITOR_ID;
         final DeleteFeatureDefinition command =
-                DeleteFeatureDefinition.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureDefinition.of(context.getState(), featureId, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDefinitionDeleted.class,
@@ -59,7 +58,7 @@ public final class DeleteFeatureDefinitionStrategyTest extends AbstractCommandSt
     public void deleteFeatureDefinitionFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDefinition command =
-                DeleteFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                DeleteFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -72,7 +71,7 @@ public final class DeleteFeatureDefinitionStrategyTest extends AbstractCommandSt
         final String featureId = FLUX_CAPACITOR_ID;
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDefinition command =
-                DeleteFeatureDefinition.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureDefinition.of(context.getState(), featureId, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -85,7 +84,7 @@ public final class DeleteFeatureDefinitionStrategyTest extends AbstractCommandSt
         final Feature feature = FLUX_CAPACITOR.removeDefinition();
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDefinition command =
-                DeleteFeatureDefinition.of(context.getState(), feature.getId(), DittoHeaders.empty());
+                DeleteFeatureDefinition.of(context.getState(), feature.getId(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDefinitionNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDesiredPropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDesiredPropertiesStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.ThingId;
@@ -48,7 +47,7 @@ public final class DeleteFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final String featureId = FLUX_CAPACITOR_ID;
         final DeleteFeatureDesiredProperties command =
-                DeleteFeatureDesiredProperties.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureDesiredProperties.of(context.getState(), featureId, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDesiredPropertiesDeleted.class,
@@ -59,7 +58,7 @@ public final class DeleteFeatureDesiredPropertiesStrategyTest extends AbstractCo
     public void deleteFeatureDesiredPropertiesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperties command =
-                DeleteFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                DeleteFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -72,7 +71,7 @@ public final class DeleteFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final String featureId = FLUX_CAPACITOR_ID;
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperties command =
-                DeleteFeatureDesiredProperties.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureDesiredProperties.of(context.getState(), featureId, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -85,7 +84,7 @@ public final class DeleteFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final Feature feature = FLUX_CAPACITOR.removeDesiredProperties();
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperties command =
-                DeleteFeatureDesiredProperties.of(context.getState(), feature.getId(), DittoHeaders.empty());
+                DeleteFeatureDesiredProperties.of(context.getState(), feature.getId(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertiesNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDesiredPropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureDesiredPropertyStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -59,7 +58,7 @@ public final class DeleteFeatureDesiredPropertyStrategyTest extends AbstractComm
     public void successfullyDeleteFeatureDesiredPropertyFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperty command =
-                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDesiredPropertyDeleted.class,
@@ -71,7 +70,7 @@ public final class DeleteFeatureDesiredPropertyStrategyTest extends AbstractComm
     public void deleteFeatureDesiredPropertyFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperty command =
-                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -83,7 +82,7 @@ public final class DeleteFeatureDesiredPropertyStrategyTest extends AbstractComm
     public void deleteFeatureDesiredPropertyFromThingWithoutThatFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperty command =
-                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -96,7 +95,7 @@ public final class DeleteFeatureDesiredPropertyStrategyTest extends AbstractComm
         final Feature feature = FLUX_CAPACITOR.removeDesiredProperties();
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperty command =
-                DeleteFeatureDesiredProperty.of(context.getState(), feature.getId(), propertyPointer, DittoHeaders.empty());
+                DeleteFeatureDesiredProperty.of(context.getState(), feature.getId(), propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertyNotFound(context.getState(), command.getFeatureId(),
                         propertyPointer, command.getDittoHeaders());
@@ -109,7 +108,7 @@ public final class DeleteFeatureDesiredPropertyStrategyTest extends AbstractComm
         final Feature feature = FLUX_CAPACITOR.removeDesiredProperty(propertyPointer);
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureDesiredProperty command =
-                DeleteFeatureDesiredProperty.of(context.getState(), feature.getId(), propertyPointer, DittoHeaders.empty());
+                DeleteFeatureDesiredProperty.of(context.getState(), feature.getId(), propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertyNotFound(context.getState(), command.getFeatureId(),
                         propertyPointer, command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturePropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturePropertiesStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.ThingId;
@@ -48,7 +47,7 @@ public final class DeleteFeaturePropertiesStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final String featureId = FLUX_CAPACITOR_ID;
         final DeleteFeatureProperties command =
-                DeleteFeatureProperties.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureProperties.of(context.getState(), featureId, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturePropertiesDeleted.class,
@@ -59,7 +58,7 @@ public final class DeleteFeaturePropertiesStrategyTest extends AbstractCommandSt
     public void deleteFeaturePropertiesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperties command =
-                DeleteFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                DeleteFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -72,7 +71,7 @@ public final class DeleteFeaturePropertiesStrategyTest extends AbstractCommandSt
         final String featureId = FLUX_CAPACITOR_ID;
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperties command =
-                DeleteFeatureProperties.of(context.getState(), featureId, DittoHeaders.empty());
+                DeleteFeatureProperties.of(context.getState(), featureId, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -85,7 +84,7 @@ public final class DeleteFeaturePropertiesStrategyTest extends AbstractCommandSt
         final Feature feature = FLUX_CAPACITOR.removeProperties();
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperties command =
-                DeleteFeatureProperties.of(context.getState(), feature.getId(), DittoHeaders.empty());
+                DeleteFeatureProperties.of(context.getState(), feature.getId(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertiesNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturePropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturePropertyStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -59,7 +58,7 @@ public final class DeleteFeaturePropertyStrategyTest extends AbstractCommandStra
     public void successfullyDeleteFeaturePropertyFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperty command =
-                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturePropertyDeleted.class,
@@ -71,7 +70,7 @@ public final class DeleteFeaturePropertyStrategyTest extends AbstractCommandStra
     public void deleteFeaturePropertyFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperty command =
-                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -83,7 +82,7 @@ public final class DeleteFeaturePropertyStrategyTest extends AbstractCommandStra
     public void deleteFeaturePropertyFromThingWithoutThatFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperty command =
-                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, DittoHeaders.empty());
+                DeleteFeatureProperty.of(context.getState(), featureId, propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -96,7 +95,7 @@ public final class DeleteFeaturePropertyStrategyTest extends AbstractCommandStra
         final Feature feature = FLUX_CAPACITOR.removeProperties();
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperty command =
-                DeleteFeatureProperty.of(context.getState(), feature.getId(), propertyPointer, DittoHeaders.empty());
+                DeleteFeatureProperty.of(context.getState(), feature.getId(), propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertyNotFound(context.getState(), command.getFeatureId(),
                         propertyPointer, command.getDittoHeaders());
@@ -109,7 +108,7 @@ public final class DeleteFeaturePropertyStrategyTest extends AbstractCommandStra
         final Feature feature = FLUX_CAPACITOR.removeProperty(propertyPointer);
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final DeleteFeatureProperty command =
-                DeleteFeatureProperty.of(context.getState(), feature.getId(), propertyPointer, DittoHeaders.empty());
+                DeleteFeatureProperty.of(context.getState(), feature.getId(), propertyPointer, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertyNotFound(context.getState(), command.getFeatureId(),
                         propertyPointer, command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeatureStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.TestConstants;
 import org.eclipse.ditto.things.model.ThingId;
@@ -52,8 +51,7 @@ public final class DeleteFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void successfullyDeleteFeatureFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteFeature command = DeleteFeature.of(context.getState(), featureId, DittoHeaders.newBuilder()
-                .build());
+        final DeleteFeature command = DeleteFeature.of(context.getState(), featureId, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command, FeatureDeleted.class,
                 DeleteFeatureResponse.of(context.getState(), command.getFeatureId(), command.getDittoHeaders()));
@@ -62,7 +60,7 @@ public final class DeleteFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void deleteFeatureFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteFeature command = DeleteFeature.of(context.getState(), featureId, DittoHeaders.empty());
+        final DeleteFeature command = DeleteFeature.of(context.getState(), featureId, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -73,7 +71,7 @@ public final class DeleteFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void deleteFeatureFromThingWithoutThatFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteFeature command = DeleteFeature.of(context.getState(), "myFeature", DittoHeaders.empty());
+        final DeleteFeature command = DeleteFeature.of(context.getState(), "myFeature", provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteFeaturesStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteFeatures;
@@ -43,7 +42,7 @@ public final class DeleteFeaturesStrategyTest extends AbstractCommandStrategyTes
     @Test
     public void successfullyDeleteFeaturesFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteFeatures command = DeleteFeatures.of(context.getState(), DittoHeaders.empty());
+        final DeleteFeatures command = DeleteFeatures.of(context.getState(), provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturesDeleted.class,
@@ -53,7 +52,7 @@ public final class DeleteFeaturesStrategyTest extends AbstractCommandStrategyTes
     @Test
     public void deleteFeaturesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteFeatures command = DeleteFeatures.of(context.getState(), DittoHeaders.empty());
+        final DeleteFeatures command = DeleteFeatures.of(context.getState(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featuresNotFound(context.getState(), command.getDittoHeaders());
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteThingDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteThingDefinitionStrategyTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingDefinitionNotAccessibleException;
@@ -43,7 +42,7 @@ public final class DeleteThingDefinitionStrategyTest extends AbstractCommandStra
     @Test
     public void successfullyDeleteDefinitionFromThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteThingDefinition command = DeleteThingDefinition.of(context.getState(), DittoHeaders.empty());
+        final DeleteThingDefinition command = DeleteThingDefinition.of(context.getState(), provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 ThingDefinitionDeleted.class,
@@ -53,7 +52,7 @@ public final class DeleteThingDefinitionStrategyTest extends AbstractCommandStra
     @Test
     public void deleteDefinitionFromThingWithoutDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteThingDefinition command = DeleteThingDefinition.of(context.getState(), DittoHeaders.empty());
+        final DeleteThingDefinition command = DeleteThingDefinition.of(context.getState(), provideHeaders(context));
         final ThingDefinitionNotAccessibleException expectedException =
                 ThingDefinitionNotAccessibleException.newBuilder(command.getEntityId())
                         .dittoHeaders(command.getDittoHeaders())

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteThingStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteThingStrategyTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteThing;
@@ -42,7 +41,7 @@ public final class DeleteThingStrategyTest extends AbstractCommandStrategyTest {
     @Test
     public void successfullyDeleteThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final DeleteThing command = DeleteThing.of(context.getState(), DittoHeaders.empty());
+        final DeleteThing command = DeleteThing.of(context.getState(), provideHeaders(context));
 
         assertModificationResult(underTest, THING_V2, command,
                 ThingDeleted.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategyTest.java
@@ -67,7 +67,7 @@ public final class MergeThingStrategyTest extends AbstractCommandStrategyTest {
         final JsonPointer path = JsonPointer.of("/");
         final JsonObject thingJson = thingToMerge.toJson();
 
-        final MergeThing mergeThing = MergeThing.of(thingId, path, thingJson, DittoHeaders.empty());
+        final MergeThing mergeThing = MergeThing.of(thingId, path, thingJson, provideHeaders(context));
         final MergeThingResponse expectedCommandResponse =
                 ETagTestUtils.mergeThingResponse(existing, path, mergeThing.getDittoHeaders());
         assertStagedModificationResult(underTest, existing, mergeThing, ThingMerged.class, expectedCommandResponse);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyAttributeStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyAttributeStrategyTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -57,7 +56,7 @@ public final class ModifyAttributeStrategyTest extends AbstractCommandStrategyTe
     public void modifyAttributeOfThingWithoutAttributes() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyAttribute command =
-                ModifyAttribute.of(context.getState(), attributePointer, attributeValue, DittoHeaders.empty());
+                ModifyAttribute.of(context.getState(), attributePointer, attributeValue, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeAttributes(), command,
                 AttributeCreated.class,
@@ -69,7 +68,7 @@ public final class ModifyAttributeStrategyTest extends AbstractCommandStrategyTe
     public void modifyAttributeOfThingWithoutThatAttribute() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyAttribute command =
-                ModifyAttribute.of(context.getState(), attributePointer, attributeValue, DittoHeaders.empty());
+                ModifyAttribute.of(context.getState(), attributePointer, attributeValue, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 AttributeCreated.class,
@@ -85,7 +84,7 @@ public final class ModifyAttributeStrategyTest extends AbstractCommandStrategyTe
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyAttribute command =
                 ModifyAttribute.of(context.getState(), existingAttributePointer, newAttributeValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 AttributeModified.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyAttributesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyAttributesStrategyTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Attributes;
 import org.eclipse.ditto.things.model.TestConstants;
@@ -56,7 +55,7 @@ public final class ModifyAttributesStrategyTest extends AbstractCommandStrategyT
     public void modifyAttributesOfThingWithoutAttributes() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyAttributes command =
-                ModifyAttributes.of(context.getState(), modifiedAttributes, DittoHeaders.empty());
+                ModifyAttributes.of(context.getState(), modifiedAttributes, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeAttributes(), command,
                 AttributesCreated.class,
@@ -67,7 +66,7 @@ public final class ModifyAttributesStrategyTest extends AbstractCommandStrategyT
     public void modifyAttributesOfThingWithAttributes() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyAttributes command =
-                ModifyAttributes.of(context.getState(), modifiedAttributes, DittoHeaders.empty());
+                ModifyAttributes.of(context.getState(), modifiedAttributes, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 AttributesModified.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDefinitionStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.FeatureDefinition;
@@ -59,7 +58,7 @@ public final class ModifyFeatureDefinitionStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDefinition command =
                 ModifyFeatureDefinition.of(context.getState(), featureId, modifiedFeatureDefinition,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), featureId, command.getDittoHeaders());
 
@@ -71,7 +70,7 @@ public final class ModifyFeatureDefinitionStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDefinition command =
                 ModifyFeatureDefinition.of(context.getState(), featureId, modifiedFeatureDefinition,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), featureId, command.getDittoHeaders());
 
@@ -84,7 +83,7 @@ public final class ModifyFeatureDefinitionStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDefinition command =
                 ModifyFeatureDefinition.of(context.getState(), featureId, modifiedFeatureDefinition,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.setFeature(featureWithoutDefinition), command,
                 FeatureDefinitionCreated.class,
@@ -97,7 +96,7 @@ public final class ModifyFeatureDefinitionStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDefinition command =
                 ModifyFeatureDefinition.of(context.getState(), featureId, modifiedFeatureDefinition,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDefinitionModified.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDesiredPropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDesiredPropertiesStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.Feature;
@@ -68,7 +67,7 @@ public final class ModifyFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperties command =
                 ModifyFeatureDesiredProperties.of(context.getState(), featureId, modifiedFeatureDesiredProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -81,7 +80,7 @@ public final class ModifyFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperties command =
                 ModifyFeatureDesiredProperties.of(context.getState(), featureId, modifiedFeatureDesiredProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -95,7 +94,7 @@ public final class ModifyFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperties command =
                 ModifyFeatureDesiredProperties.of(context.getState(), featureId, modifiedFeatureDesiredProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.setFeature(featureWithoutProperties), command,
                 FeatureDesiredPropertiesCreated.class,
@@ -108,7 +107,7 @@ public final class ModifyFeatureDesiredPropertiesStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperties command =
                 ModifyFeatureDesiredProperties.of(context.getState(), featureId, modifiedFeatureDesiredProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDesiredPropertiesModified.class,
@@ -140,11 +139,11 @@ public final class ModifyFeatureDesiredPropertiesStrategyTest extends AbstractCo
                 .build();
 
         // creating the Thing should be possible as we are below the limit:
-        CreateThing.of(thing, null, DittoHeaders.empty());
+        CreateThing.of(thing, null, provideHeaders(context));
 
         final ModifyFeatureDesiredProperties command =
                 ModifyFeatureDesiredProperties.of(thingId, feature.getId(), feature.getDesiredProperties().get(),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         // but modifying the feature properties which would cause the Thing to exceed the limit should not be allowed:
         assertThatThrownBy(() -> underTest.doApply(context, thing, NEXT_REVISION, command, null))

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDesiredPropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureDesiredPropertyStrategyTest.java
@@ -66,7 +66,7 @@ public final class ModifyFeatureDesiredPropertyStrategyTest extends AbstractComm
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperty command =
                 ModifyFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -79,7 +79,7 @@ public final class ModifyFeatureDesiredPropertyStrategyTest extends AbstractComm
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperty command =
                 ModifyFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -92,7 +92,7 @@ public final class ModifyFeatureDesiredPropertyStrategyTest extends AbstractComm
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperty command =
                 ModifyFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeFeatureDesiredProperties(featureId), command,
                 FeatureDesiredPropertyCreated.class,
@@ -105,7 +105,7 @@ public final class ModifyFeatureDesiredPropertyStrategyTest extends AbstractComm
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureDesiredProperty command =
                 ModifyFeatureDesiredProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureDesiredPropertyModified.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturePropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturePropertiesStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.common.DittoSystemProperties;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.Feature;
@@ -68,7 +67,7 @@ public final class ModifyFeaturePropertiesStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperties command =
                 ModifyFeatureProperties.of(context.getState(), featureId, modifiedFeatureProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -81,7 +80,7 @@ public final class ModifyFeaturePropertiesStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperties command =
                 ModifyFeatureProperties.of(context.getState(), featureId, modifiedFeatureProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -95,7 +94,7 @@ public final class ModifyFeaturePropertiesStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperties command =
                 ModifyFeatureProperties.of(context.getState(), featureId, modifiedFeatureProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.setFeature(featureWithoutProperties), command,
                 FeaturePropertiesCreated.class,
@@ -108,7 +107,7 @@ public final class ModifyFeaturePropertiesStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperties command =
                 ModifyFeatureProperties.of(context.getState(), featureId, modifiedFeatureProperties,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturePropertiesModified.class,
@@ -140,11 +139,11 @@ public final class ModifyFeaturePropertiesStrategyTest extends AbstractCommandSt
                 .build();
 
         // creating the Thing should be possible as we are below the limit:
-        CreateThing.of(thing, null, DittoHeaders.empty());
+        CreateThing.of(thing, null, provideHeaders(context));
 
         final ModifyFeatureProperties command =
                 ModifyFeatureProperties.of(thingId, feature.getId(), feature.getProperties().get(),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         // but modifying the feature properties which would cause the Thing to exceed the limit should not be allowed:
         assertThatThrownBy(() -> underTest.doApply(context, thing, NEXT_REVISION, command, null))

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturePropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturePropertyStrategyTest.java
@@ -66,7 +66,7 @@ public final class ModifyFeaturePropertyStrategyTest extends AbstractCommandStra
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperty command =
                 ModifyFeatureProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -79,7 +79,7 @@ public final class ModifyFeaturePropertyStrategyTest extends AbstractCommandStra
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperty command =
                 ModifyFeatureProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -92,7 +92,7 @@ public final class ModifyFeaturePropertyStrategyTest extends AbstractCommandStra
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperty command =
                 ModifyFeatureProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeFeatureProperties(featureId), command,
                 FeaturePropertyCreated.class,
@@ -105,7 +105,7 @@ public final class ModifyFeaturePropertyStrategyTest extends AbstractCommandStra
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperty command =
                 ModifyFeatureProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturePropertyModified.class,
@@ -118,7 +118,7 @@ public final class ModifyFeaturePropertyStrategyTest extends AbstractCommandStra
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyFeatureProperty command =
                 ModifyFeatureProperty.of(context.getState(), featureId, propertyPointer, newPropertyValue,
-                        DittoHeaders.newBuilder()
+                        provideHeaders(context).toBuilder()
                                 .putMetadata(MetadataHeaderKey.of(JsonPointer.of("meta")), JsonObject.newBuilder()
                                         .set("description", "bumlux")
                                         .build())

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategyTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.TestConstants;
@@ -24,7 +23,6 @@ import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeature;
 import org.eclipse.ditto.things.model.signals.events.FeatureCreated;
 import org.eclipse.ditto.things.model.signals.events.FeatureModified;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
-import org.eclipse.ditto.wot.api.generator.WotThingDescriptionGenerator;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +52,7 @@ public final class ModifyFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void modifyFeatureOnThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, DittoHeaders.empty());
+        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeFeatures(), command,
                 FeatureCreated.class,
@@ -64,7 +62,7 @@ public final class ModifyFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void modifyFeatureOnThingWithoutThatFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, DittoHeaders.empty());
+        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeFeature(modifiedFeature.getId()), command,
                 FeatureCreated.class,
@@ -74,7 +72,7 @@ public final class ModifyFeatureStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void modifyExistingFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, DittoHeaders.empty());
+        final ModifyFeature command = ModifyFeature.of(context.getState(), modifiedFeature, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeatureModified.class,

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategyTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.Feature;
@@ -31,7 +30,6 @@ import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeatures;
 import org.eclipse.ditto.things.model.signals.events.FeaturesCreated;
 import org.eclipse.ditto.things.model.signals.events.FeaturesModified;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
-import org.eclipse.ditto.wot.api.generator.WotThingDescriptionGenerator;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -65,7 +63,7 @@ public final class ModifyFeaturesStrategyTest extends AbstractCommandStrategyTes
     @Test
     public void modifyFeaturesOfThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyFeatures command = ModifyFeatures.of(context.getState(), modifiedFeatures, DittoHeaders.empty());
+        final ModifyFeatures command = ModifyFeatures.of(context.getState(), modifiedFeatures, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.removeFeatures(), command,
                 FeaturesCreated.class,
@@ -75,7 +73,7 @@ public final class ModifyFeaturesStrategyTest extends AbstractCommandStrategyTes
     @Test
     public void modifyExistingFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyFeatures command = ModifyFeatures.of(context.getState(), modifiedFeatures, DittoHeaders.empty());
+        final ModifyFeatures command = ModifyFeatures.of(context.getState(), modifiedFeatures, provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 FeaturesModified.class,
@@ -106,10 +104,10 @@ public final class ModifyFeaturesStrategyTest extends AbstractCommandStrategyTes
                 .build();
 
         // creating the Thing should be possible as we are below the limit:
-        CreateThing.of(thing, null, DittoHeaders.empty());
+        CreateThing.of(thing, null, provideHeaders(context));
 
         final ModifyFeatures command =
-                ModifyFeatures.of(thingId, Features.newBuilder().set(feature).build(), DittoHeaders.empty());
+                ModifyFeatures.of(thingId, Features.newBuilder().set(feature).build(), provideHeaders(context));
 
         // but modifying the features which would cause the Thing to exceed the limit should not be allowed:
         assertThatThrownBy(() -> underTest.doApply(context, thing, NEXT_REVISION, command, null))

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyPolicyIdStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyPolicyIdStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.POLICY_ID;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyPolicyId;
@@ -43,7 +42,7 @@ public final class ModifyPolicyIdStrategyTest extends AbstractCommandStrategyTes
     @Test
     public void modifyExistingPolicyId() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final ModifyPolicyId command = ModifyPolicyId.of(context.getState(), POLICY_ID, DittoHeaders.empty());
+        final ModifyPolicyId command = ModifyPolicyId.of(context.getState(), POLICY_ID, provideHeaders(context));
 
         assertModificationResult(underTest, THING_V2, command,
                 PolicyIdModified.class, ETagTestUtils.modifyPolicyIdResponse(context.getState(), command.getPolicyEntityId(),

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingDefinitionStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.DEFINITION;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThingDefinition;
@@ -45,7 +44,7 @@ public final class ModifyThingDefinitionStrategyTest extends AbstractCommandStra
     public void modifyDefinitionOnThingWithoutDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyThingDefinition command = ModifyThingDefinition.of(context.getState(), DEFINITION,
-                DittoHeaders.empty());
+                provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2.toBuilder().setDefinition(null).build(), command,
                 ThingDefinitionCreated.class, ETagTestUtils.modifyThingDefinitionResponse(context.getState(), command.getDefinition(),
@@ -56,7 +55,7 @@ public final class ModifyThingDefinitionStrategyTest extends AbstractCommandStra
     public void modifyExistingDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final ModifyThingDefinition command = ModifyThingDefinition.of(context.getState(), DEFINITION,
-                DittoHeaders.empty());
+                provideHeaders(context));
 
         assertStagedModificationResult(underTest, THING_V2, command,
                 ThingDefinitionModified.class, ETagTestUtils.modifyThingDefinitionResponse(context.getState(),

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingStrategyTest.java
@@ -17,7 +17,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 import java.time.Instant;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
@@ -59,7 +58,7 @@ public final class ModifyThingStrategyTest extends AbstractCommandStrategyTest {
                 .setCreated(MODIFIED)
                 .build();
 
-        final ModifyThing modifyThing = ModifyThing.of(thingId, thing, null, DittoHeaders.empty());
+        final ModifyThing modifyThing = ModifyThing.of(thingId, thing, null, provideHeaders(context));
 
         assertStagedModificationResult(underTest, existing, modifyThing,
                 ThingModified.class, ETagTestUtils.modifyThingResponse(existing, thing, modifyThing.getDittoHeaders(), false));

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveAttributeStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveAttributeStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -47,7 +46,7 @@ public final class RetrieveAttributeStrategyTest extends AbstractCommandStrategy
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final JsonPointer attributePointer = JsonFactory.newPointer("location/latitude");
         final RetrieveAttribute command =
-                RetrieveAttribute.of(context.getState(), attributePointer, DittoHeaders.empty());
+                RetrieveAttribute.of(context.getState(), attributePointer, provideHeaders(context));
         final RetrieveAttributeResponse expectedResponse =
                 ETagTestUtils.retrieveAttributeResponse(command.getEntityId(), command.getAttributePointer(),
                         JsonFactory.newValue(44.673856), command.getDittoHeaders());
@@ -60,7 +59,7 @@ public final class RetrieveAttributeStrategyTest extends AbstractCommandStrategy
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveAttribute command =
                 RetrieveAttribute.of(context.getState(), JsonFactory.newPointer("location/latitude"),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributesNotFound(command.getEntityId(), command.getDittoHeaders());
 
@@ -72,7 +71,7 @@ public final class RetrieveAttributeStrategyTest extends AbstractCommandStrategy
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveAttribute command =
                 RetrieveAttribute.of(context.getState(), JsonFactory.newPointer("location/bar"),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.attributeNotFound(command.getEntityId(), command.getAttributePointer(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveAttributesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveAttributesStrategyTest.java
@@ -17,7 +17,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
@@ -46,10 +45,10 @@ public final class RetrieveAttributesStrategyTest extends AbstractCommandStrateg
     @Test
     public void retrieveAttributesWithoutSelectedFields() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveAttributes command = RetrieveAttributes.of(context.getState(), DittoHeaders.empty());
+        final RetrieveAttributes command = RetrieveAttributes.of(context.getState(), provideHeaders(context));
         final RetrieveAttributesResponse expectedResponse =
                 ETagTestUtils.retrieveAttributesResponse(context.getState(), ATTRIBUTES,
-                        ATTRIBUTES.toJson(command.getImplementedSchemaVersion()), DittoHeaders.empty());
+                        ATTRIBUTES.toJson(command.getImplementedSchemaVersion()), provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -59,10 +58,10 @@ public final class RetrieveAttributesStrategyTest extends AbstractCommandStrateg
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector("maker");
         final RetrieveAttributes command =
-                RetrieveAttributes.of(context.getState(), selectedFields, DittoHeaders.empty());
+                RetrieveAttributes.of(context.getState(), selectedFields, provideHeaders(context));
         final RetrieveAttributesResponse expectedResponse =
                 ETagTestUtils.retrieveAttributesResponse(context.getState(), ATTRIBUTES,
-                        ATTRIBUTES.toJson(command.getImplementedSchemaVersion(), selectedFields), DittoHeaders.empty());
+                        ATTRIBUTES.toJson(command.getImplementedSchemaVersion(), selectedFields), provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -70,9 +69,9 @@ public final class RetrieveAttributesStrategyTest extends AbstractCommandStrateg
     @Test
     public void retrieveAttributesFromThingWithoutAttributes() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveAttributes command = RetrieveAttributes.of(context.getState(), DittoHeaders.empty());
+        final RetrieveAttributes command = RetrieveAttributes.of(context.getState(), provideHeaders(context));
         final DittoRuntimeException expectedException =
-                ExceptionFactory.attributesNotFound(context.getState(), DittoHeaders.empty());
+                ExceptionFactory.attributesNotFound(context.getState(), provideHeaders(context));
 
         assertErrorResult(underTest, THING_V2.removeAttributes(), command, expectedException);
     }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDefinitionStrategyTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeatureDefinition;
@@ -47,7 +46,7 @@ public final class RetrieveFeatureDefinitionStrategyTest extends AbstractCommand
     public void getDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDefinition command =
-                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final RetrieveFeatureDefinitionResponse expectedResponse =
                 ETagTestUtils.retrieveFeatureDefinitionResponse(command.getEntityId(), command.getFeatureId(),
                         FLUX_CAPACITOR_DEFINITION, command.getDittoHeaders());
@@ -59,7 +58,7 @@ public final class RetrieveFeatureDefinitionStrategyTest extends AbstractCommand
     public void getDefinitionFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDefinition command =
-                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -71,7 +70,7 @@ public final class RetrieveFeatureDefinitionStrategyTest extends AbstractCommand
     public void getNonExistingDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDefinition command =
-                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDefinition.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDefinitionNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDesiredPropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDesiredPropertiesStrategyTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
@@ -50,7 +49,7 @@ public final class RetrieveFeatureDesiredPropertiesStrategyTest extends Abstract
     public void getProperties() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDesiredProperties command =
-                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final RetrieveFeatureDesiredPropertiesResponse expectedResponse =
                 ETagTestUtils.retrieveFeatureDesiredPropertiesResponse(command.getEntityId(), command.getFeatureId(),
                         FLUX_CAPACITOR_PROPERTIES, command.getDittoHeaders());
@@ -62,7 +61,7 @@ public final class RetrieveFeatureDesiredPropertiesStrategyTest extends Abstract
     public void getPropertiesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDesiredProperties command =
-                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -74,7 +73,7 @@ public final class RetrieveFeatureDesiredPropertiesStrategyTest extends Abstract
     public void getNonExistingDesiredProperties() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDesiredProperties command =
-                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertiesNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -89,7 +88,7 @@ public final class RetrieveFeatureDesiredPropertiesStrategyTest extends Abstract
         final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector("target_year_1");
         final RetrieveFeatureDesiredProperties command =
                 RetrieveFeatureDesiredProperties.of(context.getState(), FLUX_CAPACITOR_ID, selectedFields,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final RetrieveFeatureDesiredPropertiesResponse expectedResponse =
                 ETagTestUtils.retrieveFeatureDesiredPropertiesResponse(command.getEntityId(), command.getFeatureId(),
                         FLUX_CAPACITOR_PROPERTIES,
@@ -97,7 +96,7 @@ public final class RetrieveFeatureDesiredPropertiesStrategyTest extends Abstract
                                 .set("target_year_1",
                                         FLUX_CAPACITOR_PROPERTIES.toJson(command.getImplementedSchemaVersion(),
                                                 selectedFields).getValue("target_year_1").get()).build(),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDesiredPropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureDesiredPropertyStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -50,7 +49,7 @@ public final class RetrieveFeatureDesiredPropertyStrategyTest extends AbstractCo
         final JsonPointer propertyPointer = JsonFactory.newPointer("target_year_1");
         final RetrieveFeatureDesiredProperty command =
                 RetrieveFeatureDesiredProperty.of(context.getState(), FLUX_CAPACITOR_ID, propertyPointer,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final RetrieveFeatureDesiredPropertyResponse expectedResponse =
                 ETagTestUtils.retrieveFeatureDesiredPropertyResponse(command.getEntityId(), command.getFeatureId(),
                         command.getDesiredPropertyPointer(), JsonFactory.newValue(1955), command.getDittoHeaders());
@@ -62,7 +61,7 @@ public final class RetrieveFeatureDesiredPropertyStrategyTest extends AbstractCo
     public void getPropertyFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDesiredProperty command = RetrieveFeatureDesiredProperty.of(context.getState(), FLUX_CAPACITOR_ID,
-                JsonFactory.newPointer("target_year_1"), DittoHeaders.empty());
+                JsonFactory.newPointer("target_year_1"), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -75,7 +74,7 @@ public final class RetrieveFeatureDesiredPropertyStrategyTest extends AbstractCo
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureDesiredProperty command =
                 RetrieveFeatureDesiredProperty.of(context.getState(), FLUX_CAPACITOR_ID,
-                        JsonFactory.newPointer("target_year_1"), DittoHeaders.empty());
+                        JsonFactory.newPointer("target_year_1"), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertiesNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -91,7 +90,7 @@ public final class RetrieveFeatureDesiredPropertyStrategyTest extends AbstractCo
                 getDefaultContext();
         final RetrieveFeatureDesiredProperty command =
                 RetrieveFeatureDesiredProperty.of(context.getState(), FLUX_CAPACITOR_ID, propertyPointer,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureDesiredPropertyNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDesiredPropertyPointer(), command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturePropertiesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturePropertiesStrategyTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
@@ -50,7 +49,7 @@ public final class RetrieveFeaturePropertiesStrategyTest extends AbstractCommand
     public void getProperties() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureProperties command =
-                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final RetrieveFeaturePropertiesResponse expectedResponse =
                 ETagTestUtils.retrieveFeaturePropertiesResponse(command.getEntityId(), command.getFeatureId(),
                         FLUX_CAPACITOR_PROPERTIES, command.getDittoHeaders());
@@ -62,7 +61,7 @@ public final class RetrieveFeaturePropertiesStrategyTest extends AbstractCommand
     public void getPropertiesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureProperties command =
-                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -74,7 +73,7 @@ public final class RetrieveFeaturePropertiesStrategyTest extends AbstractCommand
     public void getNonExistingProperties() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureProperties command =
-                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertiesNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -89,7 +88,7 @@ public final class RetrieveFeaturePropertiesStrategyTest extends AbstractCommand
         final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector("target_year_1");
         final RetrieveFeatureProperties command =
                 RetrieveFeatureProperties.of(context.getState(), FLUX_CAPACITOR_ID, selectedFields,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final RetrieveFeaturePropertiesResponse expectedResponse =
                 ETagTestUtils.retrieveFeaturePropertiesResponse(command.getEntityId(), command.getFeatureId(),
                         FLUX_CAPACITOR_PROPERTIES,
@@ -97,7 +96,7 @@ public final class RetrieveFeaturePropertiesStrategyTest extends AbstractCommand
                                 .set("target_year_1",
                                         FLUX_CAPACITOR_PROPERTIES.toJson(command.getImplementedSchemaVersion(),
                                                 selectedFields).getValue("target_year_1").get()).build(),
-                        DittoHeaders.empty());
+                        provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturePropertyStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturePropertyStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
@@ -50,7 +49,7 @@ public final class RetrieveFeaturePropertyStrategyTest extends AbstractCommandSt
         final JsonPointer propertyPointer = JsonFactory.newPointer("target_year_1");
         final RetrieveFeatureProperty command =
                 RetrieveFeatureProperty.of(context.getState(), FLUX_CAPACITOR_ID, propertyPointer,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final RetrieveFeaturePropertyResponse expectedResponse =
                 ETagTestUtils.retrieveFeaturePropertyResponse(command.getEntityId(), command.getFeatureId(),
                         command.getPropertyPointer(), JsonFactory.newValue(1955), command.getDittoHeaders());
@@ -62,7 +61,7 @@ public final class RetrieveFeaturePropertyStrategyTest extends AbstractCommandSt
     public void getPropertyFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureProperty command = RetrieveFeatureProperty.of(context.getState(), FLUX_CAPACITOR_ID,
-                JsonFactory.newPointer("target_year_1"), DittoHeaders.empty());
+                JsonFactory.newPointer("target_year_1"), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -75,7 +74,7 @@ public final class RetrieveFeaturePropertyStrategyTest extends AbstractCommandSt
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeatureProperty command =
                 RetrieveFeatureProperty.of(context.getState(), FLUX_CAPACITOR_ID,
-                        JsonFactory.newPointer("target_year_1"), DittoHeaders.empty());
+                        JsonFactory.newPointer("target_year_1"), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertiesNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -91,7 +90,7 @@ public final class RetrieveFeaturePropertyStrategyTest extends AbstractCommandSt
                 getDefaultContext();
         final RetrieveFeatureProperty command =
                 RetrieveFeatureProperty.of(context.getState(), FLUX_CAPACITOR_ID, propertyPointer,
-                        DittoHeaders.empty());
+                        provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featurePropertyNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getPropertyPointer(), command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeatureStrategyTest.java
@@ -18,13 +18,11 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeature;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeatureResponse;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
-import org.eclipse.ditto.wot.api.generator.WotThingDescriptionGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,7 +45,7 @@ public final class RetrieveFeatureStrategyTest extends AbstractCommandStrategyTe
     public void retrieveExistingFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeature command =
-                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final RetrieveFeatureResponse expectedResponse =
                 ETagTestUtils.retrieveFeatureResponse(command.getEntityId(), FLUX_CAPACITOR, FLUX_CAPACITOR.toJson(),
                         command.getDittoHeaders());
@@ -59,7 +57,7 @@ public final class RetrieveFeatureStrategyTest extends AbstractCommandStrategyTe
     public void retrieveFeatureFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeature command =
-                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());
@@ -71,7 +69,7 @@ public final class RetrieveFeatureStrategyTest extends AbstractCommandStrategyTe
     public void retrieveNonExistingFeature() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final RetrieveFeature command =
-                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, DittoHeaders.empty());
+                RetrieveFeature.of(context.getState(), FLUX_CAPACITOR_ID, provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featureNotFound(command.getEntityId(), command.getFeatureId(),
                         command.getDittoHeaders());

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveFeaturesStrategyTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
@@ -51,7 +50,7 @@ public final class RetrieveFeaturesStrategyTest extends AbstractCommandStrategyT
     @Test
     public void retrieveFeaturesWithoutSelectedFields() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveFeatures command = RetrieveFeatures.of(context.getState(), DittoHeaders.empty());
+        final RetrieveFeatures command = RetrieveFeatures.of(context.getState(), provideHeaders(context));
         final RetrieveFeaturesResponse expectedResponse = ETagTestUtils.retrieveFeaturesResponse(command.getEntityId(), FEATURES,
                 FEATURES.toJson(command.getImplementedSchemaVersion()), command.getDittoHeaders());
 
@@ -63,7 +62,7 @@ public final class RetrieveFeaturesStrategyTest extends AbstractCommandStrategyT
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector("maker");
         final RetrieveFeatures command =
-                RetrieveFeatures.of(context.getState(), selectedFields, DittoHeaders.empty());
+                RetrieveFeatures.of(context.getState(), selectedFields, provideHeaders(context));
         final RetrieveFeaturesResponse expectedResponse = ETagTestUtils.retrieveFeaturesResponse(command.getEntityId(), FEATURES,
                 FEATURES.toJson(command.getImplementedSchemaVersion(), selectedFields), command.getDittoHeaders());
 
@@ -73,7 +72,7 @@ public final class RetrieveFeaturesStrategyTest extends AbstractCommandStrategyT
     @Test
     public void retrieveFeaturesFromThingWithoutFeatures() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveFeatures command = RetrieveFeatures.of(context.getState(), DittoHeaders.empty());
+        final RetrieveFeatures command = RetrieveFeatures.of(context.getState(), provideHeaders(context));
         final DittoRuntimeException expectedException =
                 ExceptionFactory.featuresNotFound(command.getEntityId(), command.getDittoHeaders());
 
@@ -86,7 +85,7 @@ public final class RetrieveFeaturesStrategyTest extends AbstractCommandStrategyT
         final JsonFieldSelector selectedFields = JsonFactory.newFieldSelector("/f3/properties/location",
                 "/*/properties/target_year_1");
         final RetrieveFeatures command =
-                RetrieveFeatures.of(context.getState(), selectedFields, DittoHeaders.empty());
+                RetrieveFeatures.of(context.getState(), selectedFields, provideHeaders(context));
 
         final FeaturesBuilder featuresBuilder = ThingsModelFactory.newFeaturesBuilder();
         THING_V2.getFeatures().orElseThrow().forEach(featuresBuilder::set);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrievePolicyIdStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrievePolicyIdStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.POLICY_ID;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.PolicyIdNotAccessibleException;
@@ -44,9 +43,9 @@ public final class RetrievePolicyIdStrategyTest extends AbstractCommandStrategyT
     @Test
     public void retrieveExistingPolicyId() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrievePolicyId command = RetrievePolicyId.of(context.getState(), DittoHeaders.empty());
+        final RetrievePolicyId command = RetrievePolicyId.of(context.getState(), provideHeaders(context));
         final RetrievePolicyIdResponse expectedResponse =
-                ETagTestUtils.retrievePolicyIdResponse(command.getEntityId(), POLICY_ID, DittoHeaders.empty());
+                ETagTestUtils.retrievePolicyIdResponse(command.getEntityId(), POLICY_ID, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -54,7 +53,7 @@ public final class RetrievePolicyIdStrategyTest extends AbstractCommandStrategyT
     @Test
     public void retrieveNonExistingPolicyId() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrievePolicyId command = RetrievePolicyId.of(context.getState(), DittoHeaders.empty());
+        final RetrievePolicyId command = RetrievePolicyId.of(context.getState(), provideHeaders(context));
         final PolicyIdNotAccessibleException expectedException =
                 PolicyIdNotAccessibleException.newBuilder(command.getEntityId())
                         .dittoHeaders(command.getDittoHeaders())

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveThingDefinitionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveThingDefinitionStrategyTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.things.model.TestConstants.Thing.DEFINITION;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingDefinitionNotAccessibleException;
@@ -44,9 +43,9 @@ public final class RetrieveThingDefinitionStrategyTest extends AbstractCommandSt
     @Test
     public void retrieveExistingDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThingDefinition command = RetrieveThingDefinition.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThingDefinition command = RetrieveThingDefinition.of(context.getState(), provideHeaders(context));
         final RetrieveThingDefinitionResponse expectedResponse =
-                ETagTestUtils.retrieveDefinitionResponse(command.getEntityId(), DEFINITION, DittoHeaders.empty());
+                ETagTestUtils.retrieveDefinitionResponse(command.getEntityId(), DEFINITION, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -54,7 +53,7 @@ public final class RetrieveThingDefinitionStrategyTest extends AbstractCommandSt
     @Test
     public void retrieveNonExistingDefinition() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThingDefinition command = RetrieveThingDefinition.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThingDefinition command = RetrieveThingDefinition.of(context.getState(), provideHeaders(context));
         final ThingDefinitionNotAccessibleException expectedException =
                 ThingDefinitionNotAccessibleException.newBuilder(command.getEntityId())
                         .dittoHeaders(command.getDittoHeaders())

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveThingStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveThingStrategyTest.java
@@ -30,7 +30,6 @@ import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingNotAccess
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThing;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThingResponse;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
-import org.eclipse.ditto.wot.api.generator.WotThingDescriptionGenerator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,7 +51,7 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void isNotDefinedForDeviantThingIds() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThing command = RetrieveThing.of(ThingId.of("org.example", "myThing"), DittoHeaders.empty());
+        final RetrieveThing command = RetrieveThing.of(ThingId.of("org.example", "myThing"), provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, THING_V2, command);
 
@@ -62,7 +61,7 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void isNotDefinedIfContextHasNoThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThing command = RetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThing command = RetrieveThing.of(context.getState(), provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, null, command);
 
@@ -72,7 +71,7 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void isDefinedIfContextHasThingAndThingIdsAreEqual() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThing command = RetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThing command = RetrieveThing.of(context.getState(), provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, THING_V2, command);
 
@@ -82,9 +81,9 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void retrieveThingFromContextIfCommandHasNoSnapshotRevisionAndNoSelectedFields() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThing command = RetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThing command = RetrieveThing.of(context.getState(), provideHeaders(context));
         final RetrieveThingResponse expectedResponse =
-                ETagTestUtils.retrieveThingResponse(THING_V2, null, DittoHeaders.empty());
+                ETagTestUtils.retrieveThingResponse(THING_V2, null, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -93,11 +92,11 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     public void retrieveThingFromContextIfCommandHasNoSnapshotRevisionButSelectedFields() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final JsonFieldSelector fieldSelector = JsonFactory.newFieldSelector("/attributes/location");
-        final RetrieveThing command = RetrieveThing.getBuilder(context.getState(), DittoHeaders.empty())
+        final RetrieveThing command = RetrieveThing.getBuilder(context.getState(), provideHeaders(context))
                 .withSelectedFields(fieldSelector)
                 .build();
         final RetrieveThingResponse expectedResponse =
-                ETagTestUtils.retrieveThingResponse(THING_V2, fieldSelector, DittoHeaders.empty());
+                ETagTestUtils.retrieveThingResponse(THING_V2, fieldSelector, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -105,7 +104,7 @@ public final class RetrieveThingStrategyTest extends AbstractCommandStrategyTest
     @Test
     public void unhandledReturnsThingNotAccessibleException() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final RetrieveThing command = RetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final RetrieveThing command = RetrieveThing.of(context.getState(), provideHeaders(context));
         final ThingNotAccessibleException expectedException =
                 new ThingNotAccessibleException(command.getEntityId(), command.getDittoHeaders());
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/SudoRetrieveThingStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/SudoRetrieveThingStrategyTest.java
@@ -54,7 +54,7 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
     public void isNotDefinedForDeviantThingIds() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final SudoRetrieveThing command =
-                SudoRetrieveThing.of(ThingId.of("org.example", "myThing"), DittoHeaders.empty());
+                SudoRetrieveThing.of(ThingId.of("org.example", "myThing"), provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, THING_V2, command);
 
@@ -64,7 +64,7 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
     @Test
     public void isNotDefinedIfContextHasNoThing() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final SudoRetrieveThing command = SudoRetrieveThing.of(THING_ID, DittoHeaders.empty());
+        final SudoRetrieveThing command = SudoRetrieveThing.of(THING_ID, provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, null, command);
 
@@ -74,7 +74,7 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
     @Test
     public void isDefinedIfContextHasThingAndThingIdsAreEqual() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final SudoRetrieveThing command = SudoRetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final SudoRetrieveThing command = SudoRetrieveThing.of(context.getState(), provideHeaders(context));
 
         final boolean defined = underTest.isDefined(context, THING_V2, command);
 
@@ -100,11 +100,11 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
     public void retrieveThingWithoutSelectedFieldsWithOriginalSchemaVersion() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final SudoRetrieveThing command =
-                SudoRetrieveThing.withOriginalSchemaVersion(context.getState(), null, DittoHeaders.empty());
+                SudoRetrieveThing.withOriginalSchemaVersion(context.getState(), null, provideHeaders(context));
         final JsonObject expectedThingJson = THING_V2.toJson(THING_V2.getImplementedSchemaVersion(),
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                ETagTestUtils.sudoRetrieveThingResponse(THING_V2, expectedThingJson, DittoHeaders.empty());
+                ETagTestUtils.sudoRetrieveThingResponse(THING_V2, expectedThingJson, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -157,11 +157,11 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
         final JsonFieldSelector fieldSelector = JsonFactory.newFieldSelector("/attributes/location");
         final SudoRetrieveThing command =
-                SudoRetrieveThing.of(context.getState(), fieldSelector, DittoHeaders.empty());
+                SudoRetrieveThing.of(context.getState(), fieldSelector, provideHeaders(context));
         final JsonObject expectedThingJson = THING_V2.toJson(THING_V2.getImplementedSchemaVersion(), fieldSelector,
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                ETagTestUtils.sudoRetrieveThingResponse(THING_V2, expectedThingJson, DittoHeaders.empty());
+                ETagTestUtils.sudoRetrieveThingResponse(THING_V2, expectedThingJson, provideHeaders(context));
 
         assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
@@ -169,7 +169,7 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
     @Test
     public void unhandledReturnsThingNotAccessibleException() {
         final CommandStrategy.Context<ThingId> context = getDefaultContext();
-        final SudoRetrieveThing command = SudoRetrieveThing.of(context.getState(), DittoHeaders.empty());
+        final SudoRetrieveThing command = SudoRetrieveThing.of(context.getState(), provideHeaders(context));
         final ThingNotAccessibleException expectedException =
                 new ThingNotAccessibleException(context.getState(), command.getDittoHeaders());
 

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/ValidationContext.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/ValidationContext.java
@@ -12,11 +12,15 @@
  */
 package org.eclipse.ditto.wot.validation;
 
+import java.util.Optional;
+
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.things.model.FeatureDefinition;
 import org.eclipse.ditto.things.model.ThingDefinition;
+import org.eclipse.ditto.things.model.ThingId;
 
 /**
  * A validation context provides the context of an API call which can be used to dynamically determine custom
@@ -25,23 +29,32 @@ import org.eclipse.ditto.things.model.ThingDefinition;
  * @param dittoHeaders the DittoHeaders of the API call
  * @param thingDefinition the optional ThingDefinition of the thing to be updated by the API call
  * @param featureDefinition the optional FeatureDefinition of the thing to be updated by the API call
+ * @param thingId the ThingId of the validated Thing
  */
 public record ValidationContext(
         DittoHeaders dittoHeaders,
         @Nullable ThingDefinition thingDefinition,
-        @Nullable FeatureDefinition featureDefinition
+        @Nullable FeatureDefinition featureDefinition,
+        @Nullable ThingId thingId
 ) {
 
     public static ValidationContext buildValidationContext(final DittoHeaders dittoHeaders,
             @Nullable final ThingDefinition thingDefinition,
             @Nullable final FeatureDefinition featureDefinition
     ) {
-        return new ValidationContext(dittoHeaders, thingDefinition, featureDefinition);
+        return new ValidationContext(dittoHeaders, thingDefinition, featureDefinition,
+                extractThingId(dittoHeaders).orElse(null));
     }
 
     public static ValidationContext buildValidationContext(final DittoHeaders dittoHeaders,
             @Nullable final ThingDefinition thingDefinition
     ) {
-        return new ValidationContext(dittoHeaders, thingDefinition, null);
+        return new ValidationContext(dittoHeaders, thingDefinition, null,
+                extractThingId(dittoHeaders).orElse(null));
+    }
+
+    private static Optional<ThingId> extractThingId(final DittoHeaders dittoHeaders) {
+        return Optional.ofNullable(dittoHeaders.get(DittoHeaderDefinition.ENTITY_ID.getKey()))
+                .map(ThingId::of);
     }
 }


### PR DESCRIPTION
* without it, it is not easy to detect which thing was not valid
* also log in case API call is rejected, but on INFO level