### PR TITLE
Add support for client certificate authentication for AMQP 1.0

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
@@ -40,15 +40,9 @@ import org.eclipse.ditto.connectivity.model.ConnectionConfigurationInvalidExcept
 import org.eclipse.ditto.connectivity.model.ConnectionId;
 import org.eclipse.ditto.connectivity.model.ConnectionType;
 import org.eclipse.ditto.connectivity.model.Credentials;
-import org.eclipse.ditto.connectivity.model.CredentialsVisitor;
-import org.eclipse.ditto.connectivity.model.HmacCredentials;
-import org.eclipse.ditto.connectivity.model.OAuthClientCredentials;
-import org.eclipse.ditto.connectivity.model.OAuthPassword;
 import org.eclipse.ditto.connectivity.model.PayloadMapping;
 import org.eclipse.ditto.connectivity.model.Source;
-import org.eclipse.ditto.connectivity.model.SshPublicKeyCredentials;
 import org.eclipse.ditto.connectivity.model.Target;
-import org.eclipse.ditto.connectivity.model.UserPasswordCredentials;
 import org.eclipse.ditto.connectivity.service.config.ConnectionConfig;
 import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.config.mapping.MapperLimitsConfig;
@@ -391,36 +385,4 @@ public final class ConnectionValidator {
                 .build();
     }
 
-    private static final class IsClientCertificateCredentialsVisitor implements CredentialsVisitor<Boolean> {
-
-        @Override
-        public Boolean clientCertificate(final ClientCertificateCredentials credentials) {
-            return true;
-        }
-
-        @Override
-        public Boolean usernamePassword(final UserPasswordCredentials credentials) {
-            return false;
-        }
-
-        @Override
-        public Boolean sshPublicKeyAuthentication(final SshPublicKeyCredentials credentials) {
-            return false;
-        }
-
-        @Override
-        public Boolean hmac(final HmacCredentials credentials) {
-            return false;
-        }
-
-        @Override
-        public Boolean oauthClientCredentials(final OAuthClientCredentials credentials) {
-            return false;
-        }
-
-        @Override
-        public Boolean oauthPassword(final OAuthPassword credentials) {
-            return false;
-        }
-    }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/IsClientCertificateCredentialsVisitor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/IsClientCertificateCredentialsVisitor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.validation;
+
+import org.eclipse.ditto.connectivity.model.*;
+
+public final class IsClientCertificateCredentialsVisitor implements CredentialsVisitor<Boolean> {
+    @Override
+    public Boolean clientCertificate(final ClientCertificateCredentials credentials) {
+        return true;
+    }
+
+    @Override
+    public Boolean usernamePassword(final UserPasswordCredentials credentials) {
+        return false;
+    }
+
+    @Override
+    public Boolean sshPublicKeyAuthentication(final SshPublicKeyCredentials credentials) {
+        return false;
+    }
+
+    @Override
+    public Boolean hmac(final HmacCredentials credentials) {
+        return false;
+    }
+
+    @Override
+    public Boolean oauthClientCredentials(final OAuthClientCredentials credentials) {
+        return false;
+    }
+
+    @Override
+    public Boolean oauthPassword(final OAuthPassword credentials) {
+        return false;
+    }
+}

--- a/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
@@ -82,8 +82,11 @@ The server identity is verified directly or indirectly.
 
 ## Authenticate by client certificate
 
-_Client-certificate authentication is available for [MQTT connections](connectivity-protocol-bindings-mqtt.html)
- and [HTTP connections](connectivity-protocol-bindings-http.html) only._
+_Client-certificate authentication is available for
+[MQTT connections](connectivity-protocol-bindings-mqtt.html),
+[HTTP connections](connectivity-protocol-bindings-http.html), and
+[AMQP 1.0](connectivity-protocol-bindings-amqp10.html)
+connections only._
 
 ### Connection configuration
 


### PR DESCRIPTION
Adds support for using client certificate authentication in AMQP 1.0 connections by properly configuring the SSL context to use the connection certificate and keys and by setting the EXTERNAL authentication mechanism.