### PR TITLE
Improve WoT validation performance for "MergeThing" commands

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,8 +16,8 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.0-M3  # chart version is effectively set by release-job
-appVersion: 3.8.0-M2
+version: 3.8.0-M5  # chart version is effectively set by release-job
+appVersion: 3.8.0-M4
 keywords:
   - iot-chart
   - digital-twin

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -278,6 +278,14 @@ spec:
               value: "{{ .Values.things.config.wot.tmValidation.enabled }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS
               value: "{{ index .Values.things.config.wot.tmValidation "log-warning-instead-of-failing-api-calls" }}"
+            - name: THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_ENABLED
+              value: "{{ index .Values.things.config.wot.tmValidation "json-schema-cache-enabled" }}"
+            - name: THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_SIZE
+              value: "{{ index .Values.things.config.wot.tmValidation.jsonSchemaCache.maxSize }}"
+            - name: THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_EXPIRE_AFTER_WRITE
+              value: "{{ index .Values.things.config.wot.tmValidation.jsonSchemaCache.expireAfterWrite }}"
+            - name: THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_EXPIRE_AFTER_ACCESS
+              value: "{{ index .Values.things.config.wot.tmValidation.jsonSchemaCache.expireAfterAccess }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_THING_ENFORCE_TD_MODIFICATION
               value: "{{ index .Values.things.config.wot.tmValidation.thing.enforce "thing-description-modification" }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_THING_ENFORCE_ATTRIBUTES

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1174,6 +1174,16 @@ things:
         enabled: true
         # log-warning-instead-of-failing-api-calls whether to instead of to reject/fail API calls (when enabled=true), log a WARNING log instead
         log-warning-instead-of-failing-api-calls: false
+        # json-schema-cache-enabled whether to enable caching of JSON schemas created from WoT ThingModels
+        json-schema-cache-enabled: true
+        # jsonSchemaCache configuration of the JSON schema cache
+        jsonSchemaCache:
+          # maxSize the maximum size of JSON schemas to keep in the cache
+          maxSize: 10000
+          # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
+          expireAfterWrite: 12h
+          # expireAfterAccess prolonged on each cache access by that duration
+          expireAfterAccess: 2h
         # thing provides configuration settings for WoT based validation of Things
         thing:
           # enforce holds all configuration relating to enforcing the model

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1151,6 +1151,8 @@ things:
       cache:
         # modelCacheSize configures the amount of TMs to hold in the cache
         modelCacheSize: 1000
