### PR TITLE
increased pekko version to 1.2.0-M1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,11 +44,11 @@
         <lz4-java.version>1.8.0</lz4-java.version>
 
         <pekko-bom.version>1.2.0-M1</pekko-bom.version>
-        <pekko-http-bom.version>1.1.0</pekko-http-bom.version>
+        <pekko-http-bom.version>1.2.0</pekko-http-bom.version>
         <pekko-persistence-mongodb.version>1.2.2</pekko-persistence-mongodb.version>
-        <pekko-persistence-inmemory.version>1.2.1</pekko-persistence-inmemory.version>
+        <pekko-persistence-inmemory.version>1.3.0</pekko-persistence-inmemory.version>
         <pekko-management.version>1.1.1</pekko-management.version>
-        <pekko-connector-kafka.version>1.0.0</pekko-connector-kafka.version>
+        <pekko-connector-kafka.version>1.1.0</pekko-connector-kafka.version>
         <parboiled.version>2.5.1</parboiled.version>
 
         <!--  Necessary for pekko-persistence-mongodb -->

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- ### Compile dependencies versions -->
         <minimal-json.version>0.9.5</minimal-json.version>
-        <jackson-bom.version>2.17.3</jackson-bom.version>
+        <jackson-bom.version>2.19.0</jackson-bom.version>
         <json-schema-validator.version>1.5.6</json-schema-validator.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <ssl-config-core.version>0.6.1</ssl-config-core.version>
@@ -43,7 +43,7 @@
         <eddsa.version>0.3.0</eddsa.version>
         <lz4-java.version>1.8.0</lz4-java.version>
 
-        <pekko-bom.version>1.1.3</pekko-bom.version>
+        <pekko-bom.version>1.2.0-M1</pekko-bom.version>
         <pekko-http-bom.version>1.1.0</pekko-http-bom.version>
         <pekko-persistence-mongodb.version>1.2.2</pekko-persistence-mongodb.version>
         <pekko-persistence-inmemory.version>1.2.1</pekko-persistence-inmemory.version>

--- a/internal/utils/config/src/main/resources/ditto-pekko-config.conf
+++ b/internal/utils/config/src/main/resources/ditto-pekko-config.conf
@@ -177,6 +177,14 @@ pekko {
         port = ${?BIND_REMOTE_PORT}
       }
 
+      # If set to "on", InboundQuarantineCheck will propagate harmless quarantine events.
+      # This is the legacy behavior. Users who see these harmless quarantine events lead
+      # to problems can set this to "off" to suppress them (https://github.com/apache/pekko/pull/1555).
+      # This issue should fix https://github.com/apache/pekko/issues/578 where a cluster under load undergoing rollout restart
+      # or helm upgrade procedure interprets harmless quarantine events as DownSelfQuarantinedByRemote which drags down
+      # and downs the neighbours of that particular node.
+      propagate-harmless-quarantine-events = off
+
       advanced {
         # Maximum serialized message size, including header data. # default: 256 KiB
         maximum-frame-size = 256 KiB


### PR DESCRIPTION
 - this is done so a 3.8.0-M1 release can be built
 - added propagate-harmless-quarantine-events=off as a potential fix to https://github.com/apache/pekko/issues/578