### PR TITLE
dynamic response diversion between connections

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaderDefinition.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaderDefinition.java
@@ -222,6 +222,45 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
     REPLY_TARGET("ditto-reply-target", Integer.class, false, false, HeaderValueValidators.getIntValidator()),
 
     /**
+     * Header mapping key for the target connection ID to divert responses to.
+     * When configured in a source's headerMapping, responses from that source will be diverted
+     * to the specified connection instead of being sent to the configured replyTarget.
+     * The value should be a valid connection ID string or header placeholder.
+     *
+     * @since 3.8.0
+     */
+    DITTO_DIVERT_RESPONSE_TO("ditto-divert-response-to",
+            String.class,
+            true,
+            false,
+            HeaderValueValidators.getNonEmptyValidator()),
+
+    /**
+     * Header mapping key for specifying which response types should be diverted.
+     * Value should be a comma-separated list of response types: "response,error,nack".
+     * If not specified, all response types will be diverted.
+     *
+     * @since 3.8.0
+     */
+    DITTO_DIVERT_EXPECTED_RESPONSE_TYPES("ditto-divert-expected-response-types",
+            String.class,
+            true,
+            false,
+            HeaderValueValidators.getNonEmptyValidator()),
+
+    /**
+     * Header key for tracking the source connection of a diverted response.
+     *
+     * @since 3.8.0
+     */
+
+    DITTO_DIVERTED_RESPONSE_FROM("ditto-diverted-response-from",
+            String.class,
+            true,
+            true,
+            HeaderValueValidators.getNonEmptyValidator()),
+
+    /**
      * Header definition for the internal header "ditto-expected-response-types".
      * This header is evaluated to distinguish if a response should published or not.
      *
@@ -564,7 +603,7 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
 
     /**
      * Internal header containing the pre-defined configured {@code extraFields} as keys and the allowed "read subjects"
-     * as array of stings - defining which "auth subjects" are allowed to read which pre-defined extra field.
+     * as array of strings - defining which "auth subjects" are allowed to read which pre-defined extra field.
      *
      * @since 3.7.0
      */

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
@@ -119,6 +119,9 @@ public final class ImmutableDittoHeadersTest {
     private static final boolean KNOWN_DITTO_RETRIEVE_DELETED = true;
     private static final boolean KNOWN_DITTO_EXTERNAL_DRY_RUN = true;
     private static final String KNOWN_DITTO_ACKREGATOR_ADDRESS = "here!";
+    private static final String KNOWN_DITTO_DIVERT_RESPONSE_TO = "known-connection-id-to-divert-to";
+    private static final String KNOWN_DITTO_DIVERTED_RESPONSE_FROM = "known-connection-id-diverted-from";
+    private static final String KNOWN_DITTO_DIVERT_RESPONSE_TYPES = "response,error";
 
     private static final String KNOWN_DITTO_GET_METADATA = "attributes/*/key";
 
@@ -226,6 +229,9 @@ public final class ImmutableDittoHeadersTest {
                 .putHeader(DittoHeaderDefinition.PRE_DEFINED_EXTRA_FIELDS_OBJECT.getKey(),
                         KNOWN_PRE_DEFINED_EXTRA_FIELDS_OBJECT.formatAsString())
                 .putHeader(DittoHeaderDefinition.EXTERNAL_DRY_RUN.getKey(), String.valueOf(KNOWN_DITTO_EXTERNAL_DRY_RUN))
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO)
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM)
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES)
                 .build();
 
         assertThat(underTest).isEqualTo(expectedHeaderMap);
