### PR TITLE
fix pre-defined extraFields were causing missing extra from Thing created events

### DIFF
--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActor.java
@@ -284,7 +284,11 @@ public final class ThingPersistenceActor
         final CompletionStage<ThingEvent<?>> stage = eventPreDefinedExtraFieldsEnricher.enrichWithPredefinedExtraFields(
                 entityId,
                 entity,
-                Optional.ofNullable(previousEntity).flatMap(Thing::getPolicyId).orElse(null),
+                Optional.ofNullable(entity).flatMap(Thing::getPolicyId)
+                        .orElse(Optional.ofNullable(previousEntity)
+                                .flatMap(Thing::getPolicyId)
+                                .orElse(null)
+                        ),
                 event
         );
         stage.whenComplete((modifiedEvent, ex) -> {


### PR DESCRIPTION
With the in Ditto 3.7.0 added "pre-defined" extraFields configuration `ThingCreated` events did not contain the configured "extra" fields if pre-defined extra-fields were configured.

The reason was that the Policy is not yet available during creation of the Thing and thus, no fields were added to `extra` as authorization was missing.

This PR provides a fix which solves this by doing a roundtrip and extra-fields retrieval in such (rare) cases of thing creation.  
It also improves how it is calculated if all asked for "extra" fields were available as pre-configured fields.