### PR TITLE
Validate allowedImportAdditions for alias-based subject modifications

### DIFF
--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcer.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.policies.enforcement.pre;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +37,8 @@ import org.eclipse.ditto.policies.model.AllowedImportAddition;
 import org.eclipse.ditto.policies.model.EffectedImports;
 import org.eclipse.ditto.policies.model.EntriesAdditions;
 import org.eclipse.ditto.policies.model.EntryAddition;
+import org.eclipse.ditto.policies.model.ImportsAlias;
+import org.eclipse.ditto.policies.model.ImportsAliasTarget;
 import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.ImportedLabels;
 import org.eclipse.ditto.policies.model.Label;
@@ -51,6 +55,8 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubject;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjects;
 import org.eclipse.ditto.policies.model.signals.commands.modify.PolicyModifyCommand;
 
 import com.typesafe.config.Config;
@@ -96,6 +102,10 @@ public class PolicyImportsPreEnforcer implements PreEnforcer {
             return doApply(modifyPolicyImports.getPolicyImports().stream(), modifyPolicyImports);
         } else if (signal instanceof ModifyPolicyImport modifyPolicyImport) {
             return doApply(Stream.of(modifyPolicyImport.getPolicyImport()), modifyPolicyImport);
+        } else if (signal instanceof ModifySubject modifySubject) {
+            return validateAliasSubjectModification(modifySubject, modifySubject.getLabel());
+        } else if (signal instanceof ModifySubjects modifySubjects) {
+            return validateAliasSubjectModification(modifySubjects, modifySubjects.getLabel());
         } else {
             return CompletableFuture.completedFuture(signal);
         }
@@ -230,6 +240,87 @@ public class PolicyImportsPreEnforcer implements PreEnforcer {
                         .build();
             }
         }
+    }
+
+    /**
+     * Validates that subject modifications through an imports alias are permitted by the imported policy's
+     * {@code allowedImportAdditions}. If the label is not an alias, the command passes through unchanged.
+     */
+    private CompletionStage<Signal<?>> validateAliasSubjectModification(
+            final PolicyModifyCommand<?> command, final Label label) {
+
+        final PolicyId importingPolicyId = command.getEntityId();
+
+        return policyEnforcerProvider.getPolicyEnforcer(importingPolicyId)
+                .thenCompose(importingEnforcerOpt -> {
+                    final Optional<Policy> importingPolicyOpt = importingEnforcerOpt
+                            .flatMap(PolicyEnforcer::getPolicy);
+
+                    if (importingPolicyOpt.isEmpty()) {
+                        // Cannot resolve importing policy — let downstream handle it
+                        return CompletableFuture.completedFuture((Signal<?>) command);
+                    }
+
+                    final Policy importingPolicy = importingPolicyOpt.get();
+                    final Optional<ImportsAlias> aliasOpt =
+                            importingPolicy.getImportsAliases().getAlias(label);
+
+                    if (aliasOpt.isEmpty()) {
+                        // Not an alias — pass through
+                        return CompletableFuture.completedFuture((Signal<?>) command);
+                    }
+
+                    return validateAliasTargetsAllowSubjects(
+                            aliasOpt.get().getTargets(), command);
+                });
+    }
+
+    /**
+     * For each alias target, loads the imported policy and verifies that the target entry permits subject additions
+     * via {@code allowedImportAdditions}.
+     */
+    private CompletionStage<Signal<?>> validateAliasTargetsAllowSubjects(
+            final List<ImportsAliasTarget> targets, final PolicyModifyCommand<?> command) {
+
+        final DittoHeaders dittoHeaders = command.getDittoHeaders();
+
+        return targets.stream()
+                .map(target -> {
+                    final PolicyId importedPolicyId = target.getImportedPolicyId();
+                    final Label entryLabel = target.getEntryLabel();
+                    return getPolicyEnforcer(importedPolicyId, dittoHeaders)
+                            .thenApply(importedEnforcer -> {
+                                final Policy importedPolicy = importedEnforcer.getPolicy()
+                                        .orElseThrow(policyNotAccessible(importedPolicyId, dittoHeaders));
+
+                                final Optional<PolicyEntry> entryOpt =
+                                        importedPolicy.getEntryFor(entryLabel);
+                                if (entryOpt.isPresent()) {
+                                    final Set<AllowedImportAddition> allowed = entryOpt.get()
+                                            .getAllowedImportAdditions()
+                                            .orElse(Collections.emptySet());
+
+                                    if (!allowed.contains(AllowedImportAddition.SUBJECTS)) {
+                                        throw PolicyImportInvalidException.newBuilder()
+                                                .message("The imports alias targets entry '" +
+                                                        entryLabel + "' of imported policy '" +
+                                                        importedPolicyId +
+                                                        "' which does not allow subject additions.")
+                                                .description("The imported policy entry '" +
+                                                        entryLabel + "' does not allow " +
+                                                        "subject additions. Its " +
+                                                        "'allowedImportAdditions' is: " + allowed)
+                                                .dittoHeaders(dittoHeaders)
+                                                .build();
+                                    }
+                                }
+                                // Entry doesn't exist in imported policy — silently ignored at merge time
+                                return true;
+                            });
+                })
+                .reduce(CompletableFuture.completedFuture(true),
+                        (s1, s2) -> s1.thenCombine(s2, (b1, b2) -> b1 && b2))
+                .thenApply(ignored -> command);
     }
 
     private static DittoRuntimeException errorForPolicyModifyCommand(final PolicyImport policyImport) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcer.java
