### PR TITLE
missing customField closing bracket

### DIFF
--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -58,7 +58,7 @@
 
                 <!-- Encoder is required -->
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                    <customFields>{"appname":"policies","instance_index":"${INSTANCE_INDEX}"</customFields>
+                    <customFields>{"appname":"policies","instance_index":"${INSTANCE_INDEX}"}</customFields>
                 </encoder>
             </appender>
         </then>


### PR DESCRIPTION
missing closing bracket causes 

> |-ERROR in ch.qos.logback.core.model.util.VariableSubstitutionsHelper@58e1d9d - Problem while parsing [{"appname":"policies","instance_index":"${INSTANCE_INDEX}"] java.lang.IllegalArgumentException: All tokens consumed but was expecting "}"
	at java.lang.IllegalArgumentException: All tokens consumed but was expecting "}"