### PR TITLE
Fix several completion stages to use async execution and other performance improvements

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
@@ -78,6 +78,26 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
         BUILT_IN_DEFINITIONS = Collections.unmodifiableMap(definitions);
     }
 
+    /**
+     * Resolves the passed in collection of {@link HeaderDefinition}s to a map of the definition's keys and their
+     * {@link HeaderDefinition} as value.
+     *
+     * @param headerDefinitions the known header definitions to build up the map for.
+     * @return the build map.
+     */
+    public static Map<String, HeaderDefinition> getHeaderDefinitionsAsMap(
+            final Collection<? extends HeaderDefinition> headerDefinitions) {
+
+        final DittoHeaderDefinition[] dittoHeaderDefinitions = DittoHeaderDefinition.values();
+        final Map<String, HeaderDefinition> result =
+                new LinkedHashMap<>(headerDefinitions.size() + dittoHeaderDefinitions.length);
+        for (final HeaderDefinition definition : headerDefinitions) {
+            result.put(definition.getKey(), definition);
+        }
+        result.putAll(BUILT_IN_DEFINITIONS);
+        return result;
+    }
+
     protected final S myself;
     private final Map<String, Header> headers;
     private final Map<String, HeaderDefinition> definitions;
@@ -89,15 +109,18 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
      * Constructs a new {@code AbstractDittoHeadersBuilder} object.
      *
      * @param initialHeaders initial key-value-pairs or an empty map.
-     * @param definitions a collection of all well known {@link org.eclipse.ditto.base.model.headers.HeaderDefinition}s
-     * of this builder. The definitions are used for header value validation.
+     * @param definitions a collection of all well known {@link HeaderDefinition}s of this builder.
+     * The definitions are used for header value validation.
+     * @param definitionsMap a map of header string keys and their {@link HeaderDefinition} as value.
      * @param selfType this type is used to simulate the "self type" of the returned object for Method Chaining of
      * the builder methods.
      * @throws NullPointerException if any argument is {@code null}.
      */
     @SuppressWarnings("unchecked")
     protected AbstractDittoHeadersBuilder(final Map<String, String> initialHeaders,
-            final Collection<? extends HeaderDefinition> definitions, final Class<?> selfType) {
+            final Collection<? extends HeaderDefinition> definitions,
+            final Map<String, HeaderDefinition> definitionsMap,
+            final Class<?> selfType) {
 
         checkNotNull(initialHeaders, "initial headers");
         checkNotNull(definitions, "header definitions");
@@ -106,7 +129,7 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
         headers = preserveCaseSensitivity(initialHeaders);
         metadataHeaders = MetadataHeaders.newInstance();
         metadataHeaders.addAll(extractMetadataHeaders(headers));
-        this.definitions = getHeaderDefinitionsAsMap(definitions);
+        this.definitions = checkNotNull(definitionsMap, "definitionsMap");
         getMetadataFieldSelector = extractMetadataFieldSelector(headers, DittoHeaderDefinition.GET_METADATA);
         deleteMetadataFieldSelector = extractMetadataFieldSelector(headers, DittoHeaderDefinition.DELETE_METADATA);
     }
@@ -136,34 +159,24 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
         return result;
     }
 
-    private static Map<String, HeaderDefinition> getHeaderDefinitionsAsMap(
-            final Collection<? extends HeaderDefinition> headerDefinitions) {
-
-        final DittoHeaderDefinition[] dittoHeaderDefinitions = DittoHeaderDefinition.values();
-        final Map<String, HeaderDefinition> result =
-                new LinkedHashMap<>(headerDefinitions.size() + dittoHeaderDefinitions.length);
-        for (final HeaderDefinition definition : headerDefinitions) {
-            result.put(definition.getKey(), definition);
-        }
-        result.putAll(BUILT_IN_DEFINITIONS);
-        return result;
-    }
-
     /**
      * Constructs a new {@code AbstractDittoHeadersBuilder} object based on an existing {@code DittoHeaders} instance
      * applying a performance optimization: skipping the validation of values types as we can be sure that they already
      * are valid when being passed in as DittoHeaders.
      *
      * @param initialHeaders initial DittoHeaders.
-     * @param definitions a collection of all well known {@link org.eclipse.ditto.base.model.headers.HeaderDefinition}s
-     * of this builder. The definitions are used for header value validation.
+     * @param definitions a collection of all well known {@link HeaderDefinition}s of this builder.
+     * The definitions are used for header value validation.
+     * @param definitionsMap a map of header string keys and their {@link HeaderDefinition} as value.
      * @param selfType this type is used to simulate the "self type" of the returned object for Method Chaining of
      * the builder methods.
      * @throws NullPointerException if any argument is {@code null}.
      */
     @SuppressWarnings("unchecked")
     protected AbstractDittoHeadersBuilder(final R initialHeaders,
-            final Collection<? extends HeaderDefinition> definitions, final Class<?> selfType) {
+            final Collection<? extends HeaderDefinition> definitions,
+            final Map<String, HeaderDefinition> definitionsMap,
+            final Class<?> selfType) {
 
         checkNotNull(initialHeaders, "initialHeaders");
         checkNotNull(definitions, "definitions");
@@ -171,7 +184,7 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
         headers = preserveCaseSensitivity(initialHeaders);
         metadataHeaders = MetadataHeaders.newInstance();
         metadataHeaders.addAll(extractMetadataHeaders(headers));
-        this.definitions = getHeaderDefinitionsAsMap(definitions);
+        this.definitions = checkNotNull(definitionsMap, "definitionsMap");
         getMetadataFieldSelector = extractMetadataFieldSelector(headers, DittoHeaderDefinition.GET_METADATA);
         deleteMetadataFieldSelector = extractMetadataFieldSelector(headers, DittoHeaderDefinition.DELETE_METADATA);
     }

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilder.java
@@ -29,13 +29,15 @@ final class DefaultDittoHeadersBuilder extends AbstractDittoHeadersBuilder<Defau
 
     private static final DittoHeaders EMPTY_DITTO_HEADERS = ImmutableDittoHeaders.of(Collections.emptyMap());
     private static final EnumSet<DittoHeaderDefinition> DEFINITIONS = EnumSet.allOf(DittoHeaderDefinition.class);