@@ -55,6 +55,8 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesAdditions;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntryAddition;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubject;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjects;
 import org.eclipse.ditto.policies.model.signals.commands.modify.PolicyModifyCommand;
@@ -63,6 +65,12 @@ import com.typesafe.config.Config;
 
 /**
  * Pre-Enforcer for authorizing modifications to policy imports.
+ * <p>
+ * <b>Note:</b> The validation performed here is best-effort. The pre-enforcer reads policies from the enforcer cache,
+ * but the persistence actor applies the command against its authoritative state. A concurrent modification (e.g. a
+ * racing {@code ModifyImportsAlias}) between cache read and persistence write could change the targets or
+ * allowedImportAdditions, making the pre-enforcer check stale (TOCTOU). The pre-enforcer therefore acts as a
+ * first line of defense, not a guarantee.
  */
 public class PolicyImportsPreEnforcer implements PreEnforcer {
 
@@ -106,6 +114,10 @@ public class PolicyImportsPreEnforcer implements PreEnforcer {
             return validateAliasSubjectModification(modifySubject, modifySubject.getLabel());
         } else if (signal instanceof ModifySubjects modifySubjects) {
             return validateAliasSubjectModification(modifySubjects, modifySubjects.getLabel());
+        } else if (signal instanceof ModifyPolicyImportEntryAddition modifyEntryAddition) {
+            return validateEntryAdditionAgainstImportedPolicy(modifyEntryAddition);
+        } else if (signal instanceof ModifyPolicyImportEntriesAdditions modifyEntriesAdditions) {
+            return validateEntriesAdditionsAgainstImportedPolicy(modifyEntriesAdditions);
         } else {
             return CompletableFuture.completedFuture(signal);
         }
@@ -295,32 +307,138 @@ public class PolicyImportsPreEnforcer implements PreEnforcer {
 
                                 final Optional<PolicyEntry> entryOpt =
                                         importedPolicy.getEntryFor(entryLabel);
-                                if (entryOpt.isPresent()) {
-                                    final Set<AllowedImportAddition> allowed = entryOpt.get()
-                                            .getAllowedImportAdditions()
-                                            .orElse(Collections.emptySet());
-
-                                    if (!allowed.contains(AllowedImportAddition.SUBJECTS)) {
-                                        throw PolicyImportInvalidException.newBuilder()
-                                                .message("The imports alias targets entry '" +
-                                                        entryLabel + "' of imported policy '" +
-                                                        importedPolicyId +
-                                                        "' which does not allow subject additions.")
-                                                .description("The imported policy entry '" +
-                                                        entryLabel + "' does not allow " +
-                                                        "subject additions. Its " +
-                                                        "'allowedImportAdditions' is: " + allowed)
-                                                .dittoHeaders(dittoHeaders)
-                                                .build();
-                                    }
+                                if (entryOpt.isEmpty()) {
+                                    throw PolicyImportInvalidException.newBuilder()
+                                            .message("The imports alias targets entry '" +
+                                                    entryLabel + "' of imported policy '" +
+                                                    importedPolicyId +
+                                                    "' which does not exist.")
+                                            .description("The imported policy '" +
+                                                    importedPolicyId +
+                                                    "' does not contain an entry with label '" +
+                                                    entryLabel + "'.")
+                                            .dittoHeaders(dittoHeaders)
+                                            .build();
                                 }
-                                // Entry doesn't exist in imported policy — silently ignored at merge time
+                                final Set<AllowedImportAddition> allowed = entryOpt.get()
+                                        .getAllowedImportAdditions()
+                                        .orElse(Collections.emptySet());
+
+                                if (!allowed.contains(AllowedImportAddition.SUBJECTS)) {
+                                    throw PolicyImportInvalidException.newBuilder()
+                                            .message("The imports alias targets entry '" +
+                                                    entryLabel + "' of imported policy '" +
+                                                    importedPolicyId +
+                                                    "' which does not allow subject additions.")
+                                            .description("The imported policy entry '" +
+                                                    entryLabel + "' does not allow " +
+                                                    "subject additions. Its " +
+                                                    "'allowedImportAdditions' is: " + allowed)
+                                            .dittoHeaders(dittoHeaders)
+                                            .build();
+                                }
                                 return true;
                             });
                 })
                 .reduce(CompletableFuture.completedFuture(true),
                         (s1, s2) -> s1.thenCombine(s2, (b1, b2) -> b1 && b2))
                 .thenApply(ignored -> command);
