### PR TITLE
fix dynamic WoT validation config to use camel cased setting name

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -11086,7 +11086,7 @@ components:
       properties:
         enabled:
           type: boolean
-        logWarningInsteadOfFailingApiCalls:
+        log-warning-instead-of-failing-api-calls:
           type: boolean
         thing:
           $ref: '#/components/schemas/ThingValidationConfig'

--- a/documentation/src/main/resources/openapi/sources/schemas/wotValidationConfig/configOverrides.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/wotValidationConfig/configOverrides.yml
@@ -14,7 +14,7 @@ description: Config overrides for a dynamic config section.
 properties:
   enabled:
     type: boolean
-  logWarningInsteadOfFailingApiCalls:
+  log-warning-instead-of-failing-api-calls:
     type: boolean
   thing:
     $ref: 'thingValidationConfig.yml'

--- a/documentation/src/main/resources/pages/ditto/basic-wot-validation-config.md
+++ b/documentation/src/main/resources/pages/ditto/basic-wot-validation-config.md
@@ -87,7 +87,7 @@ Content-Type: application/json
   },
   "configOverrides": {
     "enabled": false,
-    "logWarningInsteadOfFailingApiCalls": true
+    "log-warning-instead-of-failing-api-calls": true
   }
 }
 ```

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableConfigOverrides.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableConfigOverrides.java
@@ -42,7 +42,7 @@ final class ImmutableConfigOverrides implements ConfigOverrides {
     private static final JsonFieldDefinition<Boolean> ENABLED_FIELD =
             JsonFactory.newBooleanFieldDefinition("enabled", FieldType.REGULAR, JsonSchemaVersion.V_2);
     private static final JsonFieldDefinition<Boolean> LOG_WARNING_INSTEAD_OF_FAILING_FIELD =
-            JsonFactory.newBooleanFieldDefinition("logWarningInsteadOfFailingApiCalls", FieldType.REGULAR,
+            JsonFactory.newBooleanFieldDefinition("log-warning-instead-of-failing-api-calls", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
     private static final JsonFieldDefinition<JsonObject> THING_FIELD =
             JsonFactory.newJsonObjectFieldDefinition("thing", FieldType.REGULAR, JsonSchemaVersion.V_2);

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfig.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfig.java
@@ -52,7 +52,7 @@ final class ImmutableWotValidationConfig implements WotValidationConfig {
     private static final JsonFieldDefinition<Boolean> ENABLED_FIELD =
             JsonFactory.newBooleanFieldDefinition("enabled", FieldType.REGULAR, JsonSchemaVersion.V_2);
     private static final JsonFieldDefinition<Boolean> LOG_WARNING_FIELD =
-            JsonFactory.newBooleanFieldDefinition("logWarningInsteadOfFailingApiCalls", FieldType.REGULAR,
+            JsonFactory.newBooleanFieldDefinition("log-warning-instead-of-failing-api-calls", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
     private static final JsonFieldDefinition<JsonObject> THING_FIELD =
             JsonFactory.newJsonObjectFieldDefinition("thing", FieldType.REGULAR, JsonSchemaVersion.V_2);

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfigTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfigTest.java
@@ -359,7 +359,7 @@ class ImmutableWotValidationConfigTest {
         JsonObject json = JsonFactory.newObjectBuilder()
                 .set("configId", "test:config")
                 .set("enabled", true)
-                .set("logWarningInsteadOfFailingApiCalls", false)
+                .set("log-warning-instead-of-failing-api-calls", false)
                 .set("thing", thingConfig.toJson())
                 .set("feature", featureConfig.toJson())
                 .set("dynamicConfig", JsonFactory.newArrayBuilder().build())

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveMergedWotValidationConfigStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/RetrieveMergedWotValidationConfigStrategyTest.java
@@ -144,7 +144,7 @@ public final class RetrieveMergedWotValidationConfigStrategyTest {
 
         // Verify merged config values
         assertThat(mergedConfig.getValue("enabled").get().asBoolean()).isTrue();
-        assertThat(mergedConfig.getValue("logWarningInsteadOfFailingApiCalls").get().asBoolean()).isFalse();
+        assertThat(mergedConfig.getValue("log-warning-instead-of-failing-api-calls").get().asBoolean()).isFalse();
 
         // Verify thing validation config
         final JsonObject thingConfig = mergedConfig.getValue("thing").get().asObject();

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/config/DefaultTmValidationConfig.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/config/DefaultTmValidationConfig.java
@@ -179,9 +179,9 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
 
         return dynamicTmValidationConfigurations.stream()
                 .map(internal -> {
-                    var contextConfig = internal.getDynamicValidationContextConfiguration();
+                    final var contextConfig = internal.getDynamicValidationContextConfiguration();
 
-                    var dittoHeadersPatterns = contextConfig.dittoHeadersPatterns().stream()
+                    final var dittoHeadersPatterns = contextConfig.dittoHeadersPatterns().stream()
                             .map(map -> map.entrySet().stream()
                                     .collect(Collectors.toMap(
                                             Map.Entry::getKey,
@@ -189,41 +189,42 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
                                     )))
                             .toList();
 
-                    var thingDefinitionPatterns = contextConfig.thingDefinitionPatterns().stream()
+                    final var thingDefinitionPatterns = contextConfig.thingDefinitionPatterns().stream()
                             .map(Pattern::pattern)
                             .toList();
 
-                    var featureDefinitionPatterns = contextConfig.featureDefinitionPatterns().stream()
+                    final var featureDefinitionPatterns = contextConfig.featureDefinitionPatterns().stream()
                             .map(Pattern::pattern)
                             .toList();
 
-                    var validationContext = org.eclipse.ditto.things.model.devops.ValidationContext.of(
+                    final var validationContext = org.eclipse.ditto.things.model.devops.ValidationContext.of(
                             dittoHeadersPatterns,
                             thingDefinitionPatterns,
                             featureDefinitionPatterns
                     );
 
-                    var configOverridesJson = JsonObject.of(internal.configOverrides().root().render(
+                    final var configOverridesJson = JsonObject.of(internal.configOverrides().root().render(
                             ConfigRenderOptions.defaults().setComments(false).setOriginComments(false)
                     ));
 
-                    Boolean enabled =  configOverridesJson.getValue("enabled").map(JsonValue::asBoolean).orElse(null);
-                    Boolean logWarning = configOverridesJson.getValue("logWarningInsteadOfFailingApiCalls")
+                    final Boolean enabled =  configOverridesJson.getValue(ConfigValue.ENABLED.getConfigPath())
+                            .map(JsonValue::asBoolean).orElse(null);
+                    final Boolean logWarning = configOverridesJson.getValue(ConfigValue.LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS.getConfigPath())
                             .map(JsonValue::asBoolean).orElse(null);
 
-                    org.eclipse.ditto.things.model.devops.ThingValidationConfig thingConfig = configOverridesJson.getValue("thing")
+                    final org.eclipse.ditto.things.model.devops.ThingValidationConfig thingConfig = configOverridesJson.getValue("thing")
                             .filter(JsonValue::isObject)
                             .map(JsonValue::asObject)
                             .map(org.eclipse.ditto.things.model.devops.ThingValidationConfig::fromJson)
                             .orElse(null);
 
-                    org.eclipse.ditto.things.model.devops.FeatureValidationConfig featureConfig = configOverridesJson.getValue("feature")
+                    final org.eclipse.ditto.things.model.devops.FeatureValidationConfig featureConfig = configOverridesJson.getValue("feature")
                             .filter(JsonValue::isObject)
                             .map(JsonValue::asObject)
                             .map(org.eclipse.ditto.things.model.devops.FeatureValidationConfig::fromJson)
                             .orElse(null);
 
-                    var configOverrides = ConfigOverrides.of(
+                    final var configOverrides = ConfigOverrides.of(
                             enabled,
                             logWarning,
                             thingConfig,


### PR DESCRIPTION
 instead of the dashed name static config variant of "log-warning-instead-of-failing-api-calls"