### PR TITLE
Add support for client certificate authentication for Kafka

### DIFF
--- a/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
@@ -84,8 +84,9 @@ The server identity is verified directly or indirectly.
 
 _Client-certificate authentication is available for
 [MQTT connections](connectivity-protocol-bindings-mqtt.html),
-[HTTP connections](connectivity-protocol-bindings-http.html), and
-[AMQP 1.0](connectivity-protocol-bindings-amqp10.html)
+[HTTP connections](connectivity-protocol-bindings-http.html),
+[AMQP 1.0](connectivity-protocol-bindings-amqp10.html), and
+[Kafka 2.x](connectivity-protocol-bindings-kafka2.html)
 connections only._
 
 ### Connection configuration


### PR DESCRIPTION
Adds support for using client certificate authentication in Kafka connections by setting the correct properties for the consumer/producer.

Similar to the work I did in #2223 but shifting requirements caused us to switch to using kafka instead of AMQP.