+    }
+
+    /**
+     * Validates that a single {@link ModifyPolicyImportEntryAddition} is permitted by the imported policy's
+     * {@code allowedImportAdditions}.
+     */
+    private CompletionStage<Signal<?>> validateEntryAdditionAgainstImportedPolicy(
+            final ModifyPolicyImportEntryAddition command) {
+
+        final PolicyId importedPolicyId = command.getImportedPolicyId();
+        final DittoHeaders dittoHeaders = command.getDittoHeaders();
+
+        return getPolicyEnforcer(importedPolicyId, dittoHeaders)
+                .thenApply(importedEnforcer -> {
+                    final Policy importedPolicy = importedEnforcer.getPolicy()
+                            .orElseThrow(policyNotAccessible(importedPolicyId, dittoHeaders));
+
+                    validateSingleEntryAdditionAllowed(
+                            command.getEntryAddition(), importedPolicyId, importedPolicy, dittoHeaders);
+                    return (Signal<?>) command;
+                });
+    }
+
+    /**
+     * Validates that a {@link ModifyPolicyImportEntriesAdditions} is permitted by the imported policy's
+     * {@code allowedImportAdditions}.
+     */
+    private CompletionStage<Signal<?>> validateEntriesAdditionsAgainstImportedPolicy(
+            final ModifyPolicyImportEntriesAdditions command) {
+
+        final PolicyId importedPolicyId = command.getImportedPolicyId();
+        final DittoHeaders dittoHeaders = command.getDittoHeaders();
+
+        return getPolicyEnforcer(importedPolicyId, dittoHeaders)
+                .thenApply(importedEnforcer -> {
+                    final Policy importedPolicy = importedEnforcer.getPolicy()
+                            .orElseThrow(policyNotAccessible(importedPolicyId, dittoHeaders));
+
+                    for (final EntryAddition addition : command.getEntriesAdditions()) {
+                        validateSingleEntryAdditionAllowed(
+                                addition, importedPolicyId, importedPolicy, dittoHeaders);
+                    }
+                    return (Signal<?>) command;
+                });
+    }
+
+    /**
+     * Validates that a single {@link EntryAddition} is permitted by the imported policy entry's
+     * {@code allowedImportAdditions}. Rejects if the entry does not exist in the imported policy.
+     */
+    private static void validateSingleEntryAdditionAllowed(final EntryAddition entryAddition,
+            final PolicyId importedPolicyId, final Policy importedPolicy, final DittoHeaders dittoHeaders) {
+
+        final Label label = entryAddition.getLabel();
+        final Optional<PolicyEntry> entryOpt = importedPolicy.getEntryFor(label);
+        if (entryOpt.isEmpty()) {
+            throw PolicyImportInvalidException.newBuilder()
+                    .message("The imported policy '" + importedPolicyId +
+                            "' does not contain entry '" + label + "'.")
+                    .description("The entry '" + label +
+                            "' must exist in the imported policy to accept additions.")
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+        final Set<AllowedImportAddition> allowed = entryOpt.get().getAllowedImportAdditions()
+                .orElse(Collections.emptySet());
+        if (entryAddition.getSubjects().isPresent() &&
+                !allowed.contains(AllowedImportAddition.SUBJECTS)) {
+            throw PolicyImportInvalidException.newBuilder()
+                    .message("The policy import for '" + importedPolicyId +
+                            "' contains disallowed subject additions for entry '" + label + "'.")
+                    .description("The imported policy entry '" + label +
+                            "' does not allow subject additions. Its 'allowedImportAdditions' is: " + allowed)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+        if (entryAddition.getResources().isPresent() &&
+                !allowed.contains(AllowedImportAddition.RESOURCES)) {
+            throw PolicyImportInvalidException.newBuilder()
+                    .message("The policy import for '" + importedPolicyId +
+                            "' contains disallowed resource additions for entry '" + label + "'.")
+                    .description("The imported policy entry '" + label +
+                            "' does not allow resource additions. Its 'allowedImportAdditions' is: " + allowed)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+        if (entryAddition.getNamespaces().isPresent() &&
+                !allowed.contains(AllowedImportAddition.NAMESPACES)) {
+            throw PolicyImportInvalidException.newBuilder()
+                    .message("The policy import for '" + importedPolicyId +
+                            "' contains disallowed namespace additions for entry '" + label + "'.")
+                    .description("The imported policy entry '" + label +
+                            "' does not allow namespace additions. Its 'allowedImportAdditions' is: " + allowed)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
     }
 
     private static DittoRuntimeException errorForPolicyModifyCommand(final PolicyImport policyImport) {

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcerTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcerTest.java
@@ -47,6 +47,7 @@ import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
 import org.eclipse.ditto.policies.model.EffectedImports;
 import org.eclipse.ditto.policies.model.EntriesAdditions;
+import org.eclipse.ditto.policies.model.EntryAddition;
 import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
@@ -58,6 +59,8 @@ import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAcc
 import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImport;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesAdditions;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntryAddition;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubject;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjects;
@@ -104,6 +107,21 @@ class PolicyImportsPreEnforcerTest {
         when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID))
                 .thenReturn(CompletableFuture.completedFuture(
                         Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_ALLOWED_ALIAS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_GHOST_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_GHOST_ALIAS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_MIXED_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_MIXED_ALIAS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTED_WITH_RESOURCES_ONLY_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTED_WITH_RESOURCES_ONLY))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_RESOURCES_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_RESOURCES_ALIAS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS))));
         when(policyEnforcerProvider.getPolicyEnforcer(argThat(id -> !KNOWN_IDS.contains(id))))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -394,6 +412,272 @@ class PolicyImportsPreEnforcerTest {
         assertThat(signal).isSameAs(command);
     }
 