+    private static final Map<String, HeaderDefinition> KNOWN_HEADER_DEFINITIONS =
+            AbstractDittoHeadersBuilder.getHeaderDefinitionsAsMap(DEFINITIONS);
 
     private DefaultDittoHeadersBuilder(final Map<String, String> headers) {
-        super(headers, DEFINITIONS, DefaultDittoHeadersBuilder.class);
+        super(headers, DEFINITIONS, KNOWN_HEADER_DEFINITIONS, DefaultDittoHeadersBuilder.class);
     }
 
     private DefaultDittoHeadersBuilder(final DittoHeaders dittoHeaders) {
-        super(dittoHeaders, DEFINITIONS, DefaultDittoHeadersBuilder.class);
+        super(dittoHeaders, DEFINITIONS, KNOWN_HEADER_DEFINITIONS, DefaultDittoHeadersBuilder.class);
     }
 
     /**

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.7.3  # chart version is effectively set by release-job
+version: 3.7.4  # chart version is effectively set by release-job
 appVersion: 3.7.3
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/swaggerui-deployment.yaml
+++ b/deployment/helm/ditto/templates/swaggerui-deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-swaggerui-init
-          image: "docker.io/curlimages/curl:8.3.0"
+          image: "docker.io/curlimages/curl:8.13.0"
           imagePullPolicy: {{ .Values.swaggerui.image.pullPolicy }}
           command:
             - sh

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -445,13 +445,13 @@ ingress:
         pathType: Exact
         backendSuffix: nginx
       - path: /index.html
-        pathType: Exact
+        pathType: ImplementationSpecific
         backendSuffix: nginx
       - path: /ditto-up.svg
-        pathType: Exact
+        pathType: ImplementationSpecific
         backendSuffix: nginx
       - path: /ditto-down.svg
-        pathType: Exact
+        pathType: ImplementationSpecific
         backendSuffix: nginx
     # annotations defines k8s annotations to add to the Ingress
     annotations:
@@ -2179,7 +2179,7 @@ swaggerui:
     # repository for the swagger ui docker image
     repository: docker.io/swaggerapi/swagger-ui
     # tag for the swagger ui docker image
-    tag: v5.17.14
+    tag: v5.20.8
     # pullPolicy for the swagger ui docker image
     pullPolicy: IfNotPresent
   # extraEnv to add arbitrary environment variable to swagger ui container

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -122,6 +123,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
     private final SupervisorStrategy supervisorStrategy;
 
     protected final MongoReadJournal mongoReadJournal;
+    protected final Executor enforcementExecutor;
 
     @Nullable protected final BlockedNamespaces blockedNamespaces;
 
@@ -156,6 +158,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
         this.enforcerChild = enforcerChild;
         this.blockedNamespaces = blockedNamespaces;
         this.mongoReadJournal = mongoReadJournal;
+        this.enforcementExecutor = system.dispatchers().lookup("enforcement-dispatcher");
         this.localAskTimeout = getLocalAskTimeoutConfig().getLocalAckTimeout();
         this.exponentialBackOffConfig = getExponentialBackOffConfig();
         this.backOff = ExponentialBackOff.initial(exponentialBackOffConfig);
@@ -263,7 +266,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
 
         final ActorRef sender = getSender();
         askEnforcerChild(subscribeForPersistedEvents)
-                .whenComplete((enforcedStreamPersistedEvents, throwable) -> {
+                .whenCompleteAsync((enforcedStreamPersistedEvents, throwable) -> {
                     if (enforcedStreamPersistedEvents instanceof DittoRuntimeException dre) {
                         log.withCorrelationId(subscribeForPersistedEvents)
                                 .info("Got DittoRuntimeException handling SubscribeForPersistedEvents: " +
@@ -297,7 +300,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
                                 .warning(throwable, "Got throwable: <{}: {}>", throwable.getClass().getSimpleName(),
                                             throwable.getMessage());
                     }
-                });
+                }, enforcementExecutor);
     }
 
     /**
@@ -791,12 +794,17 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
                     becomeTwinSignalProcessingAwaiting();
                 }
                 final var syncCs = signalTransformer.apply(signal)
-                        .whenComplete((result, error) -> handleOptionalTransformationException(signal, error, sender))
-                        .thenCompose(transformed -> enforceSignalAndForwardToTargetActor((S) transformed, sender)
-                                .exceptionallyCompose(error -> handleTargetActorAndEnforcerException(transformed, error))
-                                .whenComplete((response, throwable) ->
-                                        handleSignalEnforcementResponse(response, throwable, transformed, sender)
-                                ))
+                        .whenComplete((result, error) ->
+                                handleOptionalTransformationException(signal, error, sender)
+                        )
+                        .thenComposeAsync(transformed ->
+                                enforceSignalAndForwardToTargetActor((S) transformed, sender)
+                                    .exceptionallyComposeAsync(error ->
+                                            handleTargetActorAndEnforcerException(transformed, error), enforcementExecutor)
+                                    .whenComplete((response, throwable) ->
+                                            handleSignalEnforcementResponse(response, throwable, transformed, sender)
+                                    ), enforcementExecutor
+                        )
                         .handle((response, throwable) -> new ProcessNextTwinMessage(signal));
                 incrementOpCounter(signal); // decremented by ProcessNextTwinMessage
                 Patterns.pipe(syncCs, getContext().getDispatcher()).pipeTo(getSelf(), getSelf());
@@ -913,12 +921,12 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
             final StartedTimer rootTimer = createTimer(tracedSignal);
             final StartedTimer enforcementTimer = rootTimer.startNewSegment(ENFORCEMENT_TIMER_SEGMENT_ENFORCEMENT);
             return askEnforcerChild(tracedSignal)
-                    .thenCompose(this::modifyEnforcerActorEnforcedSignalResponse)
+                    .thenComposeAsync(this::modifyEnforcerActorEnforcedSignalResponse, enforcementExecutor)
                     .whenComplete((result, error) -> {
                         startedSpan.mark("enforced_policy");
                         stopTimer(enforcementTimer).accept(result, error);
                     })
-                    .thenCompose(enforcedCommand -> {
+                    .thenComposeAsync(enforcedCommand -> {
                         final StartedTimer processingTimer =
                                 rootTimer.startNewSegment(ENFORCEMENT_TIMER_SEGMENT_PROCESSING);
                         final DittoHeaders dittoHeaders;
@@ -932,21 +940,22 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
                                     startedSpan.mark("processed");
                                     stopTimer(processingTimer).accept(result, error);
                                 });
-                    })
-                    .thenCompose(targetActorResponse -> {
-                        final StartedTimer responseFilterTimer =
-                                rootTimer.startNewSegment(ENFORCEMENT_TIMER_SEGMENT_RESPONSE_FILTER);
-                        return filterTargetActorResponseViaEnforcer(targetActorResponse)
-                                .whenComplete((result, error) -> {
-                                    startedSpan.mark("filtered_response");
-                                    responseFilterTimer.tag(ENFORCEMENT_TIMER_TAG_OUTCOME,
-                                            error != null ? ENFORCEMENT_TIMER_TAG_OUTCOME_FAIL :
-                                                    ENFORCEMENT_TIMER_TAG_OUTCOME_SUCCESS).stop();
-                                    if (null != error) {
-                                        startedSpan.tagAsFailed(error);
-                                    }
-                                });
-                    }).whenComplete((result, error) -> {
+                    }, enforcementExecutor)
+                    .thenComposeAsync(targetActorResponse -> {
+                                final StartedTimer responseFilterTimer =
+                                        rootTimer.startNewSegment(ENFORCEMENT_TIMER_SEGMENT_RESPONSE_FILTER);
+                                return filterTargetActorResponseViaEnforcer(targetActorResponse)
+                                        .whenComplete((result, error) -> {
+                                            startedSpan.mark("filtered_response");
+                                            responseFilterTimer.tag(ENFORCEMENT_TIMER_TAG_OUTCOME,
+                                                    error != null ? ENFORCEMENT_TIMER_TAG_OUTCOME_FAIL :
+                                                            ENFORCEMENT_TIMER_TAG_OUTCOME_SUCCESS).stop();
+                                            if (null != error) {
+                                                startedSpan.tagAsFailed(error);
+                                            }
+                                        });
+                            }, enforcementExecutor
+                    ).whenComplete((result, error) -> {
                         if (null != error) {
                             startedSpan.tagAsFailed(error);
                         }
@@ -1001,8 +1010,8 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
                     .debug("Received enforcedSignal from enforcerChild, forwarding to target actor: {}",
                             enforcedSignal);
             return askTargetActor(enforcedSignal, shouldSendResponse(enforcedSignal), sender)
-                    .thenCompose(response ->
-                            modifyTargetActorCommandResponse(enforcedSignal, response))
+                    .thenComposeAsync(response ->
+                            modifyTargetActorCommandResponse(enforcedSignal, response), enforcementExecutor)
                     .thenApply(response ->
                             new EnforcedSignalAndTargetActorResponse(enforcedSignal, response)
                     );
@@ -1010,8 +1019,8 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
             return askTargetActor(distributedPubWithMessage,
                     distributedPubWithMessage.signal().getDittoHeaders().isResponseRequired(), sender
             )
-                    .thenCompose(response ->
-                            modifyTargetActorCommandResponse(distributedPubWithMessage.signal(), response))
+                    .thenComposeAsync(response ->
+                            modifyTargetActorCommandResponse(distributedPubWithMessage.signal(), response), enforcementExecutor)
                     .thenApply(response ->
                             new EnforcedSignalAndTargetActorResponse(distributedPubWithMessage.signal(), response)
                     );

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
@@ -85,6 +85,7 @@ import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJou
 import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
 import org.eclipse.ditto.internal.utils.tracing.span.SpanOperationName;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.policies.enforcement.AbstractEnforcerActor;
 
 import com.typesafe.config.Config;
 
@@ -158,7 +159,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
         this.enforcerChild = enforcerChild;
         this.blockedNamespaces = blockedNamespaces;
         this.mongoReadJournal = mongoReadJournal;
-        this.enforcementExecutor = system.dispatchers().lookup("enforcement-dispatcher");
+        this.enforcementExecutor = system.dispatchers().lookup(AbstractEnforcerActor.ENFORCEMENT_DISPATCHER);
         this.localAskTimeout = getLocalAskTimeoutConfig().getLocalAckTimeout();
         this.exponentialBackOffConfig = getExponentialBackOffConfig();
         this.backOff = ExponentialBackOff.initial(exponentialBackOffConfig);

--- a/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
@@ -14,7 +14,7 @@ package org.eclipse.ditto.json;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.UnaryOperator;
 
 import javax.annotation.Nullable;
@@ -33,9 +33,9 @@ final class JavaStringToEscapedJsonString implements UnaryOperator<String> {
 
     private static final char QUOTE = '\"';
 
-    private final Function<Integer, String> jsonCharEscaper;
+    private final IntFunction<String> jsonCharEscaper;
 
-    private JavaStringToEscapedJsonString(final Function<Integer, String> theJsonCharEscaper) {
+    private JavaStringToEscapedJsonString(final IntFunction<String> theJsonCharEscaper) {
         jsonCharEscaper = theJsonCharEscaper;
     }
 
@@ -56,7 +56,7 @@ final class JavaStringToEscapedJsonString implements UnaryOperator<String> {
         stringBuilder.append(javaString);
         int i = 1; // offset of starting " char
         for (final char c : javaString.toCharArray()) {
-            @Nullable final String replacement = jsonCharEscaper.apply((int) c);
+            @Nullable final String replacement = jsonCharEscaper.apply(c);
             if (null != replacement) {
                 stringBuilder.replace(i, i + 1, replacement);
                 i += replacement.length();

--- a/json/src/main/java/org/eclipse/ditto/json/JsonCharEscaper.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonCharEscaper.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.ditto.json;
 
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
  * @see "https://tools.ietf.org/html/rfc8259#section-7"
  */
 @Immutable
