### PR TITLE
Revert "improve Thing enforcement performance by caching a resolved policyId in ThingEnforcerActor"

### DIFF
--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/LiveSignalEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/LiveSignalEnforcementTest.java
@@ -118,6 +118,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             TestSetup.fishForMsgClass(this, ThingNotAccessibleException.class);
 
             supervisor.tell(getModifyFeatureCommand(liveHeaders()), getRef());
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectMsgClass(FeatureNotModifiableException.class);
         }};
     }
@@ -149,6 +150,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             final ThingCommand<?> read = getRetrieveThingCommand(liveHeaders());
             RetrieveThingResponse.of(TestSetup.THING_ID, JsonFactory.newObject(), DittoHeaders.empty());
             supervisor.tell(read, getRef());
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             final DistributedPubSubMediator.Publish publishRead =
                     pubSubMediatorProbe.expectMsgClass(DistributedPubSubMediator.Publish.class);
 
@@ -199,6 +201,8 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
                     .build();
 
             supervisor.tell(readResponse, getRef());
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             final RetrieveThingResponse retrieveThingResponse = expectMsgClass(RetrieveThingResponse.class);
             assertThat(retrieveThingResponse.getThing()).isEqualTo(expectedThing);
         }};
@@ -243,6 +247,9 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             // Second message right after the response for the first was sent, should have the same correlation-id (Not suffixed).
             supervisor.tell(readResponse, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             final RetrieveThingResponse retrieveThingResponse = expectMsgClass(RetrieveThingResponse.class);
             assertThat(retrieveThingResponse.getDittoHeaders().getCorrelationId()).isEqualTo(
                     read.getDittoHeaders().getCorrelationId());
@@ -261,9 +268,14 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
 
             supervisor.tell(read2, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             expectPubsubLiveCommandPublish("publish live read command", read2.getEntityId());
 
             supervisor.tell(readResponse2, getRef());
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final RetrieveThingResponse retrieveThingResponse2 = expectMsgClass(RetrieveThingResponse.class);
             assertThat(retrieveThingResponse2.getDittoHeaders().getCorrelationId()).isEqualTo(
@@ -304,6 +316,7 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
 
             supervisor.tell(message, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final var secondPublishRead = expectPubsubMessagePublish(message.getEntityId());
@@ -435,6 +448,8 @@ public final class LiveSignalEnforcementTest extends AbstractThingEnforcementTes
             final ThingEvent<?> liveEventRevoked = liveEventRevoked();
 
             supervisor.tell(liveEventRevoked, getRef());
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             TestSetup.fishForMsgClass(this, EventSendNotAllowedException.class);
         }};

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/MultiStageCommandEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/MultiStageCommandEnforcementTest.java
@@ -130,6 +130,9 @@ public final class MultiStageCommandEnforcementTest extends AbstractThingEnforce
             policiesShardRegionProbe.expectMsgClass(RetrievePolicy.class);
             policiesShardRegionProbe.reply(RetrievePolicyResponse.of(policyId, policy, DEFAULT_HEADERS));
 
+            // THEN: Load enforcer to filter response
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             // THEN: initial requester receives Thing with inline policy
             final RetrieveThingResponse response = TestSetup.fishForMsgClass(this, RetrieveThingResponse.class);
             assertThat((CharSequence) response.getEntityId()).isEqualTo(thingId);
@@ -175,6 +178,9 @@ public final class MultiStageCommandEnforcementTest extends AbstractThingEnforce
             policiesShardRegionProbe.expectMsgClass(RetrievePolicy.class);
             policiesShardRegionProbe.reply(PolicyNotAccessibleException.newBuilder(policyId).build());
 
+            // THEN:: Retrieve enforcer for filtering of response
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             // THEN: initial requester receives Thing with inline policy
             final RetrieveThingResponse response = expectMsgClass(RetrieveThingResponse.class);
             assertThat((CharSequence) response.getEntityId()).isEqualTo(thingId);
@@ -216,12 +222,18 @@ public final class MultiStageCommandEnforcementTest extends AbstractThingEnforce
             // WHEN: Thing exists but Policy exists only in cache
             supervisor.tell(retrieveThing, getRef());
 
+            // THEN: Load enforcer to authorize retrieve thing
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             thingPersistenceActorProbe.expectMsg(expectedRetrieveThing);
             thingPersistenceActorProbe.reply(RetrieveThingResponse.of(thingId, thing, null, null, DEFAULT_HEADERS));
 
             expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             policiesShardRegionProbe.expectMsgClass(RetrievePolicy.class);
             policiesShardRegionProbe.reply(PolicyNotAccessibleException.newBuilder(policyId).build());
+
+            // THEN: Load enforcer to filter response
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             // THEN: initial requester receives Thing without Policy
             final RetrieveThingResponse response = expectMsgClass(RetrieveThingResponse.class);
@@ -266,6 +278,9 @@ public final class MultiStageCommandEnforcementTest extends AbstractThingEnforce
             // WHEN: Thing is responsive but Policy times out
             supervisor.tell(retrieveThing, getRef());
 
+            // THEN: Load enforcer to authorize retrieve thing
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             thingPersistenceActorProbe.expectMsg(expectedRetrieveThing);
             thingPersistenceActorProbe.reply(RetrieveThingResponse.of(thingId, thing, null, null, DEFAULT_HEADERS));
 
@@ -273,6 +288,9 @@ public final class MultiStageCommandEnforcementTest extends AbstractThingEnforce
 
             policiesShardRegionProbe.expectMsgClass(RetrievePolicy.class);
             policiesShardRegionProbe.reply(new AskTimeoutException("policy timeout"));
+
+            // THEN: Load enforcer to filter response
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             // THEN: initial requester receives Thing without Policy
             final RetrieveThingResponse response = expectMsgClass(RetrieveThingResponse.class);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/SmartChannelEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/SmartChannelEnforcementTest.java
@@ -125,6 +125,8 @@ public final class SmartChannelEnforcementTest extends AbstractThingEnforcementT
             expectLiveQueryCommandOnPubSub(retrieveThing);
             pubSubMediatorProbe.reply(getRetrieveThingResponse(retrieveThing, true, b -> b.channel("live")));
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             assertLiveChannel(expectMsgClass(RetrieveThingResponse.class));
         }};
     }
