### PR TITLE
fix negative from/to for historical streaming confusion

### DIFF
--- a/documentation/src/main/resources/jsonschema/protocol-streaming-subscription-subscribe-for-persisted-events-payload.json
+++ b/documentation/src/main/resources/jsonschema/protocol-streaming-subscription-subscribe-for-persisted-events-payload.json
@@ -6,7 +6,7 @@
   "properties": {
     "fromHistoricalRevision": {
       "type": "integer",
-      "description": "The revision to start the streaming from. May also be negative in order to specify to get the last n revisions relative to the 'toHistoricalRevision'."
+      "description": "The revision to start the streaming from. May also be negative in order to specify to get the last n revisions relative to the most recent revision (`_revision` of the thing)."
     },
     "toHistoricalRevision": {
       "type": "integer",

--- a/documentation/src/main/resources/pages/ditto/basic-history.md
+++ b/documentation/src/main/resources/pages/ditto/basic-history.md
@@ -110,7 +110,7 @@ Use the following query parameters in order to specify the start/stop revision/t
 
 Either use the revision based parameters:
 * `from-historical-revision`: Specifies the revision number to start streaming historical modification events from.
-  May also be negative in order to specify to get the last `n` revisions relative to the `to-historical-revision`.
+  May also be negative in order to specify to get the last `n` revisions relative to the **most recent revision** (`_revision` of the thing).
 * `to-historical-revision`: Optionally specifies the revision number to stop streaming at (if omitted, it streams events until the current state of the entity). 
   May also be 0 or negative in order to specify to get either the latest (`0`) or the `n`th most recent revision.
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -695,9 +695,12 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             final long toSequenceNr) {
         if (fromSequenceNr <= 0 || toSequenceNr <= 0) {
             return getLatestEventSeqNo(persistenceId).flatMapConcat(latestSnOpt -> {
-                final long effectiveTo = toSequenceNr <= 0 ?
-                        latestSnOpt.map(latest -> latest + toSequenceNr).orElse(toSequenceNr) : toSequenceNr;
-                final long effectiveFrom = fromSequenceNr <= 0 ? effectiveTo + 1 + fromSequenceNr : fromSequenceNr;
+                final long effectiveTo = toSequenceNr <= 0
+                        ? latestSnOpt.map(latest -> latest + toSequenceNr).orElse(toSequenceNr)
+                        : toSequenceNr;
+                final long effectiveFrom = fromSequenceNr < 0
+                        ? latestSnOpt.map(latest -> latest + fromSequenceNr + 1).orElse(fromSequenceNr)
+                        : fromSequenceNr;
                 return pekkoReadJournal.currentEventsByPersistenceId(persistenceId, effectiveFrom, effectiveTo);
             });
         } else {


### PR DESCRIPTION
* the current behavior was instead index/offset semantics, which provides the wrong semantics for the documented options