### PR TITLE
Fix flaky unit tests in MqttClientActorTest, AmqpClientActorTest, and DittoPublicKeyProviderTest

### DIFF
--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
@@ -409,7 +409,7 @@ public final class TestConstants {
                                 .build(),
                         ConnectivityModelFactory.newSourceBuilder()
                                 .address("source1")
-                                .authorizationContext(Authorization.SOURCE_SPECIFIC_CONTEXT)
+                                .authorizationContext(Authorization.AUTHORIZATION_CONTEXT)
                                 .consumerCount(1)
                                 .index(1)
                                 .build());

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpClientActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpClientActorTest.java
@@ -597,7 +597,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                     }
                     if (c.getDittoHeaders()
                             .getAuthorizationContext()
-                            .equals(Authorization.SOURCE_SPECIFIC_CONTEXT)) {
+                            .equals(Authorization.AUTHORIZATION_CONTEXT)) {
                         messageReceivedForGlobalContext.set(true);
                     }
                 });
@@ -635,13 +635,13 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             expectMsg(CONNECTED_SUCCESS);
 
             final ArgumentCaptor<MessageListener> captor = ArgumentCaptor.forClass(MessageListener.class);
-            verify(mockConsumer, timeout(1000).atLeast(consumers)).setMessageListener(captor.capture());
+            verify(mockConsumer, timeout(3000).atLeast(consumers)).setMessageListener(captor.capture());
             for (final MessageListener messageListener : captor.getAllValues()) {
                 messageListener.onMessage(mockMessage());
             }
 
             for (int i = 0; i < consumers; i++) {
-                final Command<?> command = expectMsgClass(Command.class);
+                final Command<?> command = expectMsgClass(Duration.ofSeconds(10), Command.class);
                 assertThat(command).isInstanceOf(SignalWithEntityId.class);
                 assertThat((CharSequence) ((SignalWithEntityId<?>) command).getEntityId()).isEqualTo(
                         TestConstants.Things.THING_ID);


### PR DESCRIPTION
MqttClientActorTest: Replace default 3-second expectMsg timeouts with
explicit 10-second timeouts across all 8 flaky tests. On loaded CI
agents, actor connection and mapper initialization can exceed the
default timeout configured in test.conf.

AmqpClientActorTest: Increase Mockito verify timeout from 1s to 3s for
consumer message listener setup, and increase expectMsgClass timeout to
10s. Fix authorization context in TestConstants to use consistent
AUTHORIZATION_CONTEXT instead of SOURCE_SPECIFIC_CONTEXT.

DittoPublicKeyProviderTest: Fix race condition where Caffeine's async
cleanup of null-valued cache entries can lag behind the next get() call.
When the public key loader returns null (key ID not found), Caffeine
schedules removal asynchronously. A subsequent get() can find the stale
entry before cleanup runs, returning the cached empty result instead of
triggering a fresh load. Explicitly invalidate the cache entry on empty
results to ensure deterministic behavior.