### PR TITLE
fix http-push-connection-dispatcher config overrides

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -1331,15 +1331,28 @@ http-push-connection-dispatcher {
   # The core-pool-size-min remains unchanged so its quite small (8). Unused threads will expire after 60s.
 
   thread-pool-executor {
+    # The core-pool-size-factor is used to determine corePoolSize of the
+    # ThreadPoolExecutor using the following formula:
+    # ceil(available processors * factor).
+    # Resulting size is then bounded by the core-pool-size-min and
+    # core-pool-size-max values.
+    # Increasing can help aleviate errors of type "Dropped message as result of backpressure strategy!" during high load.
     core-pool-size-factor = 4
     core-pool-size-factor = ${?HTTP_PUSH_CORE_POOL_SIZE_FACTOR}
-    core-pool-size-max = 64,
+    # Max number of threads to cap factor-based corePoolSize number to
+    core-pool-size-max = 64
     core-pool-size-max = ${?HTTP_PUSH_CORE_POOL_SIZE_MAX}
-    max-pool-size-min= 64,
-    max-pool-size-min= ${?HTTP_PUSH_CORE_POOL_SIZE_MAX}    # Overriding with the value of HTTP_PUSH_CORE_POOL_SIZE_MAX as if threads are a reason for http problems the pool normaly doesn't grow on its own so
-    # it is better to set the core upper limit manualy and this config will forse the core pool size to this value.
-    max-pool-size-max = 2147483647,
-    allow-core-timeout = on  # Enables timeout of core threads
+    # Minimum number of threads to cap factor-based maximumPoolSize number to
+    max-pool-size-min= 64
+    max-pool-size-min= ${?HTTP_PUSH_POOL_SIZE_MAX}
+    # Max number of threads to cap factor-based maximumPoolSize number to
+    max-pool-size-max = 512
+    max-pool-size-max= ${?HTTP_PUSH_POOL_SIZE_MAX}
+
+    # Allow core threads to time out
+    allow-core-timeout = on
+    # Keep alive time for threads
+    keep-alive-time = 60s
   }
 }
 

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -1329,11 +1329,18 @@ http-push-connection-dispatcher {
   # This executor is meant to be allowed to grow quite big as its limited by the max parallelism of each http connection client.
   # Limit this parallelism here additionally could lead to confusing results regarding througput of some http connections.
   # The core-pool-size-min remains unchanged so its quite small (8). Unused threads will expire after 60s.
-  core-pool-size-factor = 2147483647
-  core-pool-size-factor = ${?HTTP_PUSH_CORE_POOL_SIZE_FACTOR}
 
-  core-pool-size-max = 2147483647
-  core-pool-size-max = ${?HTTP_PUSH_CORE_POOL_SIZE_MAX}
+  thread-pool-executor {
+    core-pool-size-factor = 4
+    core-pool-size-factor = ${?HTTP_PUSH_CORE_POOL_SIZE_FACTOR}
+    core-pool-size-max = 64,
+    core-pool-size-max = ${?HTTP_PUSH_CORE_POOL_SIZE_MAX}
+    max-pool-size-min= 64,
+    max-pool-size-min= ${?HTTP_PUSH_CORE_POOL_SIZE_MAX}    # Overriding with the value of HTTP_PUSH_CORE_POOL_SIZE_MAX as if threads are a reason for http problems the pool normaly doesn't grow on its own so
+    # it is better to set the core upper limit manualy and this config will forse the core pool size to this value.
+    max-pool-size-max = 2147483647,
+    allow-core-timeout = on  # Enables timeout of core threads
+  }
 }
 
 kafka-consumer-dispatcher {


### PR DESCRIPTION
properties were not in the right place and the config was defaulting to https://github.com/apache/pekko/blob/2469f729f7503acf814bcbd042b4bb0863103c9d/actor/src/main/resources/reference.conf#L506

Also setting the defaults to some more sensible values so that the threadpool is created with a reasonable size and only grow on demand.

fixes #2138