@@ -563,6 +569,9 @@ public final class ImmutableDittoHeadersTest {
                 .set(DittoHeaderDefinition.PUT_METADATA.getKey(), KNOWN_METADATA_HEADERS.toJson())
                 .set(DittoHeaderDefinition.GET_METADATA.getKey(), KNOWN_DITTO_GET_METADATA)
                 .set(DittoHeaderDefinition.DELETE_METADATA.getKey(), KNOWN_DITTO_DELETE_METADATA)
+                .set(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO)
+                .set(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM)
+                .set(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES)
                 .build();
 
         final Map<String, String> allKnownHeaders = createMapContainingAllKnownHeaders();
@@ -811,7 +820,12 @@ public final class ImmutableDittoHeadersTest {
                 KNOWN_PRE_DEFINED_EXTRA_FIELDS_OBJECT.formatAsString());
         result.put(DittoHeaderDefinition.EXTERNAL_DRY_RUN.getKey(),
                 String.valueOf(KNOWN_DITTO_EXTERNAL_DRY_RUN));
-
+        result.put(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO);
+        result.put(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES);
+        result.put(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM);
+        result.put(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES);
+        result.put(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO);
+        result.put(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM);
         return result;
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundDispatchingActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundDispatchingActor.java
@@ -33,6 +33,7 @@ import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.base.model.signals.events.streaming.StreamingSubscriptionEvent;
 import org.eclipse.ditto.connectivity.api.InboundSignal;
+import org.eclipse.ditto.connectivity.api.OutboundSignal;
 import org.eclipse.ditto.connectivity.api.OutboundSignalFactory;
 import org.eclipse.ditto.connectivity.model.Target;
 import org.eclipse.ditto.edge.service.acknowledgements.AcknowledgementForwarderActor;
@@ -82,6 +83,7 @@ final class OutboundDispatchingActor extends AbstractActor {
                 .match(SubscriptionEvent.class, this::forwardWithoutCheck)
                 .match(StreamingSubscriptionEvent.class, this::forwardWithoutCheck)
                 .match(DittoRuntimeException.class, this::forwardWithoutCheck)
+                .match(OutboundSignal.class, this::forwardWithoutCheck)
                 .match(Signal.class, this::handleSignal)
                 .matchAny(message -> logger.warning("Unknown message: <{}>", message))
                 .build();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionInterceptor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionInterceptor.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.apache.pekko.actor.ActorRef;
+import org.eclipse.ditto.base.model.common.ResponseType;
+import org.eclipse.ditto.base.model.entity.id.WithEntityId;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
+import org.eclipse.ditto.connectivity.api.OutboundSignal;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.service.util.ConnectionPubSub;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLogger;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+
+/**
+ * Interceptor that checks if responses should be diverted to another connection.
+ * This interceptor is responsible for:
+ * 1. Checking if a connection has response diversion configured
+ * 2. Enhancing signals with diversion metadata
+ * 3. Publishing signals to the target connection via PubSub
+ * 4. Preventing circular diversion chains
+ */
+@Immutable
+public class ResponseDiversionInterceptor {
+
+    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(ResponseDiversionInterceptor.class);
+    private static final Set<String> DEFAULT_RESPONSE_TYPES =
+            Set.of(ResponseType.RESPONSE.getName(), ResponseType.ERROR.getName());
+
+    private final Connection connection;
+    private final ConnectionPubSub pubSub;
+    private final String sourceConnectionId;
+
+    private ResponseDiversionInterceptor(final Connection connection,
+            final ConnectionPubSub pubSub) {
+        this.connection = checkNotNull(connection, "connection");
+        this.pubSub = checkNotNull(pubSub, "pubSub");
+        this.sourceConnectionId = connection.getId().toString();
+    }
+
+    /**
+     * Creates a new interceptor instance.
+     *
+     * @param connection the connection configuration
+     * @param pubSub the PubSub service for publishing diverted responses
+     * @return the new interceptor instance
+     */
+    public static ResponseDiversionInterceptor of(final Connection connection,
+            final ConnectionPubSub pubSub) {
+        return new ResponseDiversionInterceptor(connection, pubSub);
+    }
+
+    /**
+     * Intercepts an outbound signal and diverts it if configured.
+     * Only command responses are eligible for diversion.
+     *
+     * @param outboundSignal the outbound signal to intercept
+     * @return true if the signal was diverted (and should not be sent normally), false otherwise
+     */
+    public boolean interceptAndDivert(final OutboundSignal outboundSignal) {
+        checkNotNull(outboundSignal, "outboundSignal");
+        // TODO DIVERSION:
+        //  Consider static config extraction instead of header based dynamic
+        //  as static will do evaluation only once and then reroute all responses based on config.
+        //  Maybe a hybrid approach where static config is used for default diversion or one or the other.
+        //  HEADER '"ditto-divert-response-to"' (dynamic from mapping or js mapper)
+        final Signal<?> signal = outboundSignal.getSource();
+
+        // Divert instances of command responses.
+        if (!(signal instanceof CommandResponse)) {
+            LOGGER.debug("Signal is not a CommandResponse, skipping diversion: {}", signal.getType());
+            return false;
+        }
+
+        // Check if this response type should be diverted
+        final String origin = signal.getDittoHeaders().getOrigin().map(String::trim).orElse("");
+        @Nullable final String targetConnection = signal.getDittoHeaders().getOrDefault(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), null);
+        final Set<String> expectedResponses = expectedResponseTypes(signal);
+        final String responseType = signalResponseType(signal);
+        if (!origin.equals(targetConnection) && !(expectedResponseTypes(signal).isEmpty() || expectedResponses.contains(responseType))) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.withCorrelationId(signal)
+                        .debug("Response type '{}' not in expected types: {}, skipping diversion", responseType,
+                                expectedResponses);
+            }
+            return false;
+        }
+
+        return Optional.ofNullable(targetConnection)
+                .map(targetId -> divertToConnection(signal, targetId.trim()))
+                .orElse(false);
+    }
+
+    private Set<String> expectedResponseTypes(final Signal<?> signal) {
+        final String typesString =
+                signal.getDittoHeaders().get(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey());
+        final Set<String> allResponseTypes =
+                Arrays.stream(ResponseType.values()).map(ResponseType::getName).collect(Collectors.toSet());
+        if (typesString != null && !typesString.trim().isEmpty()) {
+            return Stream.of(typesString.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .filter(allResponseTypes::contains)
+                    .collect(Collectors.toSet());
+        }
+        return DEFAULT_RESPONSE_TYPES; // Default to RESPONSE and ERROR types if not specified
+    }
+
+    @Nullable
+    private String signalResponseType(final Signal<?> signal) {
+        if (signal instanceof CommandResponse<?> response) {
+            return response.getResponseType().getName();
+        }
+
+        return null; // Not a command response, no type to return
+    }
+
+    /**
+     * Diverts a signal to the specified target connection.
+     *
+     * @param signal the signal to divert
+     * @param targetConnectionIdString the target connection ID string
+     * @return true if diversion was successful, false otherwise
+     */
+    private boolean divertToConnection(final Signal<?> signal, final String targetConnectionIdString) {
+        // Enhance signal with diversion headers
+        final Signal<?> enhancedSignal = enhanceSignalForDiversion(signal);
+        try {
+            final ConnectionId targetConnectionId = ConnectionId.of(targetConnectionIdString);
+
+            // Check for self-diversion
+            if (targetConnectionId.toString().equals(sourceConnectionId)) {
+                LOGGER.withCorrelationId(signal)
+                        .warn("Connection cannot divert responses to itself: {}", sourceConnectionId);
+                return false;
+            }
+
+
+            LOGGER.withCorrelationId(signal)
+                    .info("Diverting response from connection '{}' to connection '{}'",
+                            sourceConnectionId, targetConnectionId);
+            final String groupIndexKey;
+            if (enhancedSignal instanceof WithEntityId withEntityId){
+                groupIndexKey = withEntityId.getEntityId().toString();
+            } else {
+                groupIndexKey = enhancedSignal.getName();
+            }
+            // Publish to target connection with retry capability
+            pubSub.publishSignalForDiversion(enhancedSignal, targetConnectionId, groupIndexKey, ActorRef.noSender());
+
+            return true; // The Signal was diverted
+
+        } catch (final Exception e) {
+            LOGGER.withCorrelationId(enhancedSignal)
+                    .error("Failed to divert response to connection: {}", targetConnectionIdString, e);
+            return false;
+        }
+    }
+
+    /**
+     * Enhances a signal with diversion tracking headers.
+     *
+     * @param signal the original signal
+     * @return the enhanced signal
+     */
+    private Signal<?> enhanceSignalForDiversion(final Signal<?> signal) {
+        final DittoHeaders originalHeaders = signal.getDittoHeaders();
+
+        final DittoHeaders enhancedHeaders = DittoHeaders.newBuilder(originalHeaders)
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), connection.getId().toString())
+                .build();
+
+        return signal.setDittoHeaders(enhancedHeaders);
+    }
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
@@ -229,6 +229,8 @@ public final class ConnectionValidator {
                 .ifPresent(credentials -> credentials.accept(
                         CredentialsValidationVisitor.of(connection, dittoHeaders, connectivityConfig, hostValidator)));
 
+        ResponseDiversionValidator.validate(connection, dittoHeaders);
+
         // protocol specific validations
         final AbstractProtocolValidator spec = specMap.get(connection.getConnectionType());
         if (spec != null) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ResponseDiversionValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ResponseDiversionValidator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging.validation;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.ResponseType;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionConfigurationInvalidException;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.ConnectionIdInvalidException;
+
+/**
+ * Validator for response diversion configuration in connections.
+ * This validator ensures that:
+ * 1. The target connection ID is valid
+ * 2. A connection doesn't divert to itself
+ */
+@Immutable
+public final class ResponseDiversionValidator {
+
+    private static Map<String, String> mappings;
+
+    private ResponseDiversionValidator() {
+        // no instantiation
+    }
+
+    public static void validate(final Connection connection, final DittoHeaders dittoHeaders) {
+        validateResponseDiversionConnectionId(connection, dittoHeaders);
+        connection.getSources().stream()
+                .filter(source -> mappings.containsKey(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey()))
+                .findFirst()
+                .ifPresent(source -> validateResponseTypes(source.getHeaderMapping().getMapping()
+                        .get(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey()), dittoHeaders));
+    }
+
+    /**
+     * Validates the response diversion configuration of a connection.
+     *
+     * @param connection the connection to validate
+     * @param dittoHeaders the headers to use for error reporting
+     * @throws ConnectionConfigurationInvalidException if the diversion headers are invalid
+     */
+    public static void validateResponseDiversionConnectionId(final Connection connection, final DittoHeaders dittoHeaders) {
+        final Set<String> targetConnectionId = connection.getSources().stream().filter(source -> {
+                    mappings = source.getHeaderMapping().getMapping();
+                    return mappings.containsKey(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey());
+
+                }).map(source -> mappings.get(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey()))
+                .collect(Collectors.toSet());
+
+
+        targetConnectionId.forEach(targetId -> {
+            // Check if target ID is not empty
+            if (targetId.trim().isEmpty()) {
+                throw ConnectionConfigurationInvalidException.newBuilder(
+                                "The " + DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey() +
+                                        " in headerMapping must not be empty")
+                        .dittoHeaders(dittoHeaders)
+                        .build();
+            }
+            try {
+                // Check if it's a valid connection ID format
+                final ConnectionId parsedTargetId = ConnectionId.of(targetId);
+
+                // Check for self-diversion
+                if (parsedTargetId.equals(connection.getId())) {
+                    throw ConnectionConfigurationInvalidException.newBuilder(
+                                    "It is pointless to divert responses to the originating connection, it will receive the responses by default. " +
+                                            "Remove the " + DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey() + " from the headerMapping of connection: " + connection.getId())
+                            .dittoHeaders(dittoHeaders)
+                            .build();
+                }
+            } catch (final ConnectionIdInvalidException e) {
+                throw ConnectionConfigurationInvalidException.newBuilder(
+                                "Invalid target connection ID format in " +
+                                        DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey() + ": " + targetId)
+                        .dittoHeaders(dittoHeaders)
+                        .cause(e)
+                        .build();
+            }
+        });
+    }
+
+    private static void validateResponseTypes(final String responseTypes, final DittoHeaders dittoHeaders) {
+        if (!responseTypes.trim().isEmpty()) {
+            final Set<String> validTypes = Arrays.stream(ResponseType.values())
+                    .map(ResponseType::getName)
+                    .collect(Collectors.toSet());
+            Stream.of(responseTypes.split(","))
+                    .map(String::trim)
+                    .filter(type -> !type.isEmpty() && !validTypes.contains(type))
+                    .findFirst()
+                    .ifPresent(invalidType -> {
+                        throw ConnectionConfigurationInvalidException.newBuilder(
+                                        "Invalid response type in <"
+                                                + DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey() + ">: "
+                                                + invalidType + ". Valid types are: response, error, nack")
+                                .dittoHeaders(dittoHeaders)
+                                .build();
+                    });
+        }
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
@@ -277,8 +277,7 @@ public final class OutboundMappingProcessorActorTest {
     private List<OutboundMappingProcessor> getProcessors() {
         return List.of(
                 OutboundMappingProcessor.of(CONNECTION,
-                TestConstants.CONNECTIVITY_CONFIG,
-                actorSystemResource.getActorSystem(),
+                TestConstants.CONNECTIVITY_CONFIG, actorSystemResource.getActorSystem(),
                 protocolAdapterProvider.getProtocolAdapter("test"),
                 AbstractMessageMappingProcessorActorTest.mockLoggingAdapter())
         );

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionIntegrationTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionIntegrationTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.testkit.TestProbe;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.connectivity.api.OutboundSignal;
+import org.eclipse.ditto.connectivity.api.OutboundSignalFactory;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.ConnectionType;
+import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
+import org.eclipse.ditto.connectivity.model.ConnectivityStatus;
+import org.eclipse.ditto.connectivity.model.ReplyTarget;
+import org.eclipse.ditto.connectivity.model.Source;
+import org.eclipse.ditto.connectivity.model.Target;
+import org.eclipse.ditto.connectivity.model.Topic;
+import org.eclipse.ditto.connectivity.service.util.ConnectionPubSub;
+import org.eclipse.ditto.internal.utils.pekko.ActorSystemResource;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThingResponse;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Integration test for response diversion functionality.
+ * This test verifies the complete flow of diverting responses from one connection to another.
+ */
+public class ResponseDiversionIntegrationTest {
+
+    private static final ConnectionId SOURCE_CONNECTION_ID = ConnectionId.of("source-connection");
+    private static final ConnectionId TARGET_CONNECTION_ID = ConnectionId.of("target-connection");
+    private static final ThingId THING_ID = ThingId.of("test:thing");
+    private static final String CORRELATION_ID = "integration-test-correlation";
+    private static final AuthorizationContext AUTHORIZATION_CONTEXT =
+            AuthorizationModelFactory.newAuthContext(DittoAuthorizationContextType.PRE_AUTHENTICATED_CONNECTION,
+                    AuthorizationModelFactory.newAuthSubject("nginx:ditto"));
+
+    private ConnectionPubSub pubSub;
+    private Connection sourceConnection;
+    private Connection targetConnection;
+
+    @ClassRule
+    public static final ActorSystemResource ACTOR_SYSTEM_RESOURCE = ActorSystemResource.newInstance(
+            ConfigFactory.parseMap(Map.ofEntries(
+                    Map.entry("pekko.actor.provider", "cluster")
+            ))
+    );
+
+    @Before
+    public void setUp() {
+        pubSub = ConnectionPubSub.get(ACTOR_SYSTEM_RESOURCE.getActorSystem());
+
+        // Create source connection with diversion configured
+        sourceConnection = createSourceConnection();
+
+        // Create target connection configured to receive diverted responses
+        targetConnection = createTargetConnection();
+    }
+
+    @Test
+    public void endToEndResponseDiversion() {
+        final ActorSystem actorSystem = ACTOR_SYSTEM_RESOURCE.getActorSystem();
+        new TestKit(actorSystem) {{
+            // Simulate the target connection subscribing for diverted responses
+            final TestProbe targetConnectionActor = TestProbe.apply(actorSystem);
+            pubSub.subscribeForDivertedResponses(TARGET_CONNECTION_ID, targetConnectionActor.ref(), false);
+
+            // Allow time for subscription to propagate
+            expectNoMessage(Duration.ofMillis(100));
+
+            // Create a response signal with diversion headers
+            final DittoHeaders headers = DittoHeaders.newBuilder()
+                    .correlationId(CORRELATION_ID)
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString())
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response")
+                    .build();
+
+            final ModifyThingResponse response = ModifyThingResponse.modified(THING_ID, headers);
+
+            // Create the interceptor for the source connection
+            final ResponseDiversionInterceptor interceptor =
+                    ResponseDiversionInterceptor.of(sourceConnection, pubSub);
+
+            // Create an outbound signal
+            final Target dummyTarget = ConnectivityModelFactory.newTargetBuilder()
+                    .address("dummy/address")
+                    .authorizationContext(AuthorizationContext.empty())
+                    .topics(Topic.LIVE_MESSAGES, Topic.TWIN_EVENTS)
+                    .build();
+
+            final OutboundSignal outboundSignal = OutboundSignalFactory.newOutboundSignal(
+                    response,
+                    Collections.singletonList(dummyTarget)
+            );
+
+            // Intercept and divert the response
+            final boolean wasDiverted = interceptor.interceptAndDivert(outboundSignal);
+
+            // Verify the response was diverted
+            assertThat(wasDiverted).isTrue();
+
+            // In a real distributed system with actual PubSub, the target would receive the signal
+            // Here we verify that the publish message was sent to the mediator
+            // The actual delivery would depend on the PubSub implementation
+        }};
+    }
+
+    @Test
+    public void responseDiversionWithMultipleResponseTypes() {
+        final ActorSystem actorSystem = ACTOR_SYSTEM_RESOURCE.getActorSystem();
+        new TestKit(actorSystem) {{
+            final TestProbe targetConnectionActor = TestProbe.apply(actorSystem);
+            pubSub.subscribeForDivertedResponses(TARGET_CONNECTION_ID, targetConnectionActor.ref(), false);
+
+            // Create headers that allow all response types
+            final DittoHeaders headers = DittoHeaders.newBuilder()
+                    .correlationId(CORRELATION_ID)
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString())
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response,error,nack")
+                    .build();
+
+            final ModifyThingResponse response = ModifyThingResponse.modified(THING_ID, headers);
+            final ResponseDiversionInterceptor interceptor =
+                    ResponseDiversionInterceptor.of(sourceConnection, pubSub);
+
+            final Target dummyTarget = ConnectivityModelFactory.newTargetBuilder()
+                    .address("dummy/address")
+                    .topics(Set.of())
+                    .authorizationContext(AuthorizationContext.empty())
+                    .build();
+
+            final OutboundSignal outboundSignal = OutboundSignalFactory.newOutboundSignal(
+                    response,
+                    Collections.singletonList(dummyTarget)
+            );
+
+            final boolean wasDiverted = interceptor.interceptAndDivert(outboundSignal);
+            assertThat(wasDiverted).isTrue();
+        }};
+    }
+
+    @Test
+    public void multipleTargetConnectionsReceivingDivertedResponses() {
+        final ActorSystem actorSystem = ACTOR_SYSTEM_RESOURCE.getActorSystem();
+        new TestKit(actorSystem) {{
+            final ConnectionId secondTargetId = ConnectionId.of("second-target-connection");
+
+            // Set up two target connections
+            final TestProbe targetConnectionActor1 = TestProbe.apply(actorSystem);
+            final TestProbe targetConnectionActor2 = TestProbe.apply(actorSystem);
+
+            pubSub.subscribeForDivertedResponses(TARGET_CONNECTION_ID, targetConnectionActor1.ref(), false);
+            pubSub.subscribeForDivertedResponses(secondTargetId, targetConnectionActor2.ref(), false);
+
+            expectNoMessage(Duration.ofMillis(100));
+
+            // Test diverting to first target
+            DittoHeaders headers1 = DittoHeaders.newBuilder()
+                    .correlationId(CORRELATION_ID + "-1")
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString())
+                    .build();
+
+            ModifyThingResponse response1 = ModifyThingResponse.modified(THING_ID, headers1);
+            ResponseDiversionInterceptor interceptor = ResponseDiversionInterceptor.of(sourceConnection, pubSub);
+
+            Target dummyTarget = ConnectivityModelFactory.newTargetBuilder()
+                    .address("dummy/address")
+                    .topics(Set.of())
+                    .authorizationContext(AuthorizationContext.empty())
+                    .build();
+
+            OutboundSignal outboundSignal1 = OutboundSignalFactory.newOutboundSignal(
+                    response1,
+                    Collections.singletonList(dummyTarget)
+            );
+
+            boolean wasDiverted1 = interceptor.interceptAndDivert(outboundSignal1);
+            assertThat(wasDiverted1).isTrue();
+
+            // Test diverting to second target
+            DittoHeaders headers2 = DittoHeaders.newBuilder()
+                    .correlationId(CORRELATION_ID + "-2")
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), secondTargetId.toString())
+                    .build();
+
+            ModifyThingResponse response2 = ModifyThingResponse.modified(THING_ID, headers2);
+
+            OutboundSignal outboundSignal2 = OutboundSignalFactory.newOutboundSignal(
+                    response2,
+                    Collections.singletonList(dummyTarget)
+            );
+
+            boolean wasDiverted2 = interceptor.interceptAndDivert(outboundSignal2);
+            assertThat(wasDiverted2).isTrue();
+        }};
+    }
+
+    @Test
+    public void dynamicDiversionWithWildcard() {
+        final ActorSystem actorSystem = ACTOR_SYSTEM_RESOURCE.getActorSystem();
+        new TestKit(actorSystem) {{
+            // Create connection with wildcard diversion
+            final Source sourceWithWildcard = ConnectivityModelFactory.newSourceBuilder()
+                    .authorizationContext(AUTHORIZATION_CONTEXT)
+                    .address("commands/+/+")
+                    .headerMapping(ConnectivityModelFactory.newHeaderMapping(Map.of(
+                            DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), "*"
+                    )))
+                    .build();
+
+            final Connection dynamicConnection = ConnectivityModelFactory.newConnectionBuilder(
+                            ConnectionId.of("dynamic-connection"),
+                            ConnectionType.MQTT,
+                            ConnectivityStatus.OPEN,
+                            "tcp://mqtt-broker:1883"
+                    )
+                    .sources(Collections.singletonList(sourceWithWildcard))
+                    .build();
+
+            final TestProbe targetConnectionActor = TestProbe.apply(actorSystem);
+            pubSub.subscribeForDivertedResponses(TARGET_CONNECTION_ID, targetConnectionActor.ref(), false);
+
+            expectNoMessage(Duration.ofMillis(100));
+
+            // Headers should include the actual target since wildcard is used
+            final DittoHeaders headers = DittoHeaders.newBuilder()
+                    .correlationId(CORRELATION_ID)
+                    .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString())
+                    .build();
+
+            final ModifyThingResponse response = ModifyThingResponse.modified(THING_ID, headers);
+            final ResponseDiversionInterceptor interceptor =
+                    ResponseDiversionInterceptor.of(dynamicConnection, pubSub);
+
+            final Target dummyTarget = ConnectivityModelFactory.newTargetBuilder()
+                    .address("dummy/address")
+                    .topics(Set.of())
+                    .authorizationContext(AUTHORIZATION_CONTEXT)
+                    .build();
+
+            final OutboundSignal outboundSignal = OutboundSignalFactory.newOutboundSignal(
+                    response,
+                    Collections.singletonList(dummyTarget)
+            );
+
+            final boolean wasDiverted = interceptor.interceptAndDivert(outboundSignal);
+            assertThat(wasDiverted).isTrue();
+        }};
+    }
+
+    private Connection createSourceConnection() {
+        final Map<String, String> headerMapping = Map.of(
+                "correlation-id", "{{ header:correlation-id }}",
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString(),
+                DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response,error"
+        );
+
+        final Source source = ConnectivityModelFactory.newSourceBuilder()
+                .authorizationContext(AuthorizationContext.empty())
+                .address("ditto/inbound/commands")
+                .authorizationContext(AUTHORIZATION_CONTEXT)
+                .headerMapping(ConnectivityModelFactory.newHeaderMapping(headerMapping))
+                .replyTarget(ReplyTarget.newBuilder()
+                        .address("ditto/outbound/responses/{{ header:correlation-id }}")
+                        .headerMapping(ConnectivityModelFactory.newHeaderMapping(headerMapping))
+                        .build())
+                .build();
+
+        return ConnectivityModelFactory.newConnectionBuilder(
+                        SOURCE_CONNECTION_ID,
+                        ConnectionType.MQTT,
+                        ConnectivityStatus.OPEN,
+                        "tcp://mqtt-broker:1883"
+                )
+                .sources(Collections.singletonList(source))
+                .build();
+    }
+
+    private Connection createTargetConnection() {
+        final Target target = ConnectivityModelFactory.newTargetBuilder()
+                .address("ditto.responses")
+                .authorizationContext(AUTHORIZATION_CONTEXT)
+                .topics(Topic.LIVE_MESSAGES, Topic.TWIN_EVENTS)
+                .headerMapping(ConnectivityModelFactory.newHeaderMapping(Map.of(
+                        "correlation-id", "{{ header:correlation-id }}",
+                        "diverted-from", "{{ header:ditto-diverted-response-from }}"
+                )))
+                .build();
+
+        return ConnectivityModelFactory.newConnectionBuilder(
+                        TARGET_CONNECTION_ID,
+                        ConnectionType.AMQP_091,
+                        ConnectivityStatus.OPEN,
+                        "amqp://rabbitmq:5672"
+                )
+                .specificConfig(Map.of("is-diversion-target", "true"))
+                .targets(Collections.singletonList(target))
+                .build();
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionInterceptorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ResponseDiversionInterceptorTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
+import org.eclipse.ditto.base.model.signals.commands.ErrorResponse;
+import org.eclipse.ditto.connectivity.api.OutboundSignal;
+import org.eclipse.ditto.connectivity.api.OutboundSignalFactory;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
+import org.eclipse.ditto.connectivity.model.Target;
+import org.eclipse.ditto.connectivity.model.Topic;
+import org.eclipse.ditto.connectivity.service.util.ConnectionPubSub;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.ThingsModelFactory;
+import org.eclipse.ditto.things.model.signals.commands.ThingErrorResponse;
+import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingNotAccessibleException;
+import org.eclipse.ditto.things.model.signals.commands.modify.ModifyThingResponse;
+import org.eclipse.ditto.things.model.signals.events.ThingCreated;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link ResponseDiversionInterceptor}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ResponseDiversionInterceptorTest {
+
+    private static final ConnectionId SOURCE_CONNECTION_ID = ConnectionId.of("source-connection");
+    private static final ConnectionId TARGET_CONNECTION_ID = ConnectionId.of("target-connection");
+    private static final ThingId THING_ID = ThingId.of("test:thing");
+    private static final String CORRELATION_ID = "test-correlation-id";
+
+    @Mock
+    private ConnectionPubSub pubSub;
+
+    @Mock
+    private Connection connection;
+
+    private ResponseDiversionInterceptor underTest;
+
+    @Before
+    public void setUp() {
+        when(connection.getId()).thenReturn(SOURCE_CONNECTION_ID);
+//        when(pubSub.publishSignalForDiversion(any(), any()))
+        underTest = ResponseDiversionInterceptor.of(connection, pubSub);
+    }
+
+    @Test
+    public void nullConstructorArguments() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ResponseDiversionInterceptor.of(null, pubSub))
+                .withMessage("The connection must not be null!");
+        
+        assertThatNullPointerException()
+                .isThrownBy(() -> ResponseDiversionInterceptor.of(connection, null))
+                .withMessage("The pubSub must not be null!");
+    }
+
+    @Test
+    public void divertSuccessfulResponse() {
+        final DittoHeaders headers = commonDittoHeaders().build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isTrue();
+
+        final ArgumentCaptor<Signal<?>> signalCaptor = ArgumentCaptor.forClass(Signal.class);
+        verify(pubSub).publishSignalForDiversion(signalCaptor.capture(), eq(TARGET_CONNECTION_ID), eq(THING_ID.toString()), eq(null));
+
+        final Signal<?> capturedSignal = signalCaptor.getValue();
+        assertThat(capturedSignal.getDittoHeaders())
+                .containsEntry(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), SOURCE_CONNECTION_ID.toString());
+    }
+
+    @Test
+    public void divertWithResponseTypeFiltering() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response")
+                .build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+        final CommandResponse<?> expectedResponse = response.setDittoHeaders(response.getDittoHeaders().toBuilder()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), SOURCE_CONNECTION_ID.toString())
+                .build());
+        assertThat(diverted).isTrue();
+        verify(pubSub).publishSignalForDiversion(eq(expectedResponse), eq(TARGET_CONNECTION_ID), eq(THING_ID.toString()), eq(null));
+    }
+
+    @Test
+    public void doNotDivertErrorWhenOnlyResponseTypeConfigured() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response")
+                .build();
+
+        // Create an error response
+        final CommandResponse<?> errorResponse = ThingErrorResponse.of(
+                THING_ID,
+                DittoRuntimeException.fromMessage("Test error", headers, ThingNotAccessibleException.newBuilder(THING_ID))
+        );
+
+        final OutboundSignal outboundSignal = createOutboundSignal(errorResponse);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isFalse();
+        verify(pubSub, never()).publishSignalForDiversion(eq(errorResponse), eq(TARGET_CONNECTION_ID), eq(THING_ID), any());
+    }
+
+    @Test
+    public void divertMultipleResponseTypes() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response,error,nack")
+                .build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isTrue();
+        final CommandResponse<?> expectedResponse = getExpectedResponse(response);
+        verify(pubSub).publishSignalForDiversion(eq(expectedResponse), eq(TARGET_CONNECTION_ID), eq(THING_ID.toString()), eq(null));
+    }
+
+    @Test
+    public void doNotDivertNonCommandResponse() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .build();
+
+        // Use an event instead of a command response
+        final ThingCreated event = ThingCreated.of(
+                ThingsModelFactory.newThingBuilder().setId(THING_ID).build(),
+                1L,
+                null,
+                headers,
+                null
+        );
+
+        final OutboundSignal outboundSignal = createOutboundSignal(event);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isFalse();
+        verify(pubSub, never()).publishSignalForDiversion(eq(event), eq(TARGET_CONNECTION_ID), eq(THING_ID), any());
+    }
+
+    @Test
+    public void doNotDivertWithoutDiversionHeader() {
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .correlationId(CORRELATION_ID)
+                .build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isFalse();
+        verify(pubSub, never()).publishSignalForDiversion(any(Signal.class), any(ConnectionId.class), any(CharSequence.class), any());
+    }
+
+    @Test
+    public void doNotDivertToSelf() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), SOURCE_CONNECTION_ID.toString())
+                .build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isFalse();
+        verify(pubSub, never()).publishSignalForDiversion(any(Signal.class), any(ConnectionId.class), any(CharSequence.class), any());
+    }
+
+    @Test
+    public void doNotDivertWithInvalidTargetConnectionId() {
+        final DittoHeaders headers = commonDittoHeaders()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), "invalid connection id!")
+                .build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final OutboundSignal outboundSignal = createOutboundSignal(response);
+
+        final boolean diverted = underTest.interceptAndDivert(outboundSignal);
+
+        assertThat(diverted).isFalse();
+        verify(pubSub, never()).publishSignalForDiversion(any(Signal.class), any(ConnectionId.class), any(CharSequence.class), any());
+    }
+
+    @Test
+    public void nullOutboundSignal() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> underTest.interceptAndDivert(null))
+                .withMessage("The outboundSignal must not be null!");
+    }
+    @Test
+    public void emptyResponseTypesDefaultsToResponseAndError() {
+        final DittoHeaders headers = commonDittoHeaders().build();
+
+        final CommandResponse<?> response = ModifyThingResponse.modified(THING_ID, headers);
+        final ErrorResponse<ThingErrorResponse> errorResponse = ThingErrorResponse.of(THING_ID,
+                DittoRuntimeException.fromMessage("Test error", headers, ThingNotAccessibleException.newBuilder(THING_ID)));
+        final Acknowledgement weak =
+                Acknowledgement.of(AcknowledgementLabel.of("test-label"), THING_ID, HttpStatus.BAD_REQUEST, headers, null);
+
+
+        final boolean diverted = underTest.interceptAndDivert(createOutboundSignal(response));
+        final CommandResponse<?> expectedResponse = getExpectedResponse(response);
+        assertThat(diverted).isTrue();
+        verify(pubSub, times(1)).publishSignalForDiversion(eq(expectedResponse), eq(TARGET_CONNECTION_ID), eq(THING_ID.toString()), eq(null));
+
+        final boolean divertedError = underTest.interceptAndDivert(createOutboundSignal(errorResponse));
+        final CommandResponse<?> expectedErrorResponse = getExpectedResponse(errorResponse);
+        assertThat(divertedError).isTrue();
+        verify(pubSub, times(1)).publishSignalForDiversion(eq(expectedErrorResponse), eq(TARGET_CONNECTION_ID), eq(THING_ID.toString()), eq(null));
+
+        final boolean divertedWeak = underTest.interceptAndDivert(createOutboundSignal(weak));
+        assertThat(divertedWeak).isFalse();
+        verifyNoMoreInteractions(pubSub);
+
+    }
+
+    private static @NotNull CommandResponse<?> getExpectedResponse(final CommandResponse<?> response) {
+        return response.setDittoHeaders(response.getDittoHeaders().toBuilder()
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERTED_RESPONSE_FROM.getKey(), SOURCE_CONNECTION_ID.toString())
+                .build());
+    }
+
+    private static @NotNull DittoHeadersBuilder<?,?> commonDittoHeaders() {
+        return DittoHeaders.newBuilder()
+                .correlationId(CORRELATION_ID)
+                .putHeader(DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString())
+                .putHeader(DittoHeaderDefinition.ORIGIN.getKey(), SOURCE_CONNECTION_ID.toString());
+    }
+
+    private OutboundSignal createOutboundSignal(final Signal<?> signal) {
+        final Target target = ConnectivityModelFactory.newTargetBuilder()
+                .address("test/address")
+                .authorizationContext(AuthorizationContext.empty())
+                .topics(Topic.TWIN_EVENTS)
+                .build();
+
+        return OutboundSignalFactory.newOutboundSignal(signal, Collections.singletonList(target));
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/ResponseDiversionValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/ResponseDiversionValidatorTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging.validation;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectionBuilder;
+import org.eclipse.ditto.connectivity.model.ConnectionConfigurationInvalidException;
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.ConnectionType;
+import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
+import org.eclipse.ditto.connectivity.model.ConnectivityStatus;
+import org.eclipse.ditto.connectivity.model.Source;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+
+/**
+ * Unit tests for {@link ResponseDiversionValidator}.
+ */
+public class ResponseDiversionValidatorTest {
+
+    private static final ConnectionId CONNECTION_ID = ConnectionId.of("test:connection");
+    private static final ConnectionId TARGET_CONNECTION_ID = ConnectionId.of("target-connection");
+    private static final DittoHeaders DITTO_HEADERS = DittoHeaders.empty();
+    private static final AuthorizationContext AUTHORIZATION_CONTEXT = AuthorizationModelFactory.newAuthContext(
+            DittoAuthorizationContextType.PRE_AUTHENTICATED_CONNECTION,
+            AuthorizationModelFactory.newAuthSubject("nginx:ditto"));
+    private ConnectionBuilder connectionBuilder;
+
+    @Before
+    public void setUp() {
+        connectionBuilder = ConnectivityModelFactory.newConnectionBuilder(
+                CONNECTION_ID,
+                ConnectionType.MQTT,
+                ConnectivityStatus.OPEN,
+                "tcp://mqtt-broker:1883"
+        );
+    }
+
+    @Test
+    public void validResponseDiversionConfiguration() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString()
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void validResponseDiversionWithTypes() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString(),
+                DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response,error,nack"
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void invalidEmptyTargetConnectionId() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), ""
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS))
+                .withMessageContaining("must not be empty");
+    }
+
+    @Test
+    public void invalidSelfDiversion() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), CONNECTION_ID.toString()
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS))
+                .withMessageContaining("It is pointless to divert responses to the originating connection");
+    }
+
+    @Test
+    public void invalidConnectionIdFormat() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), "invalid connection id!"
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS))
+                .withMessageContaining("Invalid target connection ID format");
+    }
+
+    @Test
+    public void invalidResponseType() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString(),
+                DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "response,invalid-type,error"
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS))
+                .withMessageContaining("Invalid response type")
+                .withMessageContaining("invalid-type")
+                .withMessageContaining("Valid types are: response, error, nack");
+    }
+
+    @Test
+    public void emptyResponseTypesIsValid() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString(),
+                DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), ""
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void whitespaceOnlyResponseTypesIsValid() {
+        final Map<String, String> headerMapping = Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString(),
+                DittoHeaderDefinition.DITTO_DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), "   "
+        );
+        
+        final Source source = createSourceWithHeaderMapping(headerMapping);
+
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void multipleSourcesWithDifferentDiversionTargets() {
+        final Source source1 = createSourceWithHeaderMapping(Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), "target-1"
+        ));
+        
+        final Source source2 = createSourceWithHeaderMapping(Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), "target-2"
+        ));
+        
+        final Connection connection = connectionBuilder
+                .sources(List.of(source1, source2))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void sourceWithoutDiversionIsValid() {
+        final Source source = createSourceWithHeaderMapping(Map.of());
+
+        final Connection connection = connectionBuilder
+                .sources(Collections.singletonList(source))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    @Test
+    public void mixedSourcesWithAndWithoutDiversion() {
+        final Source sourceWithDiversion = createSourceWithHeaderMapping(Map.of(
+                DittoHeaderDefinition.DITTO_DIVERT_RESPONSE_TO.getKey(), TARGET_CONNECTION_ID.toString()
+        ));
+        
+        final Source sourceWithoutDiversion = createSourceWithHeaderMapping(Map.of());
+        
+        final Connection connection = connectionBuilder
+                .sources(List.of(sourceWithDiversion, sourceWithoutDiversion))
+                .build();
+
+        assertThatNoException()
+                .isThrownBy(() -> ResponseDiversionValidator.validate(connection, DITTO_HEADERS));
+    }
+
+    private Source createSourceWithHeaderMapping(final Map<String, String> mapping) {
+        return ConnectivityModelFactory.newSourceBuilder()
+                .authorizationContext(AUTHORIZATION_CONTEXT)
+                .address("test/address")
+                .qos(MqttQos.EXACTLY_ONCE.getCode())
+                .headerMapping(ConnectivityModelFactory.newHeaderMapping(mapping))
+                .build();
+    }
+}

