### PR TITLE
fix "thing definition migrated" event signal enrichment caching

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/Command.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/Command.java
@@ -182,7 +182,8 @@ public interface Command<T extends Command<T>> extends Signal<T> {
          * @since 3.0.0
          */
         public static boolean isEntityModifyingCommand(final Category category) {
-            return category == CREATE || category == MODIFY || category == MERGE || category == DELETE;
+            return category == CREATE || category == MODIFY || category == MERGE || category == DELETE ||
+                    category == MIGRATE;
         }
     }
 

--- a/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActor.java
+++ b/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActor.java
@@ -15,6 +15,12 @@ package org.eclipse.ditto.edge.service.dispatching;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import org.apache.pekko.actor.AbstractActor;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
+import org.apache.pekko.japi.pf.ReceiveBuilder;
 import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.entity.id.WithEntityId;
 import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
@@ -31,12 +37,12 @@ import org.eclipse.ditto.connectivity.api.commands.sudo.ConnectivitySudoCommand;
 import org.eclipse.ditto.connectivity.model.ConnectivityConstants;
 import org.eclipse.ditto.connectivity.model.signals.commands.ConnectivityCommand;
 import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveAllConnectionIds;
-import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
-import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.cacheloaders.config.DefaultAskWithRetryConfig;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.messages.model.signals.commands.MessageCommand;
 import org.eclipse.ditto.messages.model.signals.commands.MessageCommandResponse;
 import org.eclipse.ditto.policies.api.commands.sudo.CheckPolicyPermissions;
@@ -54,13 +60,6 @@ import org.eclipse.ditto.thingsearch.api.commands.sudo.ThingSearchSudoCommand;
 import org.eclipse.ditto.thingsearch.model.signals.commands.ThingSearchCommand;
 
 import com.typesafe.config.Config;
-
-import org.apache.pekko.actor.AbstractActor;
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Props;
-import org.apache.pekko.cluster.pubsub.DistributedPubSubMediator;
-import org.apache.pekko.japi.pf.ReceiveBuilder;
 
 /**
  * Actor which acts as a client used at the Ditto edges (gateway and connectivity) in order to forward messages
@@ -121,7 +120,7 @@ public class EdgeCommandForwarderActor extends AbstractActor {
      */
     public static boolean isIdempotent(final Command<?> command) {
         return switch (command.getCategory()) {
-            case QUERY, MERGE, MODIFY, DELETE -> true;
+            case QUERY, MERGE, MODIFY, DELETE, MIGRATE -> true;
             default -> false;
         };
     }

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/AbstractThingEventStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/AbstractThingEventStrategy.java
@@ -104,9 +104,10 @@ abstract class AbstractThingEventStrategy<T extends ThingEvent<T>> implements Ev
     }
 
     private Metadata deleteMetadataForMergeAndModifiedEvents(final T event, final MetadataBuilder metadataBuilder) {
-        if (event instanceof ThingModifiedEvent && event.getCommandCategory().equals(Command.Category.DELETE)) {
+        final Command.Category commandCategory = event.getCommandCategory();
+        if (event instanceof ThingModifiedEvent && commandCategory.equals(Command.Category.DELETE)) {
             return metadataBuilder.remove(event.getResourcePath()).build();
-        } else if (event instanceof ThingModifiedEvent && event.getCommandCategory().equals(Command.Category.MERGE)) {
+        } else if (event instanceof ThingModifiedEvent && commandCategory.equals(Command.Category.MERGE)) {
             final Optional<JsonValue> optionalJsonValue = event.getEntity();
             if (optionalJsonValue.isEmpty() || optionalJsonValue.get().isNull()) {
                 return metadataBuilder.remove(event.getResourcePath()).build();
@@ -121,7 +122,10 @@ abstract class AbstractThingEventStrategy<T extends ThingEvent<T>> implements Ev
 
                 return metadataBuilder.build();
             }
-        } else if (event instanceof ThingModifiedEvent && event.getCommandCategory().equals(Command.Category.MODIFY)) {
+        } else if (event instanceof ThingModifiedEvent && (
+                commandCategory.equals(Command.Category.MODIFY) ||
+                commandCategory.equals(Command.Category.MIGRATE)
+        )) {
             final Optional<JsonValue> optionalJsonValue = event.getEntity();
             if (optionalJsonValue.isPresent() && optionalJsonValue.get().isObject()
                     && optionalJsonValue.get().asObject().isEmpty()) {


### PR DESCRIPTION
There is a bug which leads to enriched / `extra` fields no being merged correctly by the `DittoCachingSignalEnrichmentFacade`.  
This lead to missing fields from "extra" in emitted events (e.g. via Kafka).