+    @Test
+    void testModifySubjectViaAliasRejectedWhenTargetEntryMissing() {
+        // IMPORTING_WITH_GHOST_ALIAS has alias "ghostalias" targeting IMPORTED's "NONEXISTENT" entry
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_GHOST_ALIAS_POLICY_ID,
+                Label.of("ghostalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("does not exist");
+    }
+
+    @Test
+    void testModifySubjectViaAliasRejectedWhenOneTargetDenies() {
+        // IMPORTING_WITH_MIXED_ALIAS has alias "mixedalias" with two targets:
+        // - IMPORTED_WITH_ADDITIONS:IMPLICIT (allows subjects)
+        // - IMPORTED:EXPLICIT (does NOT allow subjects)
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_MIXED_ALIAS_POLICY_ID,
+                Label.of("mixedalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifySubjectViaAliasRejectedWhenOnlyResourcesAllowed() {
+        // IMPORTING_WITH_RESOURCES_ALIAS has alias targeting IMPORTED_WITH_RESOURCES_ONLY:EXPLICIT
+        // which has allowedImportAdditions=["resources"] but NOT "subjects"
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_RESOURCES_ALIAS_POLICY_ID,
+                Label.of("myalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifySubjectViaAliasRejectedWhenImportedPolicyNotFound() {
+        // IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS has alias targeting "test:nonexistent" policy
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS_POLICY_ID,
+                Label.of("myalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyNotAccessibleException.class);
+    }
+
+    @Test
+    void testModifyPolicyImportEntryAdditionRejectedWhenNotAllowed() {
+        // IMPORTED policy's EXPLICIT entry does NOT have allowedImportAdditions
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final EntryAddition entryAddition = PoliciesModelFactory.newEntryAddition(
+                Label.of("EXPLICIT"),
+                PoliciesModelFactory.newSubjects(
+                        PoliciesModelFactory.newSubject(
+                                PoliciesModelFactory.newSubjectId("ditto:extra"),
+                                PoliciesModelFactory.newSubjectType("test"))),
+                null);
+
+        final var command = ModifyPolicyImportEntryAddition.of(
+                IMPORTING_POLICY_ID, IMPORTED_POLICY_ID, entryAddition, dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifyPolicyImportEntryAdditionPassesWhenAllowed() {
+        // IMPORTED_WITH_ADDITIONS policy's IMPLICIT entry allows subjects
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final EntryAddition entryAddition = PoliciesModelFactory.newEntryAddition(
+                Label.of("IMPLICIT"),
+                PoliciesModelFactory.newSubjects(
+                        PoliciesModelFactory.newSubject(
+                                PoliciesModelFactory.newSubjectId("ditto:extra"),
+                                PoliciesModelFactory.newSubjectType("test"))),
+                null);
+
+        final var command = ModifyPolicyImportEntryAddition.of(
+                IMPORTING_POLICY_ID, Policies.IMPORTED_WITH_ADDITIONS_POLICY_ID, entryAddition, dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        final Signal<?> signal = applyFuture.join();
+        assertThat(signal).isSameAs(command);
+    }
+
+    @Test
+    void testModifyPolicyImportEntriesAdditionsRejectedWhenNotAllowed() {
+        // IMPORTED policy's EXPLICIT entry does NOT have allowedImportAdditions
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final EntriesAdditions additions = PoliciesModelFactory.newEntriesAdditions(
+                java.util.Collections.singletonList(
+                        PoliciesModelFactory.newEntryAddition(Label.of("EXPLICIT"),
+                                PoliciesModelFactory.newSubjects(
+                                        PoliciesModelFactory.newSubject(
+                                                PoliciesModelFactory.newSubjectId("ditto:extra"),
+                                                PoliciesModelFactory.newSubjectType("test"))),
+                                null)));
+
+        final var command = ModifyPolicyImportEntriesAdditions.of(
+                IMPORTING_POLICY_ID, IMPORTED_POLICY_ID, additions, dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifyPolicyImportEntriesAdditionsPassesWhenAllowed() {
+        // IMPORTED_WITH_ADDITIONS policy's IMPLICIT entry allows subjects
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final EntriesAdditions additions = PoliciesModelFactory.newEntriesAdditions(
+                java.util.Collections.singletonList(
+                        PoliciesModelFactory.newEntryAddition(Label.of("IMPLICIT"),
+                                PoliciesModelFactory.newSubjects(
+                                        PoliciesModelFactory.newSubject(
+                                                PoliciesModelFactory.newSubjectId("ditto:extra"),
+                                                PoliciesModelFactory.newSubjectType("test"))),
+                                null)));
+
+        final var command = ModifyPolicyImportEntriesAdditions.of(
+                IMPORTING_POLICY_ID, Policies.IMPORTED_WITH_ADDITIONS_POLICY_ID, additions, dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        final Signal<?> signal = applyFuture.join();
+        assertThat(signal).isSameAs(command);
+    }
+
+    @Test
+    void testModifyPolicyImportEntryAdditionRejectedForNonExistentEntry() {
+        // Targeting an entry that doesn't exist in the imported policy
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final EntryAddition entryAddition = PoliciesModelFactory.newEntryAddition(
+                Label.of("NONEXISTENT"),
+                PoliciesModelFactory.newSubjects(
+                        PoliciesModelFactory.newSubject(
+                                PoliciesModelFactory.newSubjectId("ditto:extra"),
+                                PoliciesModelFactory.newSubjectType("test"))),
+                null);
+
+        final var command = ModifyPolicyImportEntryAddition.of(
+                IMPORTING_POLICY_ID, IMPORTED_POLICY_ID, entryAddition, dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("does not contain entry");
+    }
+
     static class PolicyModifyCommandsProvider implements ArgumentsProvider {
 
         public static final Set<Set<String>> ALL_SUBJECTS =
@@ -624,10 +908,63 @@ class PolicyImportsPreEnforcerTest {
                 PolicyId.of("test", "importing.with.allowed.alias");
         static final Policy IMPORTING_WITH_ALLOWED_ALIAS = buildImportingWithAllowedAlias();
 
+        // Importing policy with alias targeting IMPORTED's "NONEXISTENT" entry (doesn't exist)
+        static final PolicyId IMPORTING_WITH_GHOST_ALIAS_POLICY_ID =
+                PolicyId.of("test", "importing.with.ghost.alias");
+        static final Policy IMPORTING_WITH_GHOST_ALIAS = buildImportingWithGhostAlias();
+
+        // Importing policy with alias having two targets: one allows, one denies subjects
+        static final PolicyId IMPORTING_WITH_MIXED_ALIAS_POLICY_ID =
+                PolicyId.of("test", "importing.with.mixed.alias");
+        static final Policy IMPORTING_WITH_MIXED_ALIAS = buildImportingWithMixedAlias();
+
+        // Imported policy with allowedImportAdditions=["resources"] only (no subjects)
+        static final Policy IMPORTED_WITH_RESOURCES_ONLY = PoliciesModelFactory.newPolicy("""
+                {
+                    "policyId": "test:imported.with.resources.only",
+                    "entries" : {
+                        "DEFAULT" : {
+                            "subjects": {
+                                "ditto:admin" : { "type": "test" }
+                            },
+                            "resources": {
+                                "policy:/": { "grant": [ "READ", "WRITE" ], "revoke": [] }
+                            },
+                            "importable":"never"
+                        },
+                        "EXPLICIT" : {
+                            "subjects": {
+                                "ditto:explicit": { "type": "test" }
+                            },
+                            "resources": {
+                                "policy:/entries/EXPLICIT": { "grant": [ "READ" ], "revoke": [] }
+                            },
+                            "importable": "explicit",
+                            "allowedImportAdditions": [ "resources" ]
+                        }
+                    }
+                }
+                """);
+        static final PolicyId IMPORTED_WITH_RESOURCES_ONLY_POLICY_ID =
+                IMPORTED_WITH_RESOURCES_ONLY.getEntityId().orElseThrow();
+
+        // Importing policy with alias targeting IMPORTED_WITH_RESOURCES_ONLY's "EXPLICIT" entry
+        static final PolicyId IMPORTING_WITH_RESOURCES_ALIAS_POLICY_ID =
+                PolicyId.of("test", "importing.with.resources.alias");
+        static final Policy IMPORTING_WITH_RESOURCES_ALIAS = buildImportingWithResourcesAlias();
+
+        // Importing policy with alias targeting a non-existent imported policy
+        static final PolicyId IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS_POLICY_ID =
+                PolicyId.of("test", "importing.with.notfound.import.alias");
+        static final Policy IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS = buildImportingWithNotFoundImportAlias();
+
         static final Collection<PolicyId> KNOWN_IDS =
                 List.of(IMPORTED_POLICY_ID, IMPORTING_POLICY_ID, IMPORT_NOT_FOUND_POLICY_ID,
                         IMPORTED_WITH_ADDITIONS_POLICY_ID, IMPORTING_WITH_ALIAS_POLICY_ID,
-                        IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID);
+                        IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID, IMPORTING_WITH_GHOST_ALIAS_POLICY_ID,
+                        IMPORTING_WITH_MIXED_ALIAS_POLICY_ID, IMPORTED_WITH_RESOURCES_ONLY_POLICY_ID,
+                        IMPORTING_WITH_RESOURCES_ALIAS_POLICY_ID,
+                        IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS_POLICY_ID);
 
         private static Policy buildImportingWithAlias() {
             final var target = PoliciesModelFactory.newImportsAliasTarget(
@@ -664,6 +1001,86 @@ class PolicyImportsPreEnforcerTest {
                             PoliciesModelFactory.newSubjectType("test"))
                     .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
                     .setPolicyImports(PolicyImports.newInstance(policyImport))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
+
+        private static Policy buildImportingWithGhostAlias() {
+            final var target = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_POLICY_ID, Label.of("NONEXISTENT"));
+            final var alias = PoliciesModelFactory.newImportsAlias(Label.of("ghostalias"), List.of(target));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            final var effectedImports = EffectedImports.newInstance(List.of(Label.of("EXPLICIT")));
+            final var policyImport = PolicyImport.newInstance(IMPORTED_POLICY_ID, effectedImports);
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_GHOST_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
+                    .setPolicyImports(PolicyImports.newInstance(policyImport))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
+
+        private static Policy buildImportingWithMixedAlias() {
+            final var target1 = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_WITH_ADDITIONS_POLICY_ID, Label.of("IMPLICIT")); // allows subjects
+            final var target2 = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_POLICY_ID, Label.of("EXPLICIT")); // does NOT allow subjects
+            final var alias = PoliciesModelFactory.newImportsAlias(
+                    Label.of("mixedalias"), List.of(target1, target2));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            final var effectedImports1 = EffectedImports.newInstance(List.of(Label.of("IMPLICIT")));
+            final var policyImport1 = PolicyImport.newInstance(
+                    IMPORTED_WITH_ADDITIONS_POLICY_ID, effectedImports1);
+            final var effectedImports2 = EffectedImports.newInstance(List.of(Label.of("EXPLICIT")));
+            final var policyImport2 = PolicyImport.newInstance(IMPORTED_POLICY_ID, effectedImports2);
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_MIXED_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
+                    .setPolicyImports(PolicyImports.newInstance(policyImport1, policyImport2))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
+
+        private static Policy buildImportingWithResourcesAlias() {
+            final var target = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_WITH_RESOURCES_ONLY_POLICY_ID, Label.of("EXPLICIT"));
+            final var alias = PoliciesModelFactory.newImportsAlias(Label.of("myalias"), List.of(target));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            final var effectedImports = EffectedImports.newInstance(List.of(Label.of("EXPLICIT")));
+            final var policyImport = PolicyImport.newInstance(
+                    IMPORTED_WITH_RESOURCES_ONLY_POLICY_ID, effectedImports);
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_RESOURCES_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
+                    .setPolicyImports(PolicyImports.newInstance(policyImport))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
+
+        private static Policy buildImportingWithNotFoundImportAlias() {
+            final PolicyId nonExistentPolicyId = PolicyId.of("test", "nonexistent");
+            final var target = PoliciesModelFactory.newImportsAliasTarget(
+                    nonExistentPolicyId, Label.of("SOME_ENTRY"));
+            final var alias = PoliciesModelFactory.newImportsAlias(Label.of("myalias"), List.of(target));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_NOTFOUND_IMPORT_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
                     .setImportsAliases(aliases)
                     .build();
         }

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcerTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/pre/PolicyImportsPreEnforcerTest.java
@@ -59,6 +59,8 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubject;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifySubjects;
 import org.eclipse.ditto.policies.model.signals.commands.modify.PolicyModifyCommand;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,6 +98,12 @@ class PolicyImportsPreEnforcerTest {
         when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTED_WITH_ADDITIONS_POLICY_ID))
                 .thenReturn(CompletableFuture.completedFuture(
                         Optional.of(PolicyEnforcer.of(Policies.IMPORTED_WITH_ADDITIONS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_ALIAS))));
+        when(policyEnforcerProvider.getPolicyEnforcer(Policies.IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(PolicyEnforcer.of(Policies.IMPORTING_WITH_ALLOWED_ALIAS))));
         when(policyEnforcerProvider.getPolicyEnforcer(argThat(id -> !KNOWN_IDS.contains(id))))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
@@ -270,6 +278,120 @@ class PolicyImportsPreEnforcerTest {
                 .withCauseInstanceOf(PolicyImportInvalidException.class)
                 .withMessageContaining("NOT_IN_ENTRIES")
                 .withMessageContaining("not listed in 'entries'");
+    }
+
+    @Test
+    void testModifySubjectViaAliasRejectedWhenSubjectAdditionsNotAllowed() {
+        // IMPORTING_WITH_ALIAS has alias "myalias" targeting IMPORTED's "EXPLICIT" entry
+        // which does NOT have allowedImportAdditions=["subjects"]
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_ALIAS_POLICY_ID,
+                Label.of("myalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifySubjectsViaAliasRejectedWhenSubjectAdditionsNotAllowed() {
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subjects = PoliciesModelFactory.newSubjects(
+                PoliciesModelFactory.newSubject(
+                        PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                        PoliciesModelFactory.newSubjectType("test")));
+
+        final var command = ModifySubjects.of(
+                Policies.IMPORTING_WITH_ALIAS_POLICY_ID,
+                Label.of("myalias"),
+                subjects,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        assertThatExceptionOfType(CompletionException.class)
+                .isThrownBy(applyFuture::join)
+                .withCauseInstanceOf(PolicyImportInvalidException.class)
+                .withMessageContaining("subject additions");
+    }
+
+    @Test
+    void testModifySubjectViaAliasPassesWhenSubjectAdditionsAllowed() {
+        // IMPORTING_WITH_ALLOWED_ALIAS has alias "myalias" targeting
+        // IMPORTED_WITH_ADDITIONS's "IMPLICIT" entry which allows subjects
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID,
+                Label.of("myalias"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        final Signal<?> signal = applyFuture.join();
+        assertThat(signal).isSameAs(command);
+    }
+
+    @Test
+    void testRegularModifySubjectPassesThroughUnchanged() {
+        // ModifySubject targeting a regular entry (not an alias) should pass through
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationModelFactory.newAuthContext(
+                        DittoAuthorizationContextType.UNSPECIFIED,
+                        java.util.Collections.singletonList(
+                                AuthorizationSubject.newInstance("ditto:admin"))))
+                .build();
+
+        final var subject = PoliciesModelFactory.newSubject(
+                PoliciesModelFactory.newSubjectId("ditto:newuser"),
+                PoliciesModelFactory.newSubjectType("test"));
+
+        final var command = ModifySubject.of(
+                Policies.IMPORTING_POLICY_ID,
+                Label.of("DEFAULT"),
+                subject,
+                dittoHeaders);
+
+        final CompletableFuture<Signal<?>> applyFuture =
+                policyImportsPreEnforcer.apply(command).toCompletableFuture();
+
+        final Signal<?> signal = applyFuture.join();
+        assertThat(signal).isSameAs(command);
     }
 
     static class PolicyModifyCommandsProvider implements ArgumentsProvider {
@@ -493,8 +615,57 @@ class PolicyImportsPreEnforcerTest {
                 IMPORTED_WITH_ADDITIONS.getEntityId().orElseThrow();
         static final PolicyId IMPORT_NOT_FOUND_POLICY_ID = IMPORT_NOT_FOUND.getEntityId().orElseThrow();
 
+        // Importing policy with alias targeting IMPORTED's "EXPLICIT" (no allowedImportAdditions)
+        static final PolicyId IMPORTING_WITH_ALIAS_POLICY_ID = PolicyId.of("test", "importing.with.alias");
+        static final Policy IMPORTING_WITH_ALIAS = buildImportingWithAlias();
+
+        // Importing policy with alias targeting IMPORTED_WITH_ADDITIONS's "IMPLICIT" (allows subjects)
+        static final PolicyId IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID =
+                PolicyId.of("test", "importing.with.allowed.alias");
+        static final Policy IMPORTING_WITH_ALLOWED_ALIAS = buildImportingWithAllowedAlias();
+
         static final Collection<PolicyId> KNOWN_IDS =
                 List.of(IMPORTED_POLICY_ID, IMPORTING_POLICY_ID, IMPORT_NOT_FOUND_POLICY_ID,
-                        IMPORTED_WITH_ADDITIONS_POLICY_ID);
+                        IMPORTED_WITH_ADDITIONS_POLICY_ID, IMPORTING_WITH_ALIAS_POLICY_ID,
+                        IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID);
+
+        private static Policy buildImportingWithAlias() {
+            final var target = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_POLICY_ID, Label.of("EXPLICIT"));
+            final var alias = PoliciesModelFactory.newImportsAlias(Label.of("myalias"), List.of(target));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            final var effectedImports = EffectedImports.newInstance(List.of(Label.of("EXPLICIT")));
+            final var policyImport = PolicyImport.newInstance(IMPORTED_POLICY_ID, effectedImports);
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
+                    .setPolicyImports(PolicyImports.newInstance(policyImport))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
+
+        private static Policy buildImportingWithAllowedAlias() {
+            final var target = PoliciesModelFactory.newImportsAliasTarget(
+                    IMPORTED_WITH_ADDITIONS_POLICY_ID, Label.of("IMPLICIT"));
+            final var alias = PoliciesModelFactory.newImportsAlias(Label.of("myalias"), List.of(target));
+            final var aliases = PoliciesModelFactory.newImportsAliases(List.of(alias));
+
+            final var effectedImports = EffectedImports.newInstance(List.of(Label.of("IMPLICIT")));
+            final var policyImport = PolicyImport.newInstance(
+                    IMPORTED_WITH_ADDITIONS_POLICY_ID, effectedImports);
+
+            return PoliciesModelFactory.newPolicyBuilder(IMPORTING_WITH_ALLOWED_ALIAS_POLICY_ID)
+                    .setSubjectFor(Label.of("DEFAULT"),
+                            PoliciesModelFactory.newSubjectId("ditto:admin"),
+                            PoliciesModelFactory.newSubjectType("test"))
+                    .setGrantedPermissionsFor(Label.of("DEFAULT"), "policy", "/", "READ", "WRITE")
+                    .setPolicyImports(PolicyImports.newInstance(policyImport))
+                    .setImportsAliases(aliases)
+                    .build();
+        }
     }
 }


### PR DESCRIPTION
Subject modifications via imports aliases (ModifySubject/ModifySubjects) bypassed the allowedImportAdditions validation that is enforced for direct import modifications (ModifyPolicyImport). This allowed adding subjects to imported entries through aliases even when the imported policy entry did not permit subject additions.

Extend PolicyImportsPreEnforcer to intercept ModifySubject and ModifySubjects commands, resolve the alias to its targets, and validate that each target entry's allowedImportAdditions includes SUBJECTS.