--- a/documentation/src/main/resources/_posts/2025-06-23-response-diversion.md
+++ b/documentation/src/main/resources/_posts/2025-06-23-response-diversion.md
@@ -1,0 +1,187 @@
+---
+title: "Response diversion - Multi-protocol workflows made easy"
+published: true
+permalink: 2025-06-23-response-diversion.html
+layout: post
+author: aleksandar_stanchev
+tags: [blog, connectivity]
+hide_sidebar: true
+sidebar: false
+toc: true
+---
+
+Today we're excited to announce a powerful new connectivity feature in Eclipse Ditto: **Response Diversion**. 
+This feature enables sophisticated multiprotocol workflows by allowing responses from one connection to be redirected to another connection instead of being sent to the originally configured reply target.
+
+With response diversion, Eclipse Ditto becomes even more versatile in bridging different IoT protocols and systems, 
+enabling complex routing scenarios that were previously challenging or impossible to achieve.
+
+## The challenge: Multi-protocol IoT landscapes
+
+Modern IoT deployments often involve multiple protocols and systems working together. Consider these common scenarios:
+
+- **Cloud integration**: Your devices use MQTT to communicate with AWS IoT Core, but your analytics pipeline consumes data via Kafka
+- **Protocol translation**: Legacy systems expect HTTP webhooks, but your devices communicate via AMQP
+- **Response aggregation**: You want to collect all device responses in a central monitoring system regardless of the original protocol
+
+Until now, implementing such multiprotocol workflows required complex external routing logic or multiple intermediate systems. 
+Response diversion brings this capability directly into Ditto's connectivity layer.
+
+## How response diversion works
+
+Response diversion is configured at the connection source level using special header mapping keys:
+
+```json
+{
+  "headerMapping": {
+    "ditto-divert-response-to": "target-connection-id", 
+    "ditto-divert-expected-response-types": "response,error,nack"
+  }
+}
+``` 
+
+And in the target connection, by defining a target that matches the diverted responses:
+```json
+  {
+    "targets": [
+        {
+            "address": "command/redirected/response",
+            "topics": [],
+            "qos": 1,
+            "authorizationContext": [
+                "pre:ditto"
+            ],
+            "headerMapping": {}
+        }
+    ],
+    "specificConfig": {
+        "is-diversion-target": "true"
+    }
+}
+
+
+```
+
+When a command is received through a source with response diversion configured, Ditto intercepts the response and routes it through the specified target connection instead of the original reply target.
+
+## Real-world use case: AWS IoT Core with Kafka 
+
+Let's explore a practical scenario that demonstrates the power of response diversion. In this setup:
+
+- Devices communicate with **AWS IoT Core** via MQTT (bidirectional)
+- **Apache Kafka** IoT Core pushes device commands to a Kafka topic
+- Device commands are consumed from Kafka topics
+- **Responses must go back to AWS IoT Core via MQTT** (since IoT Core doesn't support Kafka consumers)
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│  AWS IoT Core   │    │   Kafka Bridge  │    │  Apache Kafka   │    │  Eclipse Ditto  │
+│    (MQTT)       │    │   /Analytics    │    │                 │    │                 │
+│                 │    │                 │    │                 │    │                 │
+│ ┌─────────────┐ │    │ ┌─────────────┐ │    │ ┌─────────────┐ │    │ ┌─────────────┐ │
+│ │Device       │ │───▶│ │MQTT→Kafka   │ │───▶│ │device-      │ │───▶│ │Kafka Source │ │
+│ │Commands     │ │    │ │Bridge       │ │    │ │commands     │ │    │ │Connection   │ │
+│ │(MQTT topics)│ │    │ │             │ │    │ │topic        │ │    │ │             │ │
+│ └─────────────┘ │    │ └─────────────┘ │    │ └─────────────┘ │    │ └─────────────┘ │
+│        ▲        │    │                 │    │                 │    │        │        │
+│        │        │    │                 │    │                 │    │        ▼        │
+│        │        │    │                 │    │                 │    │ ┌─────────────┐ │
+│        │        │    │                 │    │                 │    │ │Command      │ │
+│        │        │    │                 │    │                 │    │ │Processing   │ │
+│        │        │    │                 │    │                 │    │ │             │ │
+│        │        │    │                 │    │                 │    │ └─────────────┘ │
+│        │        │    │                 │    │                 │    │        │        │
+│        │        │    │                 │    │                 │    │        ▼        │
+│        │        │    │                 │    │                 │    │ ┌─────────────┐ │
+│        │        │    │                 │    │                 │    │ │Response     │ │
+│        │        │    │                 │    │                 │    │ │Diversion    │ │
+│        │        │    │                 │    │                 │    │ │Interceptor  │ │
+│        │        │    │                 │    │                 │    │ └─────────────┘ │
+│        │        │    │                 │    │                 │    │        │        │
+│        │        │    │                 │    │                 │    │        ▼        │
+│ ┌─────────────┐ │    │                 │    │                 │    │ ┌─────────────┐ │
+│ │Device       │ │◀───┼─────────────────┼────┼─────────────────┼────│ │MQTT Target  │ │
+│ │Responses    │ │    │                 │    │                 │    │ │Connection   │ │
+│ │(MQTT topics)│ │    │                 │    │                 │    │ │(AWS IoT)    │ │
+│ └─────────────┘ │    │                 │    │                 │    │ └─────────────┘ │
+└─────────────────┘    └─────────────────┘    └─────────────────┘    └─────────────────┘
+
+Legend:
+───▶ Command Flow (MQTT → Kafka → Ditto)
+◀─── Response Flow (Ditto → MQTT, bypassing Kafka)
+
+```
+
+### Example Configuration
+
+First, create the Kafka connection that consumes device commands:
+
+```json
+{
+  "id": "kafka-commands-connection",
+  "connectionType": "kafka",
+  "connectionStatus": "open",
+  "uri": "tcp://kafka-broker:9092",
+  "specificConfig": {
+    "bootstrapServers": "kafka-broker:9092",
+    "saslMechanism": "plain"
+  },
+  "sources": [{
+    "addresses": ["device-commands"],
+    "authorizationContext": ["ditto:kafka-consumer"],
+    "headerMapping": {
+      "device-id": "{{ header:device-id }}",
+      "ditto-divert-response-to": "aws-iot-mqtt-connection",
+      "ditto-divert-expected-response-types": "response,error"
+    }
+  }]
+}
+```
+
+Next, create the MQTT connection that will handle diverted responses:
+
+```json
+{
+  "id": "aws-iot-mqtt-connection", 
+  "connectionType": "mqtt",
+  "connectionStatus": "open",
+  "uri": "ssl://your-iot-endpoint.amazonaws.com:8883",
+  "sources": [],
+  "targets": [
+      {
+    "address": "device/{{ header:device-id }}/response",
+    "topics": [],
+    "headerMapping": {
+      "device-id": "{{ header:device-id }}",
+      "correlation-id": "{{ header:correlation-id }}"
+    }
+  }
+  ],
+    "specificConfig": {
+        "is-diversion-target": "true"
+    }
+}
+```
+
+### Flow explanation
+
+1. **Command ingestion**: Kafka connection consumes device commands from the `device-commands` topic
+2. **Response diversion**: Commands are configured to divert responses to the `aws-iot-mqtt-connection`
+3. **Response routing**: Responses are automatically published to AWS IoT Core via MQTT on the device-specific response topic
+4. **Device notification**: Devices receive responses via their subscribed MQTT topics in AWS IoT Core
+
+This setup enables a seamless flow from Kafka-based systems back to MQTT-based device communication without requiring external routing logic.
+
+## Try it out
+
+Response diversion is available starting with Eclipse Ditto version 3.8.0. Update your deployment and start experimenting with multi-protocol workflows!
+
+The feature documentation provides comprehensive configuration examples and troubleshooting guidance. We'd love to hear about your use cases and feedback.
+
+Get started with response diversion today and unlock new possibilities for your IoT connectivity architecture.
+
+<br/>
+<br/>
+{% include image.html file="ditto.svg" alt="Ditto" max-width=500 %}
+--<br/>
+The Eclipse Ditto team

--- a/documentation/src/main/resources/pages/ditto/connectivity-header-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-header-mapping.md
@@ -23,3 +23,37 @@ The supported placeholders for header mapping are defined in the
 [Placeholders - Scope: Connections](basic-placeholders.html#scope-connections) section.
 If a placeholder fails to resolve for a header value, then that header is not set. Placeholder resolution failure
 does not prevent sending of the message or setting other headers with resolved values.
+
+## Special header mapping keys
+
+In addition to general header mapping capabilities, Ditto recognizes several special header mapping keys that control connectivity behavior:
+
+### Response diversion headers
+
+These headers control [response diversion](connectivity-response-diversion.html) functionality:
+
+| Header Key | Description | Example Values                                                 |
+|------------|-------------|----------------------------------------------------------------|
+| `ditto-divert-response-to` | Target connection ID for response diversion | `"target-connection-id"`, `"target-connection-id"` |
+| `ditto-divert-expected-response-types` | Response types to divert (comma-separated) | `"response"`, `"error"`, `"nack"`                |
+| `ditto-diverted-response-from` | Source connection of diverted response (automatically set) | `"source-connection-id"`                                       |
+
+Example source configuration with response diversion:
+```json
+{
+  "headerMapping": {
+    "ditto-divert-response-to": "webhook-connection",
+    "ditto-divert-expected-response-types": "response,error",
+    "device-id": "{{ header:device_id }}"
+  }
+}
+```
+
+### Protocol-specific headers
+
+Different protocols support different sets of headers. Some protocols also have special header behavior:
+
+{% include note.html content="Response diversion headers (`ditto-divert-*`)
+are processed by Ditto internally and are not sent as external protocol headers.
+They control internal routing behavior only."
+%}

--- a/documentation/src/main/resources/pages/ditto/connectivity-response-diversion.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-response-diversion.md
@@ -1,0 +1,189 @@
+---
+title: Response diversion
+keywords: response, diversion, redirect, routing, multi-protocol
+tags: [connectivity]
+permalink: connectivity-response-diversion.html
+---
+
+## Response diversion
+
+Response diversion is a powerful feature in Ditto's connectivity service that allows responses from one connection to be diverted (redirected) to another connection instead of being sent to the originally configured reply target. This enables sophisticated multi-protocol workflows.
+
+## Overview
+
+When a connection source receives a command, the response to that command would normally be sent back through the same connection's reply target. With response diversion, you can configure the response to be sent through a different connection entirely.
+
+## Configuration
+
+Response diversion is configured at the connection source level
+using header mapping and in the target connection in the specific config.
+The following special headers control the diversion behavior:
+
+### Header mapping keys
+
+#### ditto-divert-response-to
+Specifies the target connection ID where responses should be diverted.
+
+- **Static configuration**: Set to a specific connection ID (e.g., `"target-connection-123"`)
+- **Dynamic configuration**: Set to `"*"` to enable dynamic diversion where the target connection is determined at runtime through signal headers
+- **Disabled**: Omit this header to disable response diversion for the source
+
+#### ditto-divert-expected-response-types
+Specifies which response types should be diverted. Value should be a comma-separated list of response types.
+
+Supported response types:
+- `response`: Normal command responses
+- `error`: Error responses
+- `nack`: Negative acknowledgements
+
+**Default behavior**: If not specified, all response types (`response,error,nack`) will be diverted.
+
+#### ditto-diverted-response-from
+This header is automatically added by Ditto to track the source connection ID of diverted responses. It should not be manually configured.
+
+### Target connection configuration
+The target connection must be configured to accept diverted responses.
+There are few prerequisites for this:
+1. The targets in the target connection should be in the same order that the sources are defined in the source connection.
+This means that the first target in the target connection will receive responses for commands coming from the first source in the source connection,
+the second target will receive responses for commands from the second source, and so on.
+2. The target connection is registered as diversion target, which is done by setting the "is-diversion-target"
+= "true" property in the specific config.
+3. Leave the topics empty in the target connection. They are not used for diverted responses and removing them will ensure no other events are pushed to the target connection.
+
+## Configuration examples
+
+### Static diversion configuration
+
+Configure the source connection to always divert responses to a specific target connection:
+
+```json
+{
+    "name": "MQTT Source",
+    "connectionType": "mqtt",
+    "connectionStatus": "open",
+    "sources": [
+        {
+            "addresses": [
+                "commands/device1"
+            ],
+            "authorizationContext": [
+                "ditto:inbound-auth-subject"
+            ],
+            "headerMapping": {
+                "ditto-divert-response-to": "http-webhook-connection",
+                "ditto-divert-expected-response-types": "response,error"
+            }
+        }
+    ]
+}
+```
+Configure the target connection to accept diverted responses:
+
+```json
+{
+    "id": "http-webhook-connection",
+    "connectionType": "http-push",
+    "connectionStatus": "open",
+    "uri": "https://webhook.example.com",
+    "sources": [],
+    "targets": [
+        {
+            "address": "POST:/api/v1/device-responses/{{ thing:id }}",
+            "topics": [],
+            "authorizationContext": [
+                "ditto:response-publisher"
+            ]
+        }
+    ],
+    "specificConfig": {
+        "is-diversion-target": "true"
+    }
+}
+```
+
+In this example:
+- Commands received on `commands/device1` will have their responses diverted
+- Responses and errors will be sent to the connection with ID `http-webhook-connection`
+
+### Dynamic diversion configuration
+
+For dynamic diversion where the target connection is determined at runtime by a JavaScript mapper,
+you only need to enable the target connection to accept diverted responses:
+
+```json
+{
+  "addresses": ["commands/+"],
+  "authorizationContext": ["ditto:inbound-auth-subject"],
+  "headerMapping": {},
+  "payloadMapping": ["dynamic-router"],
+  "replyTarget": {
+    "enabled": true,
+    "address": "responses/default"
+  }
+}
+```
+
+With a corresponding JavaScript mapper `dynamic-router`:
+
+```javascript
+function mapToDittoProtocolMsg(headers, textPayload, bytePayload, contentType) {
+  let parsedPayload = JSON.parse(textPayload);
+  
+  // Determine target connection based on device type or other criteria
+  let targetConnection;
+  if (parsedPayload.deviceType === "sensor") {
+    targetConnection = "sensor-analytics-connection";
+  } else if (parsedPayload.deviceType === "actuator") {
+    targetConnection = "actuator-control-connection";
+  } else {
+    targetConnection = "default-processing-connection";
+  }
+  
+  let dittoHeaders = {
+    "correlation-id": headers["correlation-id"],
+    "ditto-divert-response-to": targetConnection,
+    "ditto-divert-expected-response-types": "response,error"
+  };
+  
+  return Ditto.buildDittoProtocolMsg(
+    parsedPayload.namespace,
+    parsedPayload.name,
+    "things",
+    "twin",
+    "commands", 
+    "modify",
+    "/attributes",
+    dittoHeaders,
+    parsedPayload.value
+  );
+}
+```
+
+## Technical behavior
+
+### Circular diversion prevention
+
+Ditto automatically prevents circular diversion chains by:
+- Tracking the source connection in the `ditto-diverted-response-from` header
+- Preventing responses from being diverted back to their originating connection by validating the configuration
+- Logging warnings when circular diversion attempts are detected at runtime
+
+## Monitoring and troubleshooting
+
+### Connection metrics
+Monitor the following metrics to track diversion performance:
+- Response diversion success rate
+- Diversion target distribution
+- Response latency impact
+
+### Common issues
+
+#### Responses not being diverted
+- Verify that `ditto-divert-response-to` is correctly configured in the source header mapping
+- Check that the target connection ID exists and is active
+- Ensure response types match the `ditto-divert-expected-response-types` configuration
+
+#### Target connection not receiving responses
+- Verify the target connection has appropriate target configured
+- Check authorization context permissions


### PR DESCRIPTION
Adds response diversion functionality to route command responses to different connections at runtime. Addresses use cases where responses need to go to systems other than the original sender.