### PR TITLE
fix WoT action validation was only done for application/json content-type

### DIFF
--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
@@ -93,6 +93,7 @@ import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.ThingModifyCommand;
 import org.eclipse.ditto.wot.api.validator.WotThingModelValidator;
 import org.eclipse.ditto.wot.integration.DittoWotIntegration;
+import org.eclipse.ditto.wot.validation.WotThingModelPayloadValidationException;
 
 /**
  * Enforcer responsible for enforcing {@link ThingCommand}s and filtering {@link ThingCommandResponse}s utilizing the
@@ -572,29 +573,37 @@ public final class ThingEnforcerActor
     private CompletionStage<MessageCommand<?, ?>> performWotBasedMessageCommandValidation(
             final MessageCommand<?, ?> messageCommand
     ) {
-        if (isJsonMessageContent(messageCommand.getMessage())) {
-            @SuppressWarnings("unchecked") final Message<JsonValue> message =
-                    ((MessageCommand<JsonValue, ?>) messageCommand)
-                            .getMessage();
+        @SuppressWarnings("unchecked") final Message<JsonValue> message =
+                ((MessageCommand<JsonValue, ?>) messageCommand)
+                        .getMessage();
 
-            final MessageDirection messageDirection = message.getDirection();
-            final JsonValue messageCommandPayload = message
-                    .getPayload()
-                    .orElse(null);
+        if (message.getPayload().isPresent() && !isJsonMessageContent(message)) {
+                return CompletableFuture.failedFuture(
+                        WotThingModelPayloadValidationException
+                                .newBuilder("Could not validate non-JSON message content type <" +
+                                        message.getContentType().orElse("?") + "> for message subject " +
+                                        "<" + message.getSubject() + ">"
+                                )
+                                .dittoHeaders(messageCommand.getDittoHeaders())
+                                .build()
+                );
+        }
 
-            if (messageCommand instanceof SendThingMessage<?> sendThingMessage) {
-                return performWotBasedThingMessageValidation(messageCommand, sendThingMessage, messageDirection,
-                        messageCommandPayload
-                ).thenApply(aVoid -> messageCommand);
-            } else if (messageCommand instanceof SendFeatureMessage<?> sendFeatureMessage) {
-                final String featureId = sendFeatureMessage.getFeatureId();
-                return performWotBasedFeatureMessageValidation(messageCommand, sendFeatureMessage, featureId,
-                        messageDirection, messageCommandPayload
-                ).thenApply(aVoid -> messageCommand);
+        final MessageDirection messageDirection = message.getDirection();
+        final JsonValue messageCommandPayload = message
+                .getPayload()
+                .orElse(null);
 
-            } else {
-                return CompletableFuture.completedFuture(messageCommand);
-            }
+        if (messageCommand instanceof SendThingMessage<?> sendThingMessage) {
+            return performWotBasedThingMessageValidation(messageCommand, sendThingMessage, messageDirection,
+                    messageCommandPayload
+            ).thenApply(aVoid -> messageCommand);
+        } else if (messageCommand instanceof SendFeatureMessage<?> sendFeatureMessage) {
+            final String featureId = sendFeatureMessage.getFeatureId();
+            return performWotBasedFeatureMessageValidation(messageCommand, sendFeatureMessage, featureId,
+                    messageDirection, messageCommandPayload
+            ).thenApply(aVoid -> messageCommand);
+
         } else {
             return CompletableFuture.completedFuture(messageCommand);
         }
@@ -674,44 +683,52 @@ public final class ThingEnforcerActor
     private CompletionStage<MessageCommandResponse<?, ?>> performWotBasedMessageCommandResponseValidation(
             final MessageCommandResponse<?, ?> messageCommandResponse
     ) {
-        if (isJsonMessageContent(messageCommandResponse.getMessage())) {
-            @SuppressWarnings("unchecked") final Message<JsonValue> message =
-                    ((MessageCommandResponse<JsonValue, ?>) messageCommandResponse)
-                            .getMessage();
+        @SuppressWarnings("unchecked") final Message<JsonValue> message =
+                ((MessageCommandResponse<JsonValue, ?>) messageCommandResponse)
+                        .getMessage();
 
-            final MessageDirection messageDirection = message.getDirection();
-            final JsonValue messageCommandPayload = message
-                    .getPayload()
-                    .orElse(null);
+        if (message.getPayload().isPresent() && !isJsonMessageContent(message)) {
+            return CompletableFuture.failedFuture(
+                    WotThingModelPayloadValidationException
+                            .newBuilder("Could not validate non-JSON message content type <" +
+                                    message.getContentType().orElse("?") + "> for message response subject " +
+                                    "<" + message.getSubject() + ">"
+                            )
+                            .dittoHeaders(messageCommandResponse.getDittoHeaders())
+                            .build()
+            );
+        }
 
-            if (messageDirection == MessageDirection.TO &&
-                    messageCommandResponse instanceof SendThingMessageResponse<?> sendThingMessageResponse) {
-                return resolveThingDefinition()
-                        .thenCompose(optThingDefinition -> thingModelValidator.validateThingActionOutput(
-                                optThingDefinition.orElse(null),
-                                sendThingMessageResponse.getMessage().getSubject(),
-                                messageCommandPayload,
-                                sendThingMessageResponse.getResourcePath(),
-                                sendThingMessageResponse.getDittoHeaders()
-                        ))
-                        .thenApply(aVoid -> messageCommandResponse);
-            } else if (messageDirection == MessageDirection.TO &&
-                    messageCommandResponse instanceof SendFeatureMessageResponse<?> sendFeatureMessageResponse) {
-                final String featureId = sendFeatureMessageResponse.getFeatureId();
-                return resolveThingAndFeatureDefinition(featureId)
-                        .thenCompose(optDefinitionPair -> thingModelValidator.validateFeatureActionOutput(
-                                optDefinitionPair.first().orElse(null),
-                                optDefinitionPair.second().orElse(null),
-                                featureId,
-                                sendFeatureMessageResponse.getMessage().getSubject(),
-                                messageCommandPayload,
-                                sendFeatureMessageResponse.getResourcePath(),
-                                sendFeatureMessageResponse.getDittoHeaders()
-                        ))
-                        .thenApply(aVoid -> messageCommandResponse);
-            } else {
-                return CompletableFuture.completedFuture(messageCommandResponse);
-            }
+        final MessageDirection messageDirection = message.getDirection();
+        final JsonValue messageCommandPayload = message
+                .getPayload()
+                .orElse(null);
+
+        if (messageDirection == MessageDirection.TO &&
+                messageCommandResponse instanceof SendThingMessageResponse<?> sendThingMessageResponse) {
+            return resolveThingDefinition()
+                    .thenCompose(optThingDefinition -> thingModelValidator.validateThingActionOutput(
+                            optThingDefinition.orElse(null),
+                            sendThingMessageResponse.getMessage().getSubject(),
+                            messageCommandPayload,
+                            sendThingMessageResponse.getResourcePath(),
+                            sendThingMessageResponse.getDittoHeaders()
+                    ))
+                    .thenApply(aVoid -> messageCommandResponse);
+        } else if (messageDirection == MessageDirection.TO &&
+                messageCommandResponse instanceof SendFeatureMessageResponse<?> sendFeatureMessageResponse) {
+            final String featureId = sendFeatureMessageResponse.getFeatureId();
+            return resolveThingAndFeatureDefinition(featureId)
+                    .thenCompose(optDefinitionPair -> thingModelValidator.validateFeatureActionOutput(
+                            optDefinitionPair.first().orElse(null),
+                            optDefinitionPair.second().orElse(null),
+                            featureId,
+                            sendFeatureMessageResponse.getMessage().getSubject(),
+                            messageCommandPayload,
+                            sendFeatureMessageResponse.getResourcePath(),
+                            sendFeatureMessageResponse.getDittoHeaders()
+                    ))
+                    .thenApply(aVoid -> messageCommandResponse);
         } else {
             return CompletableFuture.completedFuture(messageCommandResponse);
         }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/LiveSignalEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/LiveSignalEnforcementTest.java
@@ -306,6 +306,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             supervisor.tell(message, getRef());
 
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final var firstPublishRead = expectPubsubMessagePublish(message.getEntityId());
             assertThat((CharSequence) ((WithDittoHeaders) firstPublishRead.msg()).getDittoHeaders()
@@ -315,6 +316,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
 
             supervisor.tell(message, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final var secondPublishRead = expectPubsubMessagePublish(message.getEntityId());
@@ -352,6 +354,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             supervisor.tell(msgCommand, getRef());
 
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             expectPubsubMessagePublish(msgCommand.getEntityId());
         }};
@@ -378,6 +381,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             final MessageCommand<?, ?> msgCommand = featureMessageCommand();
             supervisor.tell(msgCommand, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             expectPubsubMessagePublish(msgCommand.getEntityId());

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -231,7 +232,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
     @Override
     public CompletionStage<Void> validateThingActionInput(@Nullable final ThingDefinition thingDefinition,
             final String messageSubject,
-            @Nullable final JsonValue inputPayload,
+            final Supplier<JsonValue> inputPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -240,7 +241,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         selectValidation(validationConfig)
                                 .validateThingActionInput(thingModel,
-                                        messageSubject, inputPayload, resourcePath, context
+                                        messageSubject, inputPayloadSupplier.get(), resourcePath, context
                                 ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingActionInput"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);
@@ -249,7 +250,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
     @Override
     public CompletionStage<Void> validateThingActionOutput(@Nullable final ThingDefinition thingDefinition,
             final String messageSubject,
-            @Nullable final JsonValue outputPayload,
+            final Supplier<JsonValue> outputPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -258,7 +259,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         selectValidation(validationConfig)
                                 .validateThingActionOutput(thingModel,
-                                        messageSubject, outputPayload, resourcePath, context
+                                        messageSubject, outputPayloadSupplier.get(), resourcePath, context
                                 ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingActionOutput"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);
@@ -267,7 +268,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
     @Override
     public CompletionStage<Void> validateThingEventData(@Nullable final ThingDefinition thingDefinition,
             final String messageSubject,
-            @Nullable final JsonValue dataPayload,
+            final Supplier<JsonValue> dataPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -276,7 +277,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         selectValidation(validationConfig)
                                 .validateThingEventData(thingModel,
-                                        messageSubject, dataPayload, resourcePath, context
+                                        messageSubject, dataPayloadSupplier.get(), resourcePath, context
                                 ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingEventData"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);
@@ -493,7 +494,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
             @Nullable final FeatureDefinition featureDefinition,
             final String featureId,
             final String messageSubject,
-            @Nullable final JsonValue inputPayload,
+            final Supplier<JsonValue> inputPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -504,7 +505,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                         dittoHeaders, featureThingModel ->
                                 selectValidation(validationConfig)
                                         .validateFeatureActionInput(featureThingModel,
-                                                featureId, messageSubject, inputPayload, resourcePath, context
+                                                featureId, messageSubject, inputPayloadSupplier.get(), resourcePath, context
                                         ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureActionInput"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);
@@ -515,7 +516,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
             @Nullable final FeatureDefinition featureDefinition,
             final String featureId,
             final String messageSubject,
-            @Nullable final JsonValue inputPayload,
+            final Supplier<JsonValue> inputPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -526,7 +527,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                         dittoHeaders, featureThingModel ->
                                 selectValidation(validationConfig)
                                         .validateFeatureActionOutput(featureThingModel,
-                                                featureId, messageSubject, inputPayload, resourcePath, context
+                                                featureId, messageSubject, inputPayloadSupplier.get(), resourcePath, context
                                         ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureActionOutput"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);
@@ -537,7 +538,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
             @Nullable final FeatureDefinition featureDefinition,
             final String featureId,
             final String messageSubject,
-            @Nullable final JsonValue dataPayload,
+            final Supplier<JsonValue> dataPayloadSupplier,
             final JsonPointer resourcePath,
             final DittoHeaders dittoHeaders
     ) {
@@ -548,7 +549,7 @@ final class DefaultWotThingModelValidator implements WotThingModelValidator {
                         dittoHeaders, featureThingModel ->
                                 selectValidation(validationConfig)
                                         .validateFeatureEventData(featureThingModel,
-                                                featureId, messageSubject, dataPayload, resourcePath, context
+                                                featureId, messageSubject, dataPayloadSupplier.get(), resourcePath, context
                                         ).handle(applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureEventData"))
                 ))
                 .orElseGet(DefaultWotThingModelValidator::success);

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/WotThingModelValidator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/WotThingModelValidator.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.wot.api.validator;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -197,7 +198,7 @@ public interface WotThingModelValidator {
      *
      * @param thingDefinition the ThingDefinition to retrieve the WoT TM from
      * @param messageSubject the (Thing) message subject
-     * @param inputPayload the input payload to validate
+     * @param inputPayloadSupplier the supplier of the input payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -205,7 +206,7 @@ public interface WotThingModelValidator {
      */
     CompletionStage<Void> validateThingActionInput(@Nullable ThingDefinition thingDefinition,
             String messageSubject,
-            @Nullable JsonValue inputPayload,
+            Supplier<JsonValue> inputPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );
@@ -216,7 +217,7 @@ public interface WotThingModelValidator {
      *
      * @param thingDefinition the ThingDefinition to retrieve the WoT TM from
      * @param messageSubject the (Thing) message subject
-     * @param outputPayload the output payload to validate
+     * @param outputPayloadSupplier the supplier of the output payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -224,7 +225,7 @@ public interface WotThingModelValidator {
      */
     CompletionStage<Void> validateThingActionOutput(@Nullable ThingDefinition thingDefinition,
             String messageSubject,
-            @Nullable JsonValue outputPayload,
+            Supplier<JsonValue> outputPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );
@@ -235,7 +236,7 @@ public interface WotThingModelValidator {
      *
      * @param thingDefinition the ThingDefinition to retrieve the WoT TM from
      * @param messageSubject the (Thing) message subject
-     * @param dataPayload the data payload to validate
+     * @param dataPayloadSupplier the supplier of data payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -243,7 +244,7 @@ public interface WotThingModelValidator {
      */
     CompletionStage<Void> validateThingEventData(@Nullable ThingDefinition thingDefinition,
             String messageSubject,
-            @Nullable JsonValue dataPayload,
+            Supplier<JsonValue> dataPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );
@@ -459,7 +460,7 @@ public interface WotThingModelValidator {
      * @param featureDefinition the FeatureDefinition to retrieve the WoT TM from
      * @param featureId the ID of the feature to validate the message input payload for
      * @param messageSubject the (Feature) message subject
-     * @param inputPayload the input payload to validate
+     * @param inputPayloadSupplier the supplier of input payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -469,7 +470,7 @@ public interface WotThingModelValidator {
             @Nullable FeatureDefinition featureDefinition,
             String featureId,
             String messageSubject,
-            @Nullable JsonValue inputPayload,
+            Supplier<JsonValue> inputPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );
@@ -482,7 +483,7 @@ public interface WotThingModelValidator {
      * @param featureDefinition the FeatureDefinition to retrieve the WoT TM from
      * @param featureId the ID of the feature to validate the message output payload for
      * @param messageSubject the (Feature) message subject
-     * @param outputPayload the output payload to validate
+     * @param outputPayloadSupplier the supplier of output payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -492,7 +493,7 @@ public interface WotThingModelValidator {
             @Nullable FeatureDefinition featureDefinition,
             String featureId,
             String messageSubject,
-            @Nullable JsonValue outputPayload,
+            Supplier<JsonValue> outputPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );
@@ -505,7 +506,7 @@ public interface WotThingModelValidator {
      * @param featureDefinition the FeatureDefinition to retrieve the WoT TM from
      * @param featureId the ID of the feature to validate the message payload for
      * @param messageSubject the (Feature) message subject
-     * @param dataPayload the data payload to validate
+     * @param dataPayloadSupplier the supplier of data payload to validate
      * @param resourcePath the originating path of the command which caused validation
      * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
      * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
@@ -515,7 +516,7 @@ public interface WotThingModelValidator {
             @Nullable FeatureDefinition featureDefinition,
             String featureId,
             String messageSubject,
-            @Nullable JsonValue dataPayload,
+            Supplier<JsonValue> dataPayloadSupplier,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders
     );


### PR DESCRIPTION
This allowed bypassing of WoT validation for actions - e.g. by defining another content-type than `application/json`