### PR TITLE
fix aggregation metrics retaining stale values for vanished group-by …

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActor.java
@@ -15,27 +15,21 @@
 package org.eclipse.ditto.thingsearch.service.starter.actors;
 
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.AbstractActor;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.Props;
-import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.actor.Status;
 import org.apache.pekko.japi.pf.ReceiveBuilder;
-import org.apache.pekko.pattern.Patterns;
-import org.apache.pekko.stream.Graph;
 import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.SourceShape;
 import org.apache.pekko.stream.SystemMaterializer;
-import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.bson.Document;
 import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
 import org.eclipse.ditto.base.model.exceptions.DittoJsonException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.timer.StartedTimer;
@@ -61,6 +55,7 @@ public final class AggregateThingsMetricsActor extends AbstractActor {
      */
     public static final String CLUSTER_ROLE = "search";
     private static final String TRACING_THINGS_AGGREGATION = "aggregate_things_metrics";
+    private static final Duration AGGREGATION_TIMEOUT = Duration.ofMinutes(2);
 
     private final ThreadSafeDittoLoggingAdapter log;
     private final ThingsAggregationPersistence thingsAggregationPersistence;
@@ -86,51 +81,38 @@ public final class AggregateThingsMetricsActor extends AbstractActor {
 
     private void aggregate(final AggregateThingsMetrics aggregateThingsMetrics) {
         log.debug("Received aggregate command for {}", aggregateThingsMetrics);
+        final ActorRef sender = getSender();
+        final ActorRef self = getSelf();
         final StartedTimer aggregationTimer = startNewTimer(aggregateThingsMetrics);
         final Source<Document, NotUsed> source =
                 DittoJsonException.wrapJsonRuntimeException(aggregateThingsMetrics,
                         aggregateThingsMetrics.getDittoHeaders(),
                         (command, headers) -> thingsAggregationPersistence.aggregateThings(command));
         final Source<AggregateThingsMetricsResponse, NotUsed> aggregationResult =
-                processAggregationPersistenceResult(source, aggregateThingsMetrics.getDittoHeaders())
+                source.map(doc -> {
+                            log.withCorrelationId(aggregateThingsMetrics.getDittoHeaders())
+                                    .debug("aggregation element: {}", doc);
+                            return doc;
+                        })
                         .map(aggregation -> JsonFactory.newObject(aggregation.toJson()))
                         .map(aggregation -> AggregateThingsMetricsResponse.of(aggregation, aggregateThingsMetrics));
-        final ActorRef sender = getSender(); // Save sender as it is not available after the first element is processed
-        final Source<Object, ?> replySourceWithErrorHandling =
-                aggregationResult.via(stopTimerAndHandleError(aggregationTimer, aggregateThingsMetrics));
 
-        replySourceWithErrorHandling.runWith(Sink.foreach(
-                        elem -> Patterns.pipe(CompletableFuture.completedFuture(elem), getContext().dispatcher()).to(sender)),
-                materializer);
-    }
-
-    private <T> Source<T, NotUsed> processAggregationPersistenceResult(final Source<T, NotUsed> source,
-            final DittoHeaders dittoHeaders) {
-
-        final Flow<T, T, NotUsed> logAndFinishPersistenceSegmentFlow =
-                Flow.fromFunction(result -> {
-                    log.withCorrelationId(dittoHeaders)
-                            .debug("aggregation element: {}", result);
-                    return result;
-                });
-        return source.via(logAndFinishPersistenceSegmentFlow);
-    }
-
-    private <T> Flow<T, Object, NotUsed> stopTimerAndHandleError(final StartedTimer searchTimer,
-            final AggregateThingsMetrics command) {
-        return Flow.<T, Object>fromFunction(element -> element)
-                .recoverWithRetries(1, new PFBuilder<Throwable, Graph<SourceShape<Object>, NotUsed>>()
-                        .matchAny(error -> Source.single(asDittoRuntimeException(error, command)))
-                        .build()
-                ).watchTermination((notUsed, done) -> {
-                    done.whenComplete((d, throwable) -> {
-                        final long now = System.nanoTime();
-                        stopTimer(searchTimer);
-                        final long duration =
-                                Duration.ofNanos(now - searchTimer.getStartInstant().toNanos()).toMillis();
-                        log.withCorrelationId(command).info("Db aggregation for metric <{}> - took: <{}ms>", command.getMetricName(), duration);
-                    });
-                    return NotUsed.getInstance();
+        aggregationResult.completionTimeout(AGGREGATION_TIMEOUT).runWith(Sink.seq(), materializer)
+                .whenComplete((responses, error) -> {
+                    final long now = System.nanoTime();
+                    stopTimer(aggregationTimer);
+                    final long duration =
+                            Duration.ofNanos(now - aggregationTimer.getStartInstant().toNanos()).toMillis();
+                    log.withCorrelationId(aggregateThingsMetrics)
+                            .info("Db aggregation for metric <{}> - took: <{}ms>",
+                                    aggregateThingsMetrics.getMetricName(), duration);
+                    if (error != null) {
+                        sender.tell(new Status.Failure(
+                                asDittoRuntimeException(error, aggregateThingsMetrics)), self);
+                    } else {
+                        sender.tell(new AggregateThingsMetricsBatch(
+                                aggregateThingsMetrics.getMetricName(), responses), self);
+                    }
                 });
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsBatch.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsBatch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.starter.actors;
+
+import java.util.List;
+
+import org.eclipse.ditto.thingsearch.model.signals.commands.query.AggregateThingsMetricsResponse;
+
+/**
+ * Internal message wrapping all {@link AggregateThingsMetricsResponse}s for a single aggregation scrape cycle
+ * of a specific metric. Enables the receiving actor to reconcile vanished group-by buckets by comparing the
+ * batch contents against previously known gauges.
+ * <p>
+ * IMPORTANT: This record is intentionally not serializable. It is a local-only message that must only be sent
+ * between co-located actors on the same JVM. Both {@link AggregateThingsMetricsActor} and
+ * {@link OperatorAggregateMetricsProviderActor} are cluster singletons on the "search" role and are guaranteed
+ * to run on the same node. If this co-location guarantee ever changes, this record must be made serializable
+ * (e.g. by implementing {@code Jsonifiable} and registering a serializer).
+ *
+ * @param metricName the name of the metric this batch belongs to.
+ * @param responses the list of aggregation responses for all group-by buckets returned in this scrape cycle.
+ */
+record AggregateThingsMetricsBatch(String metricName, List<AggregateThingsMetricsResponse> responses) {}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
@@ -15,17 +15,17 @@ package org.eclipse.ditto.thingsearch.service.starter.actors;
 import static org.eclipse.ditto.thingsearch.service.starter.actors.AggregateThingsMetricsActor.CLUSTER_ROLE;
 
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.pekko.actor.AbstractActorWithTimers;
 import org.apache.pekko.actor.ActorRef;
@@ -85,7 +85,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
                 (metricName, customSearchMetricConfig) -> initializeCustomMetricTimer(metricName,
                         customSearchMetricConfig,
                         searchConfig.getOperatorMetricsConfig().getScrapeInterval()));
-        initializeCustomMetricsCleanupTimer(searchConfig.getOperatorMetricsConfig());
+        initializeCustomMetricsCleanupTimers(searchConfig.getOperatorMetricsConfig());
     }
 
     /**
@@ -102,7 +102,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
     public Receive createReceive() {
         return ReceiveBuilder.create()
                 .match(GatherMetricsCommand.class, this::handleGatheringMetrics)
-                .match(AggregateThingsMetricsResponse.class, this::handleAggregateThingsResponse)
+                .match(AggregateThingsMetricsBatch.class, this::handleAggregateThingsBatch)
                 .match(CleanupUnusedMetricsCommand.class, this::handleCleanupUnusedMetrics)
                 .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
                 .matchAny(m -> {
@@ -139,24 +139,50 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
     }
 
 
-    private void handleAggregateThingsResponse(final AggregateThingsMetricsResponse response) {
-        final String metricName = response.getMetricName();
-        final Optional<Long> result = response.getResult();
+    private void handleAggregateThingsBatch(final AggregateThingsMetricsBatch batch) {
+        final String metricName = batch.metricName();
+        final Set<GageIdentifier> seenInBatch = new HashSet<>();
 
-        result.ifPresentOrElse(value -> {
-            final CustomAggregationMetricConfig customAggregationMetricConfig =
-                    customSearchMetricConfigMap.get(metricName);
-            final TagSet tagSet = resolveTags(customAggregationMetricConfig, response);
-            log.withCorrelationId(response)
-                    .debug("Received aggregate things response for metric name <{} : {}>: {}, " +
-                                    "extracted result: <{}> - in thread: {}",
-                            metricName, tagSet, response, result, Thread.currentThread().getName());
-            recordMetric(metricName, tagSet, value);
+        for (final AggregateThingsMetricsResponse response : batch.responses()) {
+            final Optional<Long> result = response.getResult();
+            result.ifPresentOrElse(value -> {
+                final CustomAggregationMetricConfig config = customSearchMetricConfigMap.get(metricName);
+                final TagSet tagSet = resolveTags(config, response);
+                log.withCorrelationId(response)
+                        .debug("Received aggregate things response for metric name <{} : {}>: {}, " +
+                                        "extracted result: <{}> - in thread: {}",
+                                metricName, tagSet, response, result, Thread.currentThread().getName());
+                recordMetric(metricName, tagSet, value);
+                seenInBatch.add(new GageIdentifier(metricName, tagSet));
+            }, () -> log.withCorrelationId(response)
+                    .info("No result for metric name <{}> in aggregate things response: {}. " +
+                                    "Should not happen, at least 0 is expected in each result",
+                            metricName, response));
+        }
 
-        }, () -> log.withCorrelationId(response)
-                .info("No result for metric name <{}> in aggregate things response: {}. " +
-                                "Should not happen, at least 0 is expected in each result",
-                        metricName, response));
+        reconcileVanishedBuckets(metricName, seenInBatch);
+    }
+
+    private void reconcileVanishedBuckets(final String metricName, final Set<GageIdentifier> seenInBatch) {
+        final Iterator<Map.Entry<GageIdentifier, TimestampedGauge>> iterator =
+                metricsGauges.entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Map.Entry<GageIdentifier, TimestampedGauge> entry = iterator.next();
+            if (entry.getKey().metricName().equals(metricName) && !seenInBatch.contains(entry.getKey())) {
+                log.debug("Zeroing vanished gauge for metric <{}>: {}", metricName, entry.getKey().tags());
+                entry.getValue().set(0L);
+                if (Kamon.gauge(metricName)
+                        .remove(KamonTagSetConverter.getKamonTagSet(entry.getValue().getTagSet()))) {
+                    log.debug("Removed vanished custom search metric instrument: {} {}",
+                            metricName, entry.getValue().getTagSet());
+                    iterator.remove();
+                    decrementMonitorGauge(metricName);
+                } else {
+                    log.warning("Could not remove vanished custom search metric instrument: {}",
+                            entry.getKey());
+                }
+            }
+        }
     }
 
     private void recordMetric(final String metricName, final TagSet tagSet, final Long value) {
@@ -193,14 +219,16 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
     }
 
     private void handleCleanupUnusedMetrics(final CleanupUnusedMetricsCommand cleanupCommand) {
-        // remove metrics who were not used for longer than three times the max configured scrape interval
+        // remove metrics who were not used for longer than two times the metric's own scrape interval
         final long currentTime = System.currentTimeMillis();
+        final long unusedPeriod = cleanupCommand.scrapeInterval().multipliedBy(2).toMillis();
         final Iterator<Map.Entry<GageIdentifier, TimestampedGauge>> iterator = metricsGauges.entrySet().iterator();
         while (iterator.hasNext()) {
             final Map.Entry<GageIdentifier, TimestampedGauge> next = iterator.next();
+            if (!next.getKey().metricName().equals(cleanupCommand.metricName())) {
+                continue;
+            }
             final long lastUpdated = next.getValue().getLastUpdated();
-            final long unusedPeriod =
-                    getMaxConfiguredScrapeInterval(cleanupCommand.config()).multipliedBy(2).toMillis();
             final long expire = lastUpdated + unusedPeriod;
             log.debug("cleanup metrics:  expired: {}, time left: {} lastUpdated: {}  expire: {} currentTime: {}",
                     currentTime > expire, expire - currentTime, lastUpdated, expire, currentTime);
@@ -219,16 +247,6 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
                 }
             }
         }
-    }
-
-    private Duration getMaxConfiguredScrapeInterval(final OperatorMetricsConfig operatorMetricsConfig) {
-        return Stream.concat(Stream.of(operatorMetricsConfig.getScrapeInterval()),
-                        operatorMetricsConfig.getCustomAggregationMetricConfigs().values().stream()
-                                .map(CustomAggregationMetricConfig::getScrapeInterval)
-                                .filter(Optional::isPresent)
-                                .map(Optional::get))
-                .max(Comparator.naturalOrder())
-                .orElse(operatorMetricsConfig.getScrapeInterval());
     }
 
     private void initializeCustomMetricTimer(final String metricName, final CustomAggregationMetricConfig config,
@@ -250,12 +268,19 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
                 scrapeInterval);
     }
 
-    private void initializeCustomMetricsCleanupTimer(final OperatorMetricsConfig operatorMetricsConfig) {
-        final Duration interval = getMaxConfiguredScrapeInterval(operatorMetricsConfig);
-        log.info("Initializing custom metric cleanup timer Interval <{}>", interval);
-        getTimers().startTimerAtFixedRate("cleanup-unused-metrics",
-                new CleanupUnusedMetricsCommand(operatorMetricsConfig),
-                interval);
+    private void initializeCustomMetricsCleanupTimers(final OperatorMetricsConfig operatorMetricsConfig) {
+        final Duration defaultScrapeInterval = operatorMetricsConfig.getScrapeInterval();
+        operatorMetricsConfig.getCustomAggregationMetricConfigs().forEach((metricName, metricConfig) -> {
+            if (metricConfig.isEnabled()) {
+                final Duration scrapeInterval = metricConfig.getScrapeInterval().orElse(defaultScrapeInterval);
+                final Duration cleanupInterval = scrapeInterval.multipliedBy(2);
+                log.info("Initializing custom metric cleanup timer for metric <{}> with interval <{}>",
+                        metricName, cleanupInterval);
+                getTimers().startTimerAtFixedRate("cleanup-" + metricName,
+                        new CleanupUnusedMetricsCommand(metricName, scrapeInterval),
+                        cleanupInterval);
+            }
+        });
     }
 
     private boolean isPlaceHolder(final String value) {
@@ -318,7 +343,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
 
     private record GatherMetricsCommand(CustomAggregationMetricConfig config) {}
 
-    private record CleanupUnusedMetricsCommand(OperatorMetricsConfig config) {}
+    private record CleanupUnusedMetricsCommand(String metricName, Duration scrapeInterval) {}
 
     private record GageIdentifier(String metricName, TagSet tags) {}
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActorTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.pekko.actor.ActorSystem;
@@ -169,22 +171,73 @@ public class AggregateThingsMetricsActorTest {
             );
 
             actor.tell(command, getRef());
-            config.getTags().entrySet().stream().filter(entry -> entry.getKey().startsWith("expectedResult"))
-                    .forEach(entry -> {
-                        String expectedResult = entry.getValue();
-                        final AggregateThingsMetricsResponse response =
-                                expectMsgClass(Duration.ofSeconds(5), AggregateThingsMetricsResponse.class);
-                        LOG.info("Aggregation {}: {}", entry.getKey(), response);
-                        assertThat(response.getMetricName()).isEqualTo(config.getMetricName());
-                        assertThat(response.getResult()).isPresent();
-                        config.getGroupBy().keySet().forEach(key ->
-                                assertThat(response.getGroupedBy()).containsKey(key)
-                        );
-                        if (expectedResult != null) {
-                            assertThat(response.getResult().get()).isEqualTo(Integer.parseInt(expectedResult));
-                        }
 
-                    });
+            final AggregateThingsMetricsBatch batch =
+                    expectMsgClass(Duration.ofSeconds(5), AggregateThingsMetricsBatch.class);
+            assertThat(batch.metricName()).isEqualTo(config.getMetricName());
+
+            final List<Map.Entry<String, String>> expectedResults = config.getTags().entrySet().stream()
+                    .filter(entry -> entry.getKey().startsWith("expectedResult"))
+                    .toList();
+            assertThat(batch.responses()).hasSize(expectedResults.size());
+
+            for (final AggregateThingsMetricsResponse response : batch.responses()) {
+                LOG.info("Aggregation batch element: {}", response);
+                assertThat(response.getMetricName()).isEqualTo(config.getMetricName());
+                assertThat(response.getResult()).isPresent();
+                config.getGroupBy().keySet().forEach(key ->
+                        assertThat(response.getGroupedBy()).containsKey(key)
+                );
+            }
+
+            // verify expected result values are present in the batch
+            final List<Long> actualValues = batch.responses().stream()
+                    .map(AggregateThingsMetricsResponse::getResult)
+                    .filter(Optional::isPresent)
+                    .map(java.util.Optional::get)
+                    .sorted()
+                    .toList();
+            final List<Long> expectedValues = expectedResults.stream()
+                    .map(Map.Entry::getValue)
+                    .filter(Objects::nonNull)
+                    .map(Long::parseLong)
+                    .sorted()
+                    .toList();
+            assertThat(actualValues).isEqualTo(expectedValues);
+
+            expectNoMsg();
+        }};
+    }
+
+    /**
+     * Regression test: when the aggregation filter matches zero documents (all group-by buckets vanished),
+     * the actor must still return an {@link AggregateThingsMetricsBatch} with an empty response list.
+     * This enables the receiving actor to reconcile and zero the vanished gauges.
+     */
+    @Test
+    public void testVanishedBucketsReturnEmptyBatch() {
+        new TestKit(SYSTEM) {{
+
+            final var actor = SYSTEM.actorOf(AggregateThingsMetricsActor.props(persistence));
+
+            // use a filter that matches no documents to simulate all group-by buckets vanishing
+            final AggregateThingsMetrics command = AggregateThingsMetrics.of(
+                    config.getMetricName(),
+                    config.getGroupBy(),
+                    "eq(attributes/nonExistentField,\"impossible-value\")",
+                    config.getNamespaces(),
+                    DittoHeaders.newBuilder()
+                            .correlationId("vanished-buckets-test-" + UUID.randomUUID())
+                            .build()
+            );
+
+            actor.tell(command, getRef());
+
+            final AggregateThingsMetricsBatch batch =
+                    expectMsgClass(Duration.ofSeconds(5), AggregateThingsMetricsBatch.class);
+            assertThat(batch.metricName()).isEqualTo(config.getMetricName());
+            assertThat(batch.responses()).isEmpty();
+
             expectNoMsg();
         }};
     }


### PR DESCRIPTION
## Summary
                                                                                                                                                                             
  - **Fix stale gauges**: When a group-by bucket vanishes from MongoDB `$group` results,                                                                                     
    the corresponding Prometheus gauge is now zeroed and removed within one scrape cycle                                                                                     
    instead of waiting up to 2-3 hours                                                                                                                                       
  - **Per-metric cleanup timers**: Each metric's cleanup timer now uses its own scrape
    interval instead of the global maximum across all metrics                                                                                                                
  - **Timeout safety**: Added 2-minute `completionTimeout` on the aggregation stream to
    prevent hung MongoDB connections from permanently leaking actor closures        