### PR TITLE
fix array sort values in GetSortBsonVisitor

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetSortBsonVisitor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetSortBsonVisitor.java
@@ -168,6 +168,10 @@ public final class GetSortBsonVisitor implements SortFieldExpressionVisitor<Stri
             return JsonFactory.readFrom((document).toJson());
         } else if (object instanceof BsonValue bsonValue) {
             return DittoBsonJson.getInstance().serialize(bsonValue);
+        } else if (object instanceof List<?> list) {
+            JsonArrayBuilder builder = JsonFactory.newArrayBuilder();
+            list.forEach(item -> builder.add(toJsonValue(item)));
+            return builder.build();
         } else {
             return JsonValue.of(object);
         }


### PR DESCRIPTION
Sorting on array fields caused a JsonParseException because GetSortBsonVisitor#toJsonValue did not handle array values correctly.

**Fix**

Added support in toJsonValue for converting Java collections into proper JsonArray instead of treating them as plain JSON strings.