+        # expireAfterWrite configures how long a single TM should remain cached after first writing it to the cache
+        expireAfterWrite: 2d
         # expireAfterAccess configures how long a single TM should remain cached after its last access
         expireAfterAccess: 1d
       # tdJsonTemplate contains a json template added to generated TDs, e.g. containing security information:

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeThingStrategy.java
@@ -79,10 +79,11 @@ final class MergeThingStrategy extends AbstractThingModifyCommandStrategy<MergeT
             @Nullable final Thing previousThing,
             @Nullable final Thing previewThing
     ) {
-        return wotThingModelValidator.validateThing(
+        return wotThingModelValidator.validateMergeThing(
                 Optional.ofNullable(previewThing).flatMap(Thing::getDefinition)
                         .or(() -> Optional.ofNullable(previousThing).flatMap(Thing::getDefinition))
                         .orElse(null),
+                command,
                 Optional.ofNullable(previewThing).orElseThrow(),
                 command.getResourcePath(),
                 command.getDittoHeaders()

--- a/things/service/src/main/resources/things-dev.conf
+++ b/things/service/src/main/resources/things-dev.conf
@@ -3,6 +3,19 @@ ditto {
     grant = [
       {
         resource-types = ["thing"]
+        namespaces = [
+          "*"  # allow creation of things in any namespace
+        ]
+        auth-subjects = [
+          "*"  # allow any authenticated subject
+        ]
+        thing-definitions = [
+          null,
+          "*" # allow any definition
+        ]
+      },
+      {
+        resource-types = ["thing"]
         namespaces = ["some.dimmable.lamp.namespace"]
         auth-subjects = ["pre:ditto"]
         thing-definitions = [ # don't allow null here - so a definition is required when creating a thing in this namespace

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -297,6 +297,9 @@ ditto {
         maximum-size = 1000
         maximum-size = ${?THINGS_WOT_THING_MODEL_CACHE_SIZE}
 
+        expire-after-write = 2d
+        expire-after-write = ${?THINGS_WOT_THING_MODEL_CACHE_EXPIRE_AFTER_WRITE}
+
         # prolonged on each cache access by that duration
         expire-after-access = 1d
         expire-after-access = ${?THINGS_WOT_THING_MODEL_CACHE_EXPIRE_AFTER_ACCESS}

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -385,6 +385,24 @@ ditto {
         log-warning-instead-of-failing-api-calls = false
         log-warning-instead-of-failing-api-calls = ${?THINGS_WOT_TM_MODEL_VALIDATION_LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS}
 
+        # whether to enable a cache for JsonSchemas derived from WoT ThingModel properties dynamically
+        json-schema-cache-enabled = true
+        json-schema-cache-enabled = ${?THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_ENABLED}
+
+        # configures a cache for JsonSchemas derived from WoT ThingModel properties dynamically
+        json-schema-cache {
+          # how many JSON Schemas to cache
+          maximum-size = 10000
+          maximum-size = ${?THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_SIZE}
+
+          expire-after-write = 12h
+          expire-after-write = ${?THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_EXPIRE_AFTER_WRITE}
+
+          # prolonged on each cache access by that duration
+          expire-after-access = 2h
+          expire-after-access = ${?THINGS_WOT_TM_MODEL_VALIDATION_JSON_SCHEMA_CACHE_EXPIRE_AFTER_ACCESS}
+        }
+
         thing {
           enforce {
             # whether to enforce a thing whenever the "definition" of the thing is updated to a new/other WoT TM

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/config/DefaultTmValidationConfig.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/config/DefaultTmValidationConfig.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
+import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
@@ -47,6 +49,7 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
     private static final String CONFIG_PATH = "tm-model-validation";
 
     private static final String CONFIG_KEY_DYNAMIC_CONFIGURATION = "dynamic-configuration";
+    private static final String JSON_SCHEMA_CACHE = "json-schema-cache";
 
     private final ScopedConfig scopedConfig;
     private final List<InternalDynamicTmValidationConfiguration> dynamicTmValidationConfigurations;
@@ -55,6 +58,8 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
     private final boolean logWarningInsteadOfFailingApiCalls;
     private final ThingValidationConfig thingValidationConfig;
     private final FeatureValidationConfig featureValidationConfig;
+    private final boolean jsonSchemaCacheEnabled;
+    private final CacheConfig jsonSchemaCacheConfig;
 
 
     private DefaultTmValidationConfig(final ScopedConfig scopedConfig,
@@ -73,6 +78,8 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
 
         thingValidationConfig = DefaultThingValidationConfig.of(effectiveConfig);
         featureValidationConfig = DefaultFeatureValidationConfig.of(effectiveConfig);
+        jsonSchemaCacheEnabled = effectiveConfig.getBoolean(ConfigValue.JSON_SCHEMA_CACHE_ENABLED.getConfigPath());
+        jsonSchemaCacheConfig = DefaultCacheConfig.of(effectiveConfig, JSON_SCHEMA_CACHE);
     }
 
     /**
@@ -115,55 +122,14 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
         return featureValidationConfig;
     }
 
-    /**
-     * Creates a new instance of this configuration with the specified validation context.
-     * If dynamic configurations are present, they will be evaluated against the provided context.
-     *
-     * @param context the validation context to use for dynamic configuration selection
-     * @return a new TmValidationConfig instance with context-specific settings applied
-     */
     @Override
-    public TmValidationConfig withValidationContext(@Nullable final ValidationContext context) {
-        if (dynamicTmValidationConfigurations.isEmpty()) {
-            return this;
-        } else {
-            return new DefaultTmValidationConfig(scopedConfig, dynamicTmValidationConfigurations, context);
-        }
+    public boolean isJsonSchemaCacheEnabled() {
+        return jsonSchemaCacheEnabled;
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final DefaultTmValidationConfig that = (DefaultTmValidationConfig) o;
-        return Objects.equals(dynamicTmValidationConfigurations, that.dynamicTmValidationConfigurations) &&
-                enabled == that.enabled &&
-                logWarningInsteadOfFailingApiCalls == that.logWarningInsteadOfFailingApiCalls &&
-                Objects.equals(thingValidationConfig, that.thingValidationConfig) &&
-                Objects.equals(featureValidationConfig, that.featureValidationConfig) &&
-                Objects.equals(scopedConfig, that.scopedConfig);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(dynamicTmValidationConfigurations, enabled, logWarningInsteadOfFailingApiCalls,
-                thingValidationConfig, featureValidationConfig, scopedConfig);
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + " [" +
-                "dynamicTmValidationConfiguration=" + dynamicTmValidationConfigurations +
-                ", enabled=" + enabled +
-                ", logWarningInsteadOfFailingApiCalls=" + logWarningInsteadOfFailingApiCalls +
-                ", thingValidationConfig=" + thingValidationConfig +
-                ", featureValidationConfig=" + featureValidationConfig +
-                ", scopedConfig=" + scopedConfig +
-                "]";
+    public CacheConfig getJsonSchemaCacheConfig() {
+        return jsonSchemaCacheConfig;
     }
 
     /**
@@ -239,4 +205,61 @@ public final class DefaultTmValidationConfig implements TmValidationConfig {
                 })
                 .toList();
     }
+
+    /**
+     * Creates a new instance of this configuration with the specified validation context.
+     * If dynamic configurations are present, they will be evaluated against the provided context.
+     *
+     * @param context the validation context to use for dynamic configuration selection
+     * @return a new TmValidationConfig instance with context-specific settings applied
+     */
+    @Override
+    public TmValidationConfig withValidationContext(@Nullable final ValidationContext context) {
+        if (dynamicTmValidationConfigurations.isEmpty()) {
+            return this;
+        } else {
+            return new DefaultTmValidationConfig(scopedConfig, dynamicTmValidationConfigurations, context);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultTmValidationConfig that = (DefaultTmValidationConfig) o;
+        return Objects.equals(dynamicTmValidationConfigurations, that.dynamicTmValidationConfigurations) &&
+                enabled == that.enabled &&
+                logWarningInsteadOfFailingApiCalls == that.logWarningInsteadOfFailingApiCalls &&
+                Objects.equals(thingValidationConfig, that.thingValidationConfig) &&
+                Objects.equals(featureValidationConfig, that.featureValidationConfig) &&
+                Objects.equals(scopedConfig, that.scopedConfig) &&
+                Objects.equals(jsonSchemaCacheEnabled, that.jsonSchemaCacheEnabled) &&
+                Objects.equals(jsonSchemaCacheConfig, that.jsonSchemaCacheConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dynamicTmValidationConfigurations, enabled, logWarningInsteadOfFailingApiCalls,
+                thingValidationConfig, featureValidationConfig, scopedConfig, jsonSchemaCacheEnabled,
+                jsonSchemaCacheConfig);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "dynamicTmValidationConfiguration=" + dynamicTmValidationConfigurations +
+                ", enabled=" + enabled +
+                ", logWarningInsteadOfFailingApiCalls=" + logWarningInsteadOfFailingApiCalls +
+                ", thingValidationConfig=" + thingValidationConfig +
+                ", featureValidationConfig=" + featureValidationConfig +
+                ", scopedConfig=" + scopedConfig +
+                ", jsonSchemaCacheEnabled=" + jsonSchemaCacheEnabled +
+                ", jsonSchemaCacheConfig=" + jsonSchemaCacheConfig +
+                "]";
+    }
+
 }

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
@@ -15,13 +15,16 @@ package org.eclipse.ditto.wot.api.validator;
 import static org.eclipse.ditto.wot.validation.ValidationContext.buildValidationContext;
 
 import java.net.URL;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -33,6 +36,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.FeatureToggle;
+import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.things.model.Attributes;
@@ -43,6 +47,7 @@ import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingDefinition;
+import org.eclipse.ditto.things.model.signals.commands.modify.MergeThing;
 import org.eclipse.ditto.wot.api.resolver.ThingSubmodel;
 import org.eclipse.ditto.wot.api.resolver.WotThingModelResolver;
 import org.eclipse.ditto.wot.model.ThingModel;
@@ -63,7 +68,7 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
 
     private static final Logger log = LoggerFactory.getLogger(DefaultWotThingModelValidator.class);
     private static final AtomicReference<DefaultWotThingModelValidator> INSTANCE = new AtomicReference<>();
-    
+
     private final WotThingModelResolver thingModelResolver;
     private final Executor executor;
 
@@ -80,7 +85,7 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
 
     /**
      * Gets the singleton instance of the validator, creating it if it doesn't exist.
-     * 
+     *
      * @param thingModelResolver the ThingModel resolver to use
      * @param executor the executor to use
      * @param initialConfig the initial validation config
@@ -174,6 +179,46 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
     }
 
     @Override
+    public CompletionStage<Void> validateMergeThing(@Nullable final ThingDefinition thingDefinition,
+            final MergeThing mergeThing,
+            final Thing thing,
+            final JsonPointer resourcePath,
+            final DittoHeaders dittoHeaders
+    ) {
+        final ValidationContext context = buildValidationContext(dittoHeaders, thingDefinition);
+        return provideValidationConfigIfWotValidationEnabled(context)
+                .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
+                        doValidateMergeThing(Optional.ofNullable(thingDefinition).orElseThrow(),
+                                thingModel, mergeThing, thing, context, validationConfig
+                        ).handleAsync(
+                                applyLogingErrorOnlyStrategy(validationConfig, context, "validateMergeThing"),
+                                executor
+                        )
+                ))
+                .orElseGet(DefaultWotThingModelValidator::success);
+    }
+
+    @Override
+    public CompletionStage<Void> validateMergeThing(final ThingDefinition thingDefinition,
+            final ThingModel thingModel,
+            final MergeThing mergeThing,
+            final Thing thing,
+            final JsonPointer resourcePath,
+            final DittoHeaders dittoHeaders
+    ) {
+        final ValidationContext context = buildValidationContext(dittoHeaders, thingDefinition);
+        return provideValidationConfigIfWotValidationEnabled(context)
+                .map(validationConfig ->
+                        doValidateMergeThing(thingDefinition, thingModel, mergeThing, thing, context, validationConfig)
+                                .handleAsync(
+                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateMergeThing"),
+                                        executor
+                                )
+                )
+                .orElseGet(DefaultWotThingModelValidator::success);
+    }
+
+    @Override
     public CompletionStage<Void> validateThingDefinitionModification(final ThingDefinition thingDefinition,
             final Thing thing,
             final DittoHeaders dittoHeaders
@@ -186,7 +231,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         doValidateThing(thingDefinition, thingModel, thing, context, validationConfig)
                                 .handleAsync(
-                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingDefinitionModification"),
+                                        applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                "validateThingDefinitionModification"),
                                         executor
                                 )
                 ))
@@ -204,7 +250,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 )
                 .filter(validationConfig -> Optional.ofNullable(context.featureDefinition())
                         .map(FeatureDefinition::getFirstIdentifier)
-                        .filter(definitionIdentifier -> definitionIdentifier.getUrl().isPresent()) // only for URLs in the definition
+                        .filter(definitionIdentifier -> definitionIdentifier.getUrl()
+                                .isPresent()) // only for URLs in the definition
                         .isPresent()
                 )
                 .map(validationConfig ->
@@ -229,7 +276,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         doValidateThingAttributes(thingModel, attributes, resourcePath, context, validationConfig)
                                 .handleAsync(
-                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingAttributes"),
+                                        applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                "validateThingAttributes"),
                                         executor
                                 )
                 ))
@@ -248,7 +296,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig ->
                         doValidateThingAttributes(thingModel, attributes, resourcePath, context, validationConfig)
                                 .handleAsync(
-                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingAttributes"),
+                                        applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                "validateThingAttributes"),
                                         executor
                                 )
                 )
@@ -286,15 +335,16 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         thingModelResolver.resolveThingModelSubmodels(thingModel, context.dittoHeaders())
                                 .thenComposeAsync(subModels ->
-                                        selectValidation(validationConfig)
-                                                .validateThingScopedDeletion(thingModel,
-                                                        reduceSubmodelMapKeyToFeatureId(subModels),
-                                                        resourcePath,
-                                                        context
-                                                ).handleAsync(
-                                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingScopedDeletion"),
-                                                        executor
-                                                ),
+                                                selectValidation(validationConfig)
+                                                        .validateThingScopedDeletion(thingModel,
+                                                                reduceSubmodelMapKeyToFeatureId(subModels),
+                                                                resourcePath,
+                                                                context
+                                                        ).handleAsync(
+                                                                applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                                        "validateThingScopedDeletion"),
+                                                                executor
+                                                        ),
                                         executor
                                 )
 
@@ -314,17 +364,17 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                                 CompletableFuture.supplyAsync(inputPayloadSupplier, executor)
                                         .thenComposeAsync(inputPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateThingActionInput(thingModel,
-                                                                messageSubject, inputPayload, resourcePath, context
-                                                        ),
+                                                        selectValidation(validationConfig)
+                                                                .validateThingActionInput(thingModel,
+                                                                        messageSubject, inputPayload, resourcePath, context
+                                                                ),
                                                 executor
+                                        )
+                        )
+                                .handleAsync(
+                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingActionInput"),
+                                        executor
                                 )
-                        )
-                        .handleAsync(
-                                applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingActionInput"),
-                                executor
-                        )
                 )
                 .orElseGet(DefaultWotThingModelValidator::success);
     }
@@ -341,12 +391,12 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                                 CompletableFuture.supplyAsync(outputPayloadSupplier, executor)
                                         .thenComposeAsync(outputPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateThingActionOutput(thingModel,
-                                                                messageSubject, outputPayload, resourcePath, context
-                                                        ),
+                                                        selectValidation(validationConfig)
+                                                                .validateThingActionOutput(thingModel,
+                                                                        messageSubject, outputPayload, resourcePath, context
+                                                                ),
                                                 executor
-                                )
+                                        )
                         ).handleAsync(
                                 applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingActionOutput"),
                                 executor
@@ -367,12 +417,12 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                                 CompletableFuture.supplyAsync(dataPayloadSupplier, executor)
                                         .thenComposeAsync(dataPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateThingEventData(thingModel,
-                                                                messageSubject, dataPayload, resourcePath, context
-                                                        ),
+                                                        selectValidation(validationConfig)
+                                                                .validateThingEventData(thingModel,
+                                                                        messageSubject, dataPayload, resourcePath, context
+                                                                ),
                                                 executor
-                                )
+                                        )
                         ).handleAsync(
                                 applyLogingErrorOnlyStrategy(validationConfig, context, "validateThingEventData"),
                                 executor
@@ -490,7 +540,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                                 selectValidation(validationConfig)
                                         .validateFeature(featureThingModel, feature, resourcePath, context)
                                         .handleAsync(
-                                                applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureDefinitionModification"),
+                                                applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                        "validateFeatureDefinitionModification"),
                                                 executor
                                         )
                 ))
@@ -527,7 +578,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                                         featureThingModelWithExtensionsAndImports, featureId, featureProperties,
                                         desiredProperties, resourcePath, dittoHeaders
                                 ).handleAsync(
-                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureProperties"),
+                                        applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                "validateFeatureProperties"),
                                         executor
                                 )
                 ))
@@ -578,7 +630,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                                                 featureId, propertyPointer, propertyValue, desiredProperty,
                                                 resourcePath, context
                                         ).handleAsync(
-                                                applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureProperty"),
+                                                applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                        "validateFeatureProperty"),
                                                 executor
                                         )
                 ))
@@ -597,21 +650,22 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(thingDefinition, dittoHeaders, thingModel ->
                         thingModelResolver.resolveThingModelSubmodels(thingModel, context.dittoHeaders())
                                 .thenComposeAsync(subModels ->
-                                        fetchResolveAndValidateWith(
-                                                Optional.ofNullable(featureDefinition)
-                                                        .map(FeatureDefinition::getFirstIdentifier).orElse(null),
-                                                dittoHeaders,
-                                                featureThingModel ->
-                                                        selectValidation(validationConfig)
-                                                                .validateFeatureScopedDeletion(
-                                                                        reduceSubmodelMapKeyToFeatureId(subModels),
-                                                                        featureThingModel, featureId, resourcePath,
-                                                                        context
-                                                                ).handleAsync(
-                                                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureScopedDeletion"),
-                                                                        executor
-                                                                )
-                                        ),
+                                                fetchResolveAndValidateWith(
+                                                        Optional.ofNullable(featureDefinition)
+                                                                .map(FeatureDefinition::getFirstIdentifier).orElse(null),
+                                                        dittoHeaders,
+                                                        featureThingModel ->
+                                                                selectValidation(validationConfig)
+                                                                        .validateFeatureScopedDeletion(
+                                                                                reduceSubmodelMapKeyToFeatureId(subModels),
+                                                                                featureThingModel, featureId, resourcePath,
+                                                                                context
+                                                                        ).handleAsync(
+                                                                                applyLogingErrorOnlyStrategy(validationConfig, context,
+                                                                                        "validateFeatureScopedDeletion"),
+                                                                                executor
+                                                                        )
+                                                ),
                                         executor
                                 )
                 ))
@@ -632,14 +686,15 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(
                                 Optional.ofNullable(featureDefinition).map(FeatureDefinition::getFirstIdentifier).orElse(null),
                                 dittoHeaders, featureThingModel ->
-                                CompletableFuture.supplyAsync(inputPayloadSupplier, executor)
-                                        .thenComposeAsync(inputPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateFeatureActionInput(featureThingModel,
-                                                                featureId, messageSubject, inputPayload, resourcePath, context
-                                                        ),
-                                                executor
-                                        )
+                                        CompletableFuture.supplyAsync(inputPayloadSupplier, executor)
+                                                .thenComposeAsync(inputPayload ->
+                                                                selectValidation(validationConfig)
+                                                                        .validateFeatureActionInput(featureThingModel,
+                                                                                featureId, messageSubject, inputPayload, resourcePath,
+                                                                                context
+                                                                        ),
+                                                        executor
+                                                )
                         ).handleAsync(
                                 applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureActionInput"),
                                 executor
@@ -662,14 +717,14 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(
                                 Optional.ofNullable(featureDefinition).map(FeatureDefinition::getFirstIdentifier).orElse(null),
                                 dittoHeaders, featureThingModel ->
-                                CompletableFuture.supplyAsync(outputPayloadSupplier, executor)
-                                        .thenComposeAsync(outputPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateFeatureActionOutput(featureThingModel, featureId,
-                                                                messageSubject, outputPayload, resourcePath, context
-                                                        ),
-                                                executor
-                                )
+                                        CompletableFuture.supplyAsync(outputPayloadSupplier, executor)
+                                                .thenComposeAsync(outputPayload ->
+                                                                selectValidation(validationConfig)
+                                                                        .validateFeatureActionOutput(featureThingModel, featureId,
+                                                                                messageSubject, outputPayload, resourcePath, context
+                                                                        ),
+                                                        executor
+                                                )
                         ).handleAsync(
                                 applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureActionOutput"),
                                 executor
@@ -692,19 +747,19 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .map(validationConfig -> fetchResolveAndValidateWith(
                                 Optional.ofNullable(featureDefinition).map(FeatureDefinition::getFirstIdentifier).orElse(null),
                                 dittoHeaders, featureThingModel ->
-                                CompletableFuture.supplyAsync(dataPayloadSupplier, executor)
-                                        .thenComposeAsync(dataPayload ->
-                                                selectValidation(validationConfig)
-                                                        .validateFeatureEventData(featureThingModel, featureId,
-                                                                messageSubject, dataPayload, resourcePath, context
-                                                        ),
-                                                executor
+                                        CompletableFuture.supplyAsync(dataPayloadSupplier, executor)
+                                                .thenComposeAsync(dataPayload ->
+                                                                selectValidation(validationConfig)
+                                                                        .validateFeatureEventData(featureThingModel, featureId,
+                                                                                messageSubject, dataPayload, resourcePath, context
+                                                                        ),
+                                                        executor
+                                                )
+                        )
+                                .handleAsync(
+                                        applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureEventData"),
+                                        executor
                                 )
-                        )
-                        .handleAsync(
-                                applyLogingErrorOnlyStrategy(validationConfig, context, "validateFeatureEventData"),
-                                executor
-                        )
                 )
                 .orElseGet(DefaultWotThingModelValidator::success);
     }
@@ -830,6 +885,117 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
         );
     }
 
+    private CompletionStage<Void> doValidateMergeThing(final ThingDefinition thingDefinition,
+            final ThingModel thingModel,
+            final MergeThing mergeThing,
+            final Thing thing,
+            final ValidationContext context,
+            final TmValidationConfig validationConfig
+    ) {
+        final JsonValue mergeValue = mergeThing.getEntity().orElseGet(mergeThing::getValue);
+        final Set<JsonPointer> affectedLeaves = calculateLeaves(mergeThing.getResourcePath(), mergeValue);
+
+        final boolean containsDefinition = affectedLeaves.contains(Thing.JsonFields.DEFINITION.getPointer());
+        if (containsDefinition &&
+                !mergeValue.asObject().getValue(Thing.JsonFields.DEFINITION)
+                        .equals(thing.getDefinition().map(ThingDefinition::toJson))
+        ) {
+            // if the definition is affected and is different then before, we need to validate the whole thing
+            return doValidateThing(thingDefinition, thingModel, thing, context, validationConfig);
+        } else {
+            final MergeThingContext mergeThingContext = calculateMergeThingContext(affectedLeaves);
+
+            final CompletionStage<Void> firstStage;
+            if (validationConfig.getThingValidationConfig().isForbidThingDescriptionDeletion() &&
+                    thing.getDefinition().isEmpty()) {
+                firstStage = validateThingDefinitionDeletion(thingDefinition, context.dittoHeaders());
+            } else {
+                firstStage = success();
+            }
+            return firstStage.thenComposeAsync(unused ->
+                            mergeThingContext.containsAttributes().get() ? doValidateThingAttributes(thingModel,
+                                    thing.getAttributes().orElse(null),
+                                    Thing.JsonFields.ATTRIBUTES.getPointer(),
+                                    context,
+                                    validationConfig
+                            ) : CompletableFuture.completedStage(null),
+                    executor
+            ).thenComposeAsync(aVoid ->
+                            mergeThingContext.containsFeatures().get() ?
+                                    thingModelResolver.resolveThingModelSubmodels(thingModel, context.dittoHeaders())
+                                            .thenComposeAsync(subModels ->
+                                                            doValidateMergeThingAffectedFeatures(thing, context,
+                                                                    validationConfig,
+                                                                    subModels,
+                                                                    mergeThingContext.affectedFeatures()
+                                                            ),
+                                                    executor
+                                            ) : CompletableFuture.completedStage(null),
+                    executor
+            );
+        }
+    }
+
+    private MergeThingContext calculateMergeThingContext(final Set<JsonPointer> affectedLeaves) {
+        final Set<String> affectedFeatures = new HashSet<>();
+        final AtomicBoolean containsAttributes = new AtomicBoolean(false);
+        final AtomicBoolean containsFeatures = new AtomicBoolean(false);
+
+        affectedLeaves.forEach(leave -> {
+            if (!containsAttributes.get() &&
+                    Thing.JsonFields.ATTRIBUTES.getPointer().equals(leave.getPrefixPointer(1).orElse(null))
+            ){
+                containsAttributes.set(true);
+            }
+            if (!containsFeatures.get() &&
+                    Thing.JsonFields.FEATURES.getPointer().equals(leave.getPrefixPointer(1).orElse(null))
+            ) {
+                containsFeatures.set(true);
+            }
+
+            if (containsFeatures.get()) {
+                leave.getPrefixPointer(2)
+                        .flatMap(p -> p.getSubPointer(1))
+                        .flatMap(JsonPointer::getRoot)
+                        .map(JsonKey::toString)
+                        .ifPresent(affectedFeatures::add);
+            }
+        });
+        return new MergeThingContext(affectedFeatures, containsAttributes, containsFeatures);
+    }
+
+    private record MergeThingContext(Set<String> affectedFeatures, AtomicBoolean containsAttributes, AtomicBoolean containsFeatures) {}
+
+    private CompletionStage<Void> doValidateMergeThingAffectedFeatures(final Thing thing,
+            final ValidationContext context,
+            final TmValidationConfig validationConfig,
+            final Map<ThingSubmodel, ThingModel> subModels,
+            final Set<String> affectedFeatures
+    ) {
+        final Map<ThingSubmodel, ThingModel> filteredSubModels = subModels.entrySet()
+                .stream()
+                .filter(subModel ->
+                        affectedFeatures.contains(subModel.getKey().instanceName())
+                )
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        final Features filteredFeatures = thing.getFeatures()
+                .map(features -> Features.newBuilder()
+                        .setAll(features.stream()
+                                .filter(feature ->
+                                        affectedFeatures.contains(feature.getId()))
+                                .toList()
+                        )
+                        .build()
+                )
+                .orElse(null);
+        return doValidateFeatures(filteredSubModels,
+                filteredFeatures,
+                JsonPointer.empty(),
+                context,
+                validationConfig
+        );
+    }
+
     private CompletionStage<Void> doValidateThingAttributes(final ThingModel thingModel,
             @Nullable final Attributes attributes,
             final JsonPointer resourcePath,
@@ -885,8 +1051,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                         ),
                         executor
                 ).thenComposeAsync(aVoid ->
-                        selectValidation(validationConfig)
-                                .validateFeaturesProperties(featureThingModels, features, resourcePath, context),
+                                selectValidation(validationConfig)
+                                        .validateFeaturesProperties(featureThingModels, features, resourcePath, context),
                         executor
                 );
     }
@@ -977,7 +1143,8 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 )
                 .filter(validationConfig -> Optional.ofNullable(context.featureDefinition())
                         .map(FeatureDefinition::getFirstIdentifier)
-                        .filter(definitionIdentifier -> definitionIdentifier.getUrl().isPresent()) // only for URLs in the definition
+                        .filter(definitionIdentifier -> definitionIdentifier.getUrl()
+                                .isPresent()) // only for URLs in the definition
                         .isPresent()
                 )
                 .map(validationConfig ->
@@ -1003,5 +1170,45 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                         LinkedHashMap::new
                 )
         );
+    }
+
+    private static double getDuration(final long startTimeStamp) {
+        final int nanosecondsToMillisecondsFactor = 1_000_000;
+        return (double) (System.nanoTime() - startTimeStamp) / nanosecondsToMillisecondsFactor;
+    }
+
+    private static Set<JsonPointer> calculateLeaves(final JsonPointer path, final JsonValue value) {
+        if (value.isObject()) {
+            return value.asObject().stream()
+                    .map(f -> {
+                        final JsonKey key = f.getKey();
+                        if (isMergeWithNulledKeysByRegex(key, f.getValue())) {
+                            // if regex is contained, this path is a leaf
+                            return Set.of(path);
+                        } else {
+                            return calculateLeaves(path.append(key.asPointer()), f.getValue());
+                        }
+                    })
+                    .reduce(new HashSet<>(), DefaultWotThingModelValidator::addAll,
+                            DefaultWotThingModelValidator::addAll);
+        } else {
+            return Set.of(path);
+        }
+    }
+
+    private static Set<JsonPointer> addAll(final Set<JsonPointer> result, final Set<JsonPointer> toBeAdded) {
+        result.addAll(toBeAdded);
+        return result;
+    }
+
+    private static boolean isMergeWithNulledKeysByRegex(final JsonKey key, final JsonValue value) {
+        final String keyString = key.toString();
+        if (keyString.startsWith("{{") && keyString.endsWith("}}")) {
+            final String keyRegexWithoutCurly = keyString.substring(2, keyString.length() - 2).trim();
+            return keyRegexWithoutCurly.startsWith("/") && keyRegexWithoutCurly.endsWith("/") &&
+                    value.isNull();
+        } else {
+            return false;
+        }
     }
 }

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/WotThingModelValidator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/WotThingModelValidator.java
@@ -28,6 +28,7 @@ import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingDefinition;
+import org.eclipse.ditto.things.model.signals.commands.modify.MergeThing;
 import org.eclipse.ditto.wot.api.config.WotConfig;
 import org.eclipse.ditto.wot.api.resolver.WotThingModelResolver;
 import org.eclipse.ditto.wot.model.ThingModel;
@@ -92,6 +93,52 @@ public interface WotThingModelValidator {
      */
     CompletionStage<Void> validateThing(ThingDefinition thingDefinition,
             ThingModel thingModel,
+            Thing thing,
+            JsonPointer resourcePath,
+            DittoHeaders dittoHeaders
+    );
+
+    /**
+     * Validates the provided {@code thing} against the provided {@code thingDefinition} (if this links to a WoT TM)
+     * specifically for a {@code MergeThing} command.
+     * This is a separate implementation as only parts of the things might be patched which gives room to optimize which
+     * parts to validate.
+     *
+     * @param thingDefinition the ThingDefinition to retrieve the WoT TM from
+     * @param mergeThing the MergeThing command to validate
+     * @param thing the Thing to validate
+     * @param resourcePath the originating path of the command which caused validation
+     * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
+     * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
+     * validation error - exceptionally finished with a {@link org.eclipse.ditto.wot.validation.WotThingModelPayloadValidationException}
+     * @since 3.8.0
+     */
+    CompletionStage<Void> validateMergeThing(@Nullable ThingDefinition thingDefinition,
+            MergeThing mergeThing,
+            Thing thing,
+            JsonPointer resourcePath,
+            DittoHeaders dittoHeaders
+    );
+
+    /**
+     * Validates the provided {@code thing} against the provided {@code thingModel} specifically for a
+     * {@code MergeThing} command.
+     * This is a separate implementation as only parts of the things might be patched which gives room to optimize which
+     * parts to validate.
+     *
+     * @param thingDefinition the ThingDefinition which was used to retrieve the passed {@code thingModel}
+     * @param thingModel the ThingModel to validate against
+     * @param mergeThing the MergeThing command to validate
+     * @param thing the Thing to validate
+     * @param resourcePath the originating path of the command which caused validation
+     * @param dittoHeaders the DittoHeaders to use in order to build a potential exception
+     * @return a CompletionStage finished successfully with {@code null} or finished exceptionally in case of a
+     * validation error - exceptionally finished with a {@link org.eclipse.ditto.wot.validation.WotThingModelPayloadValidationException}
+     * @since 3.8.0
+     */
+    CompletionStage<Void> validateMergeThing(ThingDefinition thingDefinition,
+            ThingModel thingModel,
+            MergeThing mergeThing,
             Thing thing,
             JsonPointer resourcePath,
             DittoHeaders dittoHeaders

--- a/wot/validation/pom.xml
+++ b/wot/validation/pom.xml
@@ -49,6 +49,10 @@
 
         <dependency>
             <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-internal-utils-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-internal-utils-config</artifactId>
         </dependency>
         <dependency>

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/JsonSchemaCacheKey.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/JsonSchemaCacheKey.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.validation;
+
+import org.eclipse.ditto.wot.model.SingleDataSchema;
+
+/**
+ * Provides a cache key for caching {@link SingleDataSchema} to JsonSchema instances.
+ * @param dataSchema
+ * @param validateRequiredObjectFields
+ * @since 3.8.0
+ */
+public record JsonSchemaCacheKey(SingleDataSchema dataSchema, boolean validateRequiredObjectFields) {}

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/WotThingModelValidation.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/WotThingModelValidation.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Executor;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.things.model.Attributes;
@@ -27,6 +28,8 @@ import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.wot.model.ThingModel;
 import org.eclipse.ditto.wot.validation.config.TmValidationConfig;
+
+import com.networknt.schema.JsonSchema;
 
 /**
  * Provides functionality to validate specific parts of a Ditto {@link Thing} and/or Ditto Thing {@link Features} and
@@ -337,6 +340,20 @@ public interface WotThingModelValidation {
      * @return the created WotThingModelValidation.
      */
     static WotThingModelValidation of(final TmValidationConfig validationConfig, final Executor executor) {
-        return new DefaultWotThingModelValidation(validationConfig, executor);
+        return new DefaultWotThingModelValidation(validationConfig, executor, null);
+    }
+
+    /**
+     * Creates a new instance of WotThingModelValidation with the given {@code validationConfig}.
+     *
+     * @param validationConfig the WoT TM validation config to use.
+     * @param executor the executor to use for async operations.
+     * @param jsonSchemaCache the JsonSchema cache to use for accessing generated JsonSchemas more efficiently.
+     * @return the created WotThingModelValidation.
+     * @since 3.8.0
+     */
+    static WotThingModelValidation of(final TmValidationConfig validationConfig, final Executor executor,
+            @Nullable final Cache<JsonSchemaCacheKey, JsonSchema> jsonSchemaCache) {
+        return new DefaultWotThingModelValidation(validationConfig, executor, jsonSchemaCache);
     }
 }

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/config/TmValidationConfig.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/config/TmValidationConfig.java
@@ -17,6 +17,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 import org.eclipse.ditto.things.model.devops.DynamicValidationConfig;
 import org.eclipse.ditto.wot.validation.ValidationContext;
@@ -65,6 +66,18 @@ public interface TmValidationConfig {
      */
     List<DynamicValidationConfig> getDynamicConfigs();
 
+    /**
+     * @return whether the generated JsonSchemas based on the WoT model properties should be cached.
+     * @since 3.8.0
+     */
+    boolean isJsonSchemaCacheEnabled();
+
+    /**
+     * @return the cache configuration for when {@link #isJsonSchemaCacheEnabled()} is enabled.
+     * @since 3.8.0
+     */
+    CacheConfig getJsonSchemaCacheConfig();
+
 
     /**
      * An enumeration of the known config path expressions and their associated default values for
@@ -80,7 +93,13 @@ public interface TmValidationConfig {
         /**
          * Whether to instead of to reject/fail API calls (when {@code enabled=true}), log a WARNING log instead.
          */
-        LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS("log-warning-instead-of-failing-api-calls", false);
+        LOG_WARNING_INSTEAD_OF_FAILING_API_CALLS("log-warning-instead-of-failing-api-calls", false),
+
+        /**
+         * Whether the JsonSchema cache should be enabled.
+         * @since 3.8.0
+         */
+        JSON_SCHEMA_CACHE_ENABLED("json-schema-cache-enabled", true);
 
 
         private final String path;

--- a/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationFeatureLevelTest.java
+++ b/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationFeatureLevelTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -51,6 +52,8 @@ import org.eclipse.ditto.wot.validation.config.FeatureValidationConfig;
 import org.eclipse.ditto.wot.validation.config.TmValidationConfig;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
 
 /**
  * Provides unit tests for testing the "feature" related functionality of {@link WotThingModelValidation}.
@@ -230,6 +233,8 @@ public final class WotThingModelValidationFeatureLevelTest {
         when(featureValidationConfig.isForbidNonModeledInboxMessages()).thenReturn(true);
         when(featureValidationConfig.isForbidNonModeledOutboxMessages()).thenReturn(true);
         when(validationConfig.getFeatureValidationConfig()).thenReturn(featureValidationConfig);
+        when(validationConfig.getJsonSchemaCacheConfig()).thenReturn(DefaultCacheConfig.of(
+                ConfigFactory.parseMap(Map.of("cache.maximum-size", "1")), "cache"));
 
         sut = WotThingModelValidation.of(validationConfig, new CurrentThreadExecutor());
     }

--- a/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationThingLevelTest.java
+++ b/wot/validation/src/test/java/org/eclipse/ditto/wot/validation/WotThingModelValidationThingLevelTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -45,6 +46,8 @@ import org.eclipse.ditto.wot.validation.config.ThingValidationConfig;
 import org.eclipse.ditto.wot.validation.config.TmValidationConfig;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
 
 /**
  * Provides unit tests for testing the "thing" related functionality of {@link WotThingModelValidation}.
@@ -182,7 +185,8 @@ public final class WotThingModelValidationThingLevelTest {
         when(thingValidationConfig.isForbidNonModeledInboxMessages()).thenReturn(true);
         when(thingValidationConfig.isForbidNonModeledOutboxMessages()).thenReturn(true);
         when(validationConfig.getThingValidationConfig()).thenReturn(thingValidationConfig);
-
+        when(validationConfig.getJsonSchemaCacheConfig()).thenReturn(DefaultCacheConfig.of(
+                ConfigFactory.parseMap(Map.of("cache.maximum-size", "1")), "cache"));
 
         sut = WotThingModelValidation.of(validationConfig, new CurrentThreadExecutor());
     }


### PR DESCRIPTION
* previously, the complete thing (with all of its features) were validated against all submodels 
* this could be potentially very CPU intensive
* even if not much was changed within a `PATCH` or `MergeThing` command, this wasted a lot of resources
* the new approach only validates parts which were changed in the "Merge" command

E.g.:
* if an attribute was modified, all of the attributes are validated
* if part of a feature was modified, all properties of that feature are validated
* if all features were modified, all properties of all features are validated (but then PATCH is not really an optimisation compared to using PUT)
* special case: if the thing's `definition` was updated, the complete thing is validated as all parts have to be valid according to the updated definition