@@ -141,6 +143,8 @@ public final class SmartChannelEnforcementTest extends AbstractThingEnforcementT
             thingPersistenceActorProbe.expectMsg(addReadSubjectHeader(retrieveThing, TestSetup.GOOGLE_SUBJECT));
             final var twinResponse = getRetrieveThingResponse(retrieveThing, true, b -> {});
             thingPersistenceActorProbe.reply(twinResponse);
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             expectLiveQueryCommandOnPubSub(retrieveThing);
             assertTwinChannel(expectMsgClass(RetrieveThingResponse.class));
@@ -228,6 +232,8 @@ public final class SmartChannelEnforcementTest extends AbstractThingEnforcementT
             thingPersistenceActorProbe.expectMsg(expectedRetrieveThing);
             final var twinResponse = getRetrieveThingResponse(retrieveThing, true, b -> {});
             thingPersistenceActorProbe.reply(twinResponse);
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             expectLiveQueryCommandOnPubSub(retrieveThing);
             assertTwinChannel(expectMsgClass(RetrieveThingResponse.class));

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/SmartChannelEnforcementWithResponseReceiverTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/SmartChannelEnforcementWithResponseReceiverTest.java
@@ -111,6 +111,10 @@ public final class SmartChannelEnforcementWithResponseReceiverTest extends Abstr
             expectLiveQueryCommandOnPubSub(retrieveThing);
             supervisor.tell(getRetrieveThingResponse(retrieveThing, b -> b.channel("live")), ActorRef.noSender());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             assertLiveChannel(expectMsgClass(RetrieveThingResponse.class));
         }};
     }
@@ -134,6 +138,8 @@ public final class SmartChannelEnforcementWithResponseReceiverTest extends Abstr
                     ThingIdInvalidException.newBuilder(retrieveThing.getEntityId())
                             .dittoHeaders(retrieveThing.getDittoHeaders().toBuilder().channel("live").build())
                             .build()), ActorRef.noSender());
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final var receivedError = expectMsgClass(ThingIdInvalidException.class);
             assertLiveChannel(receivedError);