-final class JsonCharEscaper implements Function<Integer, String> {
+final class JsonCharEscaper implements IntFunction<String> {
 
     private static final JsonCharEscaper INSTANCE = new JsonCharEscaper();
 
@@ -63,7 +63,7 @@ final class JsonCharEscaper implements Function<Integer, String> {
      */
     @Nullable
     @Override
-    public String apply(final Integer i) {
+    public String apply(final int i) {
         if (0 <= i && i < ESCAPE_TABLE.length) {
             return ESCAPE_TABLE[i];
         } else {

--- a/messages/model/src/main/java/org/eclipse/ditto/messages/model/MessageHeadersBuilder.java
+++ b/messages/model/src/main/java/org/eclipse/ditto/messages/model/MessageHeadersBuilder.java
@@ -27,10 +27,11 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.AbstractDittoHeadersBuilder;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.HeaderDefinition;
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.ThingId;
 
 /**
@@ -43,13 +44,16 @@ public final class MessageHeadersBuilder extends AbstractDittoHeadersBuilder<Mes
             EnumSet.of(MessageHeaderDefinition.DIRECTION, MessageHeaderDefinition.THING_ID,
                     MessageHeaderDefinition.SUBJECT));
     private static final Set<MessageHeaderDefinition> DEFINITIONS = EnumSet.allOf(MessageHeaderDefinition.class);
+    private static final Map<String, HeaderDefinition> KNOWN_HEADER_DEFINITIONS =
+            AbstractDittoHeadersBuilder.getHeaderDefinitionsAsMap(DEFINITIONS);
+
 
     private MessageHeadersBuilder(final Map<String, String> headers) {
-        super(headers, DEFINITIONS, MessageHeadersBuilder.class);
+        super(headers, DEFINITIONS, KNOWN_HEADER_DEFINITIONS, MessageHeadersBuilder.class);
     }
 
     private MessageHeadersBuilder(final MessageHeaders dittoHeaders) {
-        super(dittoHeaders, DEFINITIONS, MessageHeadersBuilder.class);
+        super(dittoHeaders, DEFINITIONS, KNOWN_HEADER_DEFINITIONS, MessageHeadersBuilder.class);
     }
 
     /**

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
@@ -12,13 +12,12 @@
  */
 package org.eclipse.ditto.policies.enforcement;
 
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.dispatch.MessageDispatcher;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.policies.model.PolicyId;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.dispatch.MessageDispatcher;
 
 /**
  * Abstract base of {@link PolicyEnforcer} implementations.
@@ -33,7 +32,7 @@ abstract class AbstractPolicyEnforcerProvider implements PolicyEnforcerProvider 
             final ActorSystem actorSystem) {
 
         final PolicyCacheLoader policyCacheLoader = PolicyCacheLoader.getSingletonInstance(actorSystem);
-        return new PolicyEnforcerCacheLoader(policyCacheLoader);
+        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem);
     }
 
     protected static MessageDispatcher enforcementCacheDispatcher(final ActorSystem actorSystem) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -46,7 +46,7 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
         policyIdToImportingMap = new ConcurrentHashMap<>();
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
-                        .whenComplete(((policyEnforcerEntry, throwable) -> policyEnforcerEntry.get()
+                        .whenCompleteAsync(((policyEnforcerEntry, throwable) -> policyEnforcerEntry.get()
                                 .flatMap(PolicyEnforcer::getPolicy)
                                 .map(Policy::getPolicyImports)
                                 .filter(imports -> !imports.isEmpty())
@@ -59,7 +59,10 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
                                                                     importingPolicyIds;
                                                     newImportingPolicyIds.add(policyId);
                                                     return newImportingPolicyIds;
-                                                }))))),
+                                                })))
+                                ),
+                                cacheDispatcher
+                        ),
                 cacheConfig,
                 "policy_enforcer_cache",
                 cacheDispatcher

--- a/policies/enforcement/src/main/resources/reference.conf
+++ b/policies/enforcement/src/main/resources/reference.conf
@@ -3,12 +3,32 @@
 
 enforcement-cache-dispatcher {
   type = "Dispatcher"
-  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  throughput = 5
 }
 
 enforcement-dispatcher {
   type = "Dispatcher"
-  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  throughput = 5
 }
 
 ditto.extensions {

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProviderTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProviderTest.java
@@ -26,6 +26,15 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.cluster.ddata.ORSet;
+import org.apache.pekko.cluster.ddata.Replicator;
+import org.apache.pekko.cluster.ddata.SelfUniqueAddress;
+import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
+import org.apache.pekko.dispatch.MessageDispatcher;
+import org.apache.pekko.testkit.TestProbe;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.policies.api.PolicyTag;
@@ -36,15 +45,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.cluster.ddata.ORSet;
-import org.apache.pekko.cluster.ddata.Replicator;
-import org.apache.pekko.cluster.ddata.SelfUniqueAddress;
-import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
-import org.apache.pekko.testkit.TestProbe;
-import org.apache.pekko.testkit.javadsl.TestKit;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class CachingPolicyEnforcerProviderTest {
@@ -84,7 +84,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 system,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -105,7 +106,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 system,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -124,7 +126,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 system,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -146,7 +149,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 system,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -167,7 +171,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 system,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -186,7 +191,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 actorSystem,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -208,7 +214,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 actorSystem,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -227,7 +234,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 actorSystem,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{
@@ -248,7 +256,8 @@ public final class CachingPolicyEnforcerProviderTest {
                 actorSystem,
                 cache,
                 blockedNamespaces,
-                pubSubMediatorProbe.ref()
+                pubSubMediatorProbe.ref(),
+                (MessageDispatcher) actorSystem.dispatcher()
         );
 
         new TestKit(actorSystem) {{

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
@@ -38,8 +38,6 @@ import org.eclipse.ditto.policies.service.enforcement.PolicyCommandEnforcement;
 public final class PolicyEnforcerActor extends
         AbstractPolicyLoadingEnforcerActor<PolicyId, Signal<?>, PolicyCommandResponse<?>, PolicyCommandEnforcement> {
 
-    private static final String ENFORCEMENT_DISPATCHER = "enforcement-dispatcher";
-
     @SuppressWarnings("unused")
     private PolicyEnforcerActor(final PolicyId policyId, final PolicyCommandEnforcement policyCommandEnforcement,
             final PolicyEnforcerProvider policyEnforcerProvider) {

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.ditto.things.service.enforcement;
 
-import static org.eclipse.ditto.things.service.enforcement.ThingEnforcerActor.ENFORCEMENT_DISPATCHER;
+import static org.eclipse.ditto.policies.enforcement.AbstractEnforcerActor.ENFORCEMENT_DISPATCHER;
 
 import java.util.HashMap;
 import java.util.HashSet;

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
@@ -143,7 +143,7 @@ public final class ThingEnforcerActor
 
         final DittoWotIntegration wotIntegration = DittoWotIntegration.get(system);
         thingModelValidator = wotIntegration.getWotThingModelValidator();
-        wotValidationExecutor = getContext().getSystem().dispatchers().lookup("wot-dispatcher");
+        wotValidationExecutor = getContext().getSystem().dispatchers().lookup(DittoWotIntegration.WOT_DISPATCHER);
     }
 
     /**

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
@@ -110,8 +110,6 @@ import org.eclipse.ditto.wot.validation.WotThingModelPayloadValidationException;
 public final class ThingEnforcerActor
         extends AbstractPolicyLoadingEnforcerActor<ThingId, Signal<?>, CommandResponse<?>, ThingEnforcement> {
 
-    static final String ENFORCEMENT_DISPATCHER = "enforcement-dispatcher";
-
     /**
      * Label of default policy entry in default policy.
      */
@@ -122,7 +120,6 @@ public final class ThingEnforcerActor
     private final DittoThingsConfig thingsConfig;
     private final AskWithRetryConfig askWithRetryConfig;
     private final WotThingModelValidator thingModelValidator;
-    private final Executor enforcementExecutor;
     private final Executor wotValidationExecutor;
 
     @SuppressWarnings("unused")
@@ -146,7 +143,6 @@ public final class ThingEnforcerActor
 
         final DittoWotIntegration wotIntegration = DittoWotIntegration.get(system);
         thingModelValidator = wotIntegration.getWotThingModelValidator();
-        enforcementExecutor = getContext().getSystem().dispatchers().lookup(ENFORCEMENT_DISPATCHER);
         wotValidationExecutor = getContext().getSystem().dispatchers().lookup("wot-dispatcher");
     }
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingModifyCommandStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingModifyCommandStrategy.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
 import org.eclipse.ditto.internal.utils.tracing.span.SpanOperationName;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.signals.commands.modify.ThingModifyCommand;
+import org.eclipse.ditto.wot.integration.DittoWotIntegration;
 
 /**
  * Abstract base class for {@link ThingModifyCommand} strategies.
@@ -40,7 +41,7 @@ abstract class AbstractThingModifyCommandStrategy<C extends ThingModifyCommand<C
 
     protected AbstractThingModifyCommandStrategy(final Class<C> theMatchingClass, final ActorSystem actorSystem) {
         super(theMatchingClass, actorSystem);
-        wotValidationExecutor = actorSystem.dispatchers().lookup("wot-dispatcher");
+        wotValidationExecutor = actorSystem.dispatchers().lookup(DittoWotIntegration.WOT_DISPATCHER);
     }
 
     /**

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateThingStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateThingStrategy.java
@@ -123,9 +123,11 @@ final class CreateThingStrategy extends AbstractThingModifyCommandStrategy<Creat
 
         // validate based on potentially referenced Thing WoT TM/TD
         final CompletionStage<Pair<CreateThing, Thing>> validatedStage =
-                thingStage.thenCompose(createdThingWithImplicits ->
+                thingStage.thenComposeAsync(createdThingWithImplicits ->
                         buildValidatedStage(command, null, createdThingWithImplicits)
-                                .thenApply(createThing -> new Pair<>(createThing, createdThingWithImplicits))
+                                .thenApplyAsync(createThing ->
+                                        new Pair<>(createThing, createdThingWithImplicits), wotValidationExecutor),
+                        wotValidationExecutor
                 );
 
         final CompletionStage<ThingEvent<?>> eventStage = validatedStage.thenApply(pair ->

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategy.java
@@ -180,12 +180,14 @@ final class ModifyFeatureStrategy extends AbstractThingModifyCommandStrategy<Mod
                 );
 
         final CompletionStage<Pair<ModifyFeature, Feature>> validatedStage =
-                featureStage.thenCompose(createdFeatureWithImplicits ->
+                featureStage.thenComposeAsync(createdFeatureWithImplicits ->
                         buildValidatedStage(
                                 ModifyFeature.of(command.getEntityId(), createdFeatureWithImplicits,
                                         command.getDittoHeaders()),
                                 thing
-                        ).thenApply(modifyFeature -> new Pair<>(modifyFeature, createdFeatureWithImplicits))
+                        ).thenApplyAsync(modifyFeature ->
+                                new Pair<>(modifyFeature, createdFeatureWithImplicits), wotValidationExecutor),
+                        wotValidationExecutor
                 );
         final CompletionStage<ThingEvent<?>> eventStage =
                 validatedStage.thenApply(pair ->

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -581,11 +581,31 @@ thing-snaps-persistence-dispatcher {
 
 wot-dispatcher {
   type = Dispatcher
-  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  throughput = 5
 }
 wot-dispatcher-cache-loader {
   type = Dispatcher
-  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  throughput = 5
 }
 
 blocked-namespaces-dispatcher {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
@@ -48,7 +48,7 @@ final class ResolvedPolicyCacheLoader
             final Executor executor) {
 
         return policyCacheLoader.asyncLoad(policyIdResolvingImports.policyId(), executor)
-                .thenCompose(policyEntry -> {
+                .thenComposeAsync(policyEntry -> {
                     if (policyEntry.exists()) {
                         final Policy policy = policyEntry.getValueOrThrow();
                         final long revision = policy.getRevision().map(PolicyRevision::toLong)
@@ -57,8 +57,8 @@ final class ResolvedPolicyCacheLoader
                         final Set<PolicyTag> referencedPolicies = new HashSet<>();
 
                         if (policyIdResolvingImports.resolveImports()) {
-                            return cacheFuture.thenCompose(cache ->
-                                            resolvePolicyImports(cache, policy, referencedPolicies)
+                            return cacheFuture.thenComposeAsync(cache ->
+                                            resolvePolicyImports(cache, policy, referencedPolicies), executor
                                     )
                                     .thenApply(resolvedPolicy ->
                                             Entry.of(revision, new Pair<>(resolvedPolicy, referencedPolicies))
@@ -71,7 +71,7 @@ final class ResolvedPolicyCacheLoader
                     } else {
                         return CompletableFuture.completedFuture(Entry.nonexistent());
                     }
-                });
+                }, executor);
     }
 
     private static CompletionStage<Policy> resolvePolicyImports(

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/generator/DefaultWotThingDescriptionGenerator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/generator/DefaultWotThingDescriptionGenerator.java
@@ -270,7 +270,7 @@ final class DefaultWotThingDescriptionGenerator implements WotThingDescriptionGe
 
         // generation rules defined at: https://w3c.github.io/wot-thing-description/#thing-model-td-generation
         return CompletableFuture.completedFuture(thingModel)
-                .thenApply(thingModelWithExtensionsAndImports -> {
+                .thenApplyAsync(thingModelWithExtensionsAndImports -> {
                     LOGGER.debug("ThingModel after resolving extensions + refs: <{}>",
                             thingModelWithExtensionsAndImports);
 
@@ -306,7 +306,7 @@ final class DefaultWotThingDescriptionGenerator implements WotThingDescriptionGe
                     LOGGER.info("Created ThingDescription for thingId <{}> and featureId <{}>: <{}>", thingId,
                             featureId, thingDescription);
                     return thingDescription;
-                });
+                }, executor);
     }
 
     private ObjectSchema buildDittoErrorSchema() {

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DefaultDittoWotIntegration.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DefaultDittoWotIntegration.java
@@ -54,8 +54,8 @@ final class DefaultDittoWotIntegration implements DittoWotIntegration {
         this.wotConfig = checkNotNull(wotConfig, "wotConfig");
         LOGGER.info("Initializing DefaultDittoWotIntegration with config: {}", wotConfig);
 
-        final Executor executor = actorSystem.dispatchers().lookup("wot-dispatcher");
-        final Executor cacheLoaderExecutor = actorSystem.dispatchers().lookup("wot-dispatcher-cache-loader");
+        final Executor executor = actorSystem.dispatchers().lookup(WOT_DISPATCHER);
+        final Executor cacheLoaderExecutor = actorSystem.dispatchers().lookup(WOT_DISPATCHER_CACHE_LOADER);
         final PekkoHttpJsonDownloader httpThingModelDownloader =
                 new PekkoHttpJsonDownloader(actorSystem, wotConfig, executor);
         thingModelFetcher = WotThingModelFetcher.of(wotConfig, httpThingModelDownloader, cacheLoaderExecutor);

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DefaultDittoWotIntegration.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DefaultDittoWotIntegration.java
@@ -57,7 +57,7 @@ final class DefaultDittoWotIntegration implements DittoWotIntegration {
         final Executor executor = actorSystem.dispatchers().lookup("wot-dispatcher");
         final Executor cacheLoaderExecutor = actorSystem.dispatchers().lookup("wot-dispatcher-cache-loader");
         final PekkoHttpJsonDownloader httpThingModelDownloader =
-                new PekkoHttpJsonDownloader(actorSystem, wotConfig);
+                new PekkoHttpJsonDownloader(actorSystem, wotConfig, executor);
         thingModelFetcher = WotThingModelFetcher.of(wotConfig, httpThingModelDownloader, cacheLoaderExecutor);
         thingModelExtensionResolver = WotThingModelExtensionResolver.of(thingModelFetcher, executor);
         thingModelResolver =

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DittoWotIntegration.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/DittoWotIntegration.java
@@ -30,6 +30,16 @@ import org.eclipse.ditto.wot.api.validator.WotThingModelValidator;
 public interface DittoWotIntegration extends Extension {
 
     /**
+     * Dispatcher name used for WoT integration (e.g. validating, resolving of WoT models).
+     */
+    String WOT_DISPATCHER = "wot-dispatcher";
+
+    /**
+     * Dispatcher name used for loading and caching WoT models.
+     */
+    String WOT_DISPATCHER_CACHE_LOADER = "wot-dispatcher-cache-loader";
+
+    /**
      * @return the applied WoT configuration.
      */
     WotConfig getWotConfig();

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/DefaultWotThingModelValidation.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/DefaultWotThingModelValidation.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
@@ -51,9 +52,11 @@ import org.eclipse.ditto.wot.validation.config.TmValidationConfig;
 final class DefaultWotThingModelValidation implements WotThingModelValidation {
 
     private final TmValidationConfig validationConfig;
+    private final Executor executor;
 
-    DefaultWotThingModelValidation(final TmValidationConfig validationConfig) {
+    DefaultWotThingModelValidation(final TmValidationConfig validationConfig, final Executor executor) {
         this.validationConfig = validationConfig;
+        this.executor = executor;
     }
 
     @Override
@@ -146,7 +149,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     validationConfig.getThingValidationConfig().isForbidNonModeledInboxMessages(),
                     resourcePath,
                     true,
-                    context
+                    context,
+                    executor
             );
         }
         return success();
@@ -166,7 +170,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     validationConfig.getThingValidationConfig().isForbidNonModeledInboxMessages(),
                     resourcePath,
                     false,
-                    context
+                    context,
+                    executor
             );
         }
         return success();
@@ -185,7 +190,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     dataPayload,
                     validationConfig.getThingValidationConfig().isForbidNonModeledOutboxMessages(),
                     resourcePath,
-                    context
+                    context,
+                    executor
             );
         }
         return success();
@@ -209,7 +215,7 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
         } else {
             secondStage = success();
         }
