### PR TITLE
fixed regression in message response WoT validation done at wrong place

### DIFF
--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
@@ -715,18 +715,6 @@ public final class ThingEnforcerActor
                 ((MessageCommandResponse<JsonValue, ?>) messageCommandResponse)
                         .getMessage();
 
-        if (message.getPayload().isPresent() && !isJsonMessageContent(message)) {
-            return CompletableFuture.failedFuture(
-                    WotThingModelPayloadValidationException
-                            .newBuilder("Could not validate non-JSON message content type <" +
-                                    message.getContentType().orElse("?") + "> for message response subject " +
-                                    "<" + message.getSubject() + ">"
-                            )
-                            .dittoHeaders(messageCommandResponse.getDittoHeaders())
-                            .build()
-            );
-        }
-
         // lazily only supply JsonValue if validation is enabled for the message:
         final Supplier<JsonValue> messageCommandPayloadSupplier = () -> {
             if (message.getPayload().isPresent() && !isJsonMessageContent(message)) {
@@ -742,9 +730,7 @@ public final class ThingEnforcerActor
             return message.getPayload().orElse(null);
         };
 
-        final MessageDirection messageDirection = message.getDirection();
-        if (messageDirection == MessageDirection.TO &&
-                messageCommandResponse instanceof SendThingMessageResponse<?> sendThingMessageResponse) {
+        if (messageCommandResponse instanceof SendThingMessageResponse<?> sendThingMessageResponse) {
             return resolveThingDefinition()
                     .thenCompose(optThingDefinition -> thingModelValidator.validateThingActionOutput(
                             optThingDefinition.orElse(null),
@@ -754,8 +740,7 @@ public final class ThingEnforcerActor
                             sendThingMessageResponse.getDittoHeaders()
                     ))
                     .thenApply(aVoid -> messageCommandResponse);
-        } else if (messageDirection == MessageDirection.TO &&
-                messageCommandResponse instanceof SendFeatureMessageResponse<?> sendFeatureMessageResponse) {
+        } else if (messageCommandResponse instanceof SendFeatureMessageResponse<?> sendFeatureMessageResponse) {
             final String featureId = sendFeatureMessageResponse.getFeatureId();
             return resolveThingAndFeatureDefinition(featureId)
                     .thenCompose(optDefinitionPair -> thingModelValidator.validateFeatureActionOutput(


### PR DESCRIPTION
* leading to message responses not being of type "application/json" being rejected, even if WoT validation was deactivated