@@ -164,6 +170,8 @@ public final class SmartChannelEnforcementWithResponseReceiverTest extends Abstr
                     ThingIdInvalidException.newBuilder(retrieveThing.getEntityId())
                             .dittoHeaders(retrieveThing.getDittoHeaders().toBuilder().channel("live").build())
                             .build()), ActorRef.noSender());
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final var receivedError = expectMsgClass(ThingIdInvalidException.class);
             assertLiveChannel(receivedError);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcementTest.java
@@ -133,6 +133,8 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
 
             supervisor.tell(getModifyCommand(), getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             expectMsgClass(FeatureNotModifiableException.class);
         }};
     }
@@ -262,10 +264,14 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
                     RetrieveThingResponse.of(THING_ID, JsonFactory.newObject(), DittoHeaders.empty());
             supervisor.tell(read, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             final ThingCommand<?> expectedReadCommand = addReadSubjectHeader(read,
                     SubjectId.newInstance(GOOGLE, TestSetup.SUBJECT_ID));
             thingPersistenceActorProbe.expectMsg(expectedReadCommand);
             thingPersistenceActorProbe.reply(retrieveThingResponse);
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             expectMsg(retrieveThingResponse);
         }};
@@ -306,6 +312,8 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
 
             supervisor.tell(getReadCommand(), getRef());
             thingPersistenceActorProbe.reply(retrieveThingResponseWithAttr);
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             final JsonObject jsonObjectWithoutAttr = JsonObject.newBuilder()
                     .set("thingId", "thing:id") // this is re-added as first field being a "special" field always visible after enforcement
@@ -358,6 +366,8 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
             final RetrieveThingResponse retrieveThingResponse = RetrieveThingResponse.of(THING_ID, thing, headers());
             thingPersistenceActorProbe.reply(retrieveThingResponse);
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             // THEN: The command is authorized and response is forwarded
             final var response1 = expectMsgClass(RetrieveThingResponse.class);
             Assertions.assertThat(response1.getThing().toJson().get(revokedFeaturePointer))
@@ -369,6 +379,8 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
                     getRetrieveThing(builder -> builder.condition("exists(features/revokedFeature)"));
             supervisor.tell(conditionalRetrieveThing2, getRef());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
+
             // THEN: The command is rejected
             expectMsgClass(ThingConditionFailedException.class);
 
@@ -376,6 +388,8 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
             final var conditionalRetrieveThing3 = getRetrieveThing(builder ->
                     builder.liveChannelCondition("exists(features/revokedFeature)").channel("live"));
             supervisor.tell(conditionalRetrieveThing3, getRef());
+
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             // THEN: The command is rejected
             expectMsgClass(ThingConditionFailedException.class);
@@ -544,7 +558,9 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
             final ActorRef retrieveThingSender = thingPersistenceActorProbe.lastSender();
             retrieveThingSender.tell(retrieveThingResponse, ActorRef.noSender());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectMsgClass(RetrieveThingResponse.class);
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
 
             thingPersistenceActorProbe.expectMsgClass(ModifyPolicyId.class);
             final ActorRef modifyPolicyIdSender = thingPersistenceActorProbe.lastSender();
@@ -557,12 +573,14 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
             final ActorRef modifyAttributeSender = thingPersistenceActorProbe.lastSender();
             modifyAttributeSender.tell(modifyAttributeResponse, ActorRef.noSender());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectMsgClass(ModifyAttributeResponse.class);
 
             thingPersistenceActorProbe.expectMsgClass(RetrieveAttribute.class);
             final ActorRef retrieveAttributeSender = thingPersistenceActorProbe.lastSender();
             retrieveAttributeSender.tell(retrieveAttributeResponse, ActorRef.noSender());
 
+            expectAndAnswerSudoRetrieveThing(sudoRetrieveThingResponse);
             expectMsgClass(RetrieveAttributeResponse.class);
         }};
     }


### PR DESCRIPTION
This reverts commit 66856820e603d12ba9541094071583ea99cbd9d0 done in #2212

System-Tests revealed that the order of commands applied in the ThingPersistenceActor is no longer "stable" with this optimisation.  
It seems that this 1-2ms delay is somehow needed in order to get a proper ordering of enforced commands.

For the future - PR #2212 together with the discarded PR #2219 might be a good starting point to optimise this.