-        return firstStage.thenCompose(unused -> secondStage);
+        return firstStage.thenComposeAsync(unused -> secondStage, executor);
     }
 
     @Override
@@ -225,7 +231,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     features,
                     false,
                     validationConfig.getFeatureValidationConfig().isForbidNonModeledProperties(),
-                    context
+                    context,
+                    executor
             ).thenApply(aVoid -> null);
         } else {
             firstStage = success();
@@ -238,12 +245,13 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     features,
                     true,
                     validationConfig.getFeatureValidationConfig().isForbidNonModeledDesiredProperties(),
-                    context
+                    context,
+                    executor
             ).thenApply(aVoid -> null);
         } else {
             secondStage = success();
         }
-        return firstStage.thenCompose(unused -> secondStage);
+        return firstStage.thenComposeAsync(unused -> secondStage, executor);
     }
 
 
@@ -297,7 +305,7 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
         } else {
             secondStage = success();
         }
-        return firstStage.thenCompose(unused -> secondStage);
+        return firstStage.thenComposeAsync(unused -> secondStage, executor);
     }
 
     @Override
@@ -378,7 +386,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
             return enforcePresenceOfRequiredPropertiesUponFeatureLevelDeletion(featureThingModel,
                     featureId,
                     resourcePath,
-                    context
+                    context,
+                    executor
             );
         }
         // desired properties do not need to be checked, as the "required" definitions do not apply for them
@@ -402,7 +411,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     validationConfig.getFeatureValidationConfig().isForbidNonModeledInboxMessages(),
                     resourcePath,
                     true,
-                    context
+                    context,
+                    executor
             );
         }
         return success();
@@ -424,7 +434,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     validationConfig.getFeatureValidationConfig().isForbidNonModeledInboxMessages(),
                     resourcePath,
                     false,
-                    context
+                    context,
+                    executor
             );
         }
         return success();
@@ -445,7 +456,8 @@ final class DefaultWotThingModelValidation implements WotThingModelValidation {
                     dataPayload,
                     validationConfig.getFeatureValidationConfig().isForbidNonModeledOutboxMessages(),
                     resourcePath,
-                    context
+                    context,
+                    executor
             );
         }
         return success();

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/InternalThingValidation.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/InternalThingValidation.java
@@ -25,6 +25,7 @@ import static org.eclipse.ditto.wot.validation.InternalValidation.validateProper
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
@@ -152,7 +153,8 @@ final class InternalThingValidation {
             final boolean forbidNonModeledInboxMessages,
             final JsonPointer resourcePath,
             final boolean isInput,
-            final ValidationContext context
+            final ValidationContext context,
+            final Executor executor
     ) {
         final CompletableFuture<Void> firstStage;
         if (isInput && forbidNonModeledInboxMessages) {
@@ -164,11 +166,12 @@ final class InternalThingValidation {
         } else {
             firstStage = success();
         }
-        return firstStage.thenCompose(unused ->
+        return firstStage.thenComposeAsync(unused ->
                 enforceActionPayload(thingModel, messageSubject, payload, resourcePath, isInput,
                         "Thing's action <" + messageSubject + "> " + (isInput ? "input" : "output"),
                         context
-                )
+                ),
+                executor
         );
     }
 
@@ -177,7 +180,8 @@ final class InternalThingValidation {
             @Nullable final JsonValue payload,
             final boolean forbidNonModeledOutboxMessages,
             final JsonPointer resourcePath,
-            final ValidationContext context
+            final ValidationContext context,
+            final Executor executor
     ) {
         final CompletableFuture<Void> firstStage;
         if (forbidNonModeledOutboxMessages) {
@@ -186,10 +190,11 @@ final class InternalThingValidation {
         } else {
             firstStage = success();
         }
-        return firstStage.thenCompose(unused ->
+        return firstStage.thenComposeAsync(unused ->
                 enforceEventPayload(thingModel, messageSubject, payload, resourcePath,
                         "Thing's event <" + messageSubject + "> data", context
-                )
+                ),
+                executor
         );
     }
 

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/WotThingModelValidation.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/WotThingModelValidation.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.wot.validation;
 
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
@@ -332,9 +333,10 @@ public interface WotThingModelValidation {
      * Creates a new instance of WotThingModelValidation with the given {@code validationConfig}.
      *
      * @param validationConfig the WoT TM validation config to use.
+     * @param executor the executor to use for async operations.
      * @return the created WotThingModelValidation.
      */
-    static WotThingModelValidation of(final TmValidationConfig validationConfig) {
-        return new DefaultWotThingModelValidation(validationConfig);
+    static WotThingModelValidation of(final TmValidationConfig validationConfig, final Executor executor) {
+        return new DefaultWotThingModelValidation(validationConfig, executor);
     }
 }

--- a/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/CurrentThreadExecutor.java
+++ b/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/CurrentThreadExecutor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.validation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+final class CurrentThreadExecutor implements ExecutorService {
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+
+    @Override
+    public void shutdown() {
+        // no-op
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public <T> Future<T> submit(final Callable<T> task) {
+        final FutureTask<T> f = new FutureTask<T>(task);
+        f.run();
+        return f;
+    }
+
+    @Override
+    public <T> Future<T> submit(final Runnable task, final T result) {
+        final FutureTask<T> f = new FutureTask<T>(task, result);
+        f.run();
+        return f;
+    }
+
+    @Override
+    public Future<?> submit(final Runnable task) {
+        final FutureTask<?> f = new FutureTask<Void>(task, null);
+        f.run();
+        return f;
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(this::submit).toList();
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks, final long timeout,
+            final TimeUnit unit) {
+        return tasks.stream().map(this::submit).toList();
+    }
+
+    @Override
+    public <T> T invokeAny(final Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return tasks.stream().map(this::submit).findFirst().orElseThrow().get();
+    }
+
+    @Override
+    public <T> T invokeAny(final Collection<? extends Callable<T>> tasks, final long timeout, final TimeUnit unit)
+            throws InterruptedException, ExecutionException {
+        return tasks.stream().map(this::submit).findFirst().orElseThrow().get();
+    }
+
+}

--- a/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationFeatureLevelTest.java
+++ b/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationFeatureLevelTest.java
@@ -233,7 +233,7 @@ public final class WotThingModelValidationFeatureLevelTest {
         when(featureValidationConfig.isForbidNonModeledOutboxMessages()).thenReturn(true);
         when(validationConfig.getFeatureValidationConfig()).thenReturn(featureValidationConfig);
 
-        sut = WotThingModelValidation.of(validationConfig);
+        sut = WotThingModelValidation.of(validationConfig, new CurrentThreadExecutor());
     }
 
     @Test
@@ -938,7 +938,7 @@ public final class WotThingModelValidationFeatureLevelTest {
                     .withThrowableOfType(ExecutionException.class)
                     .withCauseInstanceOf(WotThingModelPayloadValidationException.class);
         } else {
-            assertThat(stage).isNotCompletedExceptionally().isDone();
+            assertThat(stage).isNotCompletedExceptionally().succeedsWithin(150, TimeUnit.MILLISECONDS);
         }
     }
 }

--- a/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationThingLevelTest.java
+++ b/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationThingLevelTest.java
@@ -183,7 +183,8 @@ public final class WotThingModelValidationThingLevelTest {
         when(thingValidationConfig.isForbidNonModeledOutboxMessages()).thenReturn(true);
         when(validationConfig.getThingValidationConfig()).thenReturn(thingValidationConfig);
 
-        sut = WotThingModelValidation.of(validationConfig);
+
+        sut = WotThingModelValidation.of(validationConfig, new CurrentThreadExecutor());
     }
 
     @Test


### PR DESCRIPTION
* For WoT validation, specifying the "wot-dispatcher" Executor to use
* For policy enforcement, specifying the "enforcement-dispatcher" Executor to use

Classifying as "bug" as we already have dedicated dispatchers / executors configured which shall be used to perform those async operations, but most of the time they are not used.
Instead, they use the "commonPool" JoinForkPool - which has a limited amount of threads and is used for "everything else" not explicitly defining an executor to run on.

This can be problematic, as under load e.g. WoT validation might influence other async tasks of the things service. Or the other way around as well - without having a proper isolation or options to "tweak".