### PR TITLE
harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -28,6 +28,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -21,15 +21,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+      -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3 # setup buildx in order to do build and push multi-architecture images
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 # setup buildx in order to do build and push multi-architecture images
       -
         name: Inspect buildx builder
         run: |
@@ -40,7 +45,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: eclipsedittobot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -55,7 +60,7 @@ jobs:
           echo $IMAGE_TAG
       -
         name: Build and push ditto-policies
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -70,7 +75,7 @@ jobs:
             eclipse/ditto-policies:${{ env.IMAGE_TAG }}
       -
         name: Build and push ditto-things
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -85,7 +90,7 @@ jobs:
             eclipse/ditto-things:${{ env.IMAGE_TAG }}
       -
         name: Build and push ditto-gateway
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -100,7 +105,7 @@ jobs:
             eclipse/ditto-gateway:${{ env.IMAGE_TAG }}
       -
         name: Build and push ditto-thingsearch
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -115,7 +120,7 @@ jobs:
             eclipse/ditto-things-search:${{ env.IMAGE_TAG }}
       -
         name: Build and push ditto-connectivity
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -131,7 +136,7 @@ jobs:
             eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}
       -
         name: Use Node.js 18.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       -
@@ -144,7 +149,7 @@ jobs:
         working-directory: ./ui
       -
         name: Build and push ditto-ui image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: ./ui
           file: ui/Dockerfile
@@ -155,7 +160,7 @@ jobs:
             eclipse/ditto-ui:${{ env.IMAGE_TAG }}
       - 
         name: Run Trivy vulnerability scanner for ditto-policies
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-policies:${{ env.IMAGE_TAG }}'
           format: 'table'
@@ -165,7 +170,7 @@ jobs:
           severity: 'CRITICAL'
       - 
         name: Run Trivy vulnerability scanner for ditto-things
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-things:${{ env.IMAGE_TAG }}'
           format: 'table'
@@ -175,7 +180,7 @@ jobs:
           severity: 'CRITICAL'
       - 
         name: Run Trivy vulnerability scanner for ditto-gateway
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-gateway:${{ env.IMAGE_TAG }}'
           format: 'table'
@@ -185,7 +190,7 @@ jobs:
           severity: 'CRITICAL'
       - 
         name: Run Trivy vulnerability scanner for ditto-things-search
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-things-search:${{ env.IMAGE_TAG }}'
           format: 'table'
@@ -195,7 +200,7 @@ jobs:
           severity: 'CRITICAL'
       - 
         name: Run Trivy vulnerability scanner for ditto-connectivity
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}'
           format: 'table'
@@ -205,7 +210,7 @@ jobs:
           severity: 'CRITICAL'
       - 
         name: Run Trivy vulnerability scanner for ditto-ui
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: 'docker.io/eclipse/ditto-ui:${{ env.IMAGE_TAG }}'
           format: 'table'

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 1 * * *' # run at 1 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'eclipse-ditto/ditto'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,6 +35,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js 18.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,9 @@ on:
   # Enable manually triggering
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,9 +29,14 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v6
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Install npm dependencies
@@ -41,7 +46,7 @@ jobs:
         run: npm run build
         working-directory: ./ui
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./ui

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
@@ -45,11 +46,15 @@ jobs:
 
       - name: Helm | Package
         shell: bash
-        run: helm package deployment/helm/ditto --dependency-update --version ${{ inputs.chartVersion }}
+        env:
+          CHART_VERSION: ${{ inputs.chartVersion }}
+        run: helm package deployment/helm/ditto --dependency-update --version "$CHART_VERSION"
 
       - name: Helm | Push
         shell: bash
-        run: helm push ditto-${{ inputs.chartVersion }}.tgz oci://registry-1.docker.io/eclipse
+        env:
+          CHART_VERSION: ${{ inputs.chartVersion }}
+        run: helm push "ditto-${CHART_VERSION}.tgz" oci://registry-1.docker.io/eclipse
 
       - name: Helm | Logout
         shell: bash
@@ -58,4 +63,6 @@ jobs:
       - name: Helm | Output
         id: output
         shell: bash
-        run: echo "image=registry-1.docker.io/eclipse/ditto:${{ inputs.chartVersion }}" >> $GITHUB_OUTPUT
+        env:
+          CHART_VERSION: ${{ inputs.chartVersion }}
+        run: echo "image=registry-1.docker.io/eclipse/ditto:${CHART_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -24,13 +24,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: ${{ env.VERSION_HELM }}
 

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -23,6 +23,9 @@ on:
       - '.github/ct.yml'
       - '.github/kubeval.sh'
 
+permissions:
+  contents: read
+
 jobs:
   lint-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
@@ -50,14 +51,20 @@ jobs:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Run chart-testing (list-changed)
         id: list-changed
+        env:
+          CT_CONFIG: ${{ env.CONFIG_OPTION_CHART_TESTING }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          changed=$(ct list-changed ${{ env.CONFIG_OPTION_CHART_TESTING }} --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed $CT_CONFIG --target-branch "$DEFAULT_BRANCH")
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint ${{ env.CONFIG_OPTION_CHART_TESTING }} --target-branch ${{ github.event.repository.default_branch }}
+        env:
+          CT_CONFIG: ${{ env.CONFIG_OPTION_CHART_TESTING }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: ct lint $CT_CONFIG --target-branch "$DEFAULT_BRANCH"
 
   kubeval-chart:
     runs-on: ubuntu-latest
@@ -79,6 +86,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
@@ -113,6 +122,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
@@ -129,8 +140,11 @@ jobs:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Run chart-testing (list-changed)
         id: list-changed
+        env:
+          CT_CONFIG: ${{ env.CONFIG_OPTION_CHART_TESTING }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          changed=$(ct list-changed ${{ env.CONFIG_OPTION_CHART_TESTING }} --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed $CT_CONFIG --target-branch "$DEFAULT_BRANCH")
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -141,4 +155,7 @@ jobs:
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install ${{ env.CONFIG_OPTION_CHART_TESTING }} --target-branch ${{ github.event.repository.default_branch }}
+        env:
+          CT_CONFIG: ${{ env.CONFIG_OPTION_CHART_TESTING }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: ct install $CT_CONFIG --target-branch "$DEFAULT_BRANCH"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -27,20 +27,25 @@ jobs:
   lint-chart:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: ${{ env.VERSION_HELM }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.VERSION_PYTHON }}
           check-latest: true
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
         with:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Run chart-testing (list-changed)
@@ -67,12 +72,17 @@ jobs:
           - v1.34.3
           - v1.35.1
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: ${{ env.VERSION_HELM }}
       - name: Run kubeval
@@ -96,20 +106,25 @@ jobs:
           - v1.34.3
           - v1.35.1
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fetch history for chart testing
         run: git fetch --prune --unshallow
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: ${{ env.VERSION_HELM }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ env.VERSION_PYTHON }}
           check-latest: true
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
         with:
           version: ${{ env.VERSION_CHART_TESTING }}
       - name: Run chart-testing (list-changed)
@@ -121,7 +136,7 @@ jobs:
           fi
       - name: Create kind ${{ matrix.k8s }} cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@9e8295d178de23cbfbd8fa16cf844eec1d773a07 # v1.4.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Run chart-testing (install)

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -14,6 +14,9 @@ on:
   # Run build for any PR
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-license-header-year:
     runs-on: ubuntu-latest

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -24,6 +24,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
         id: the-files
         continue-on-error: true

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,8 +18,13 @@ jobs:
   check-license-header-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jitterbit/get-changed-files@v1
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
         id: the-files
         continue-on-error: true
       - name: Printing added files

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,9 @@ on:
       - 'ui/**'
       - 'benchmark-tool/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,10 +33,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: 25

--- a/.github/workflows/push-dockerhub-on-demand.yml
+++ b/.github/workflows/push-dockerhub-on-demand.yml
@@ -30,6 +30,9 @@ on:
           - ditto-connectivity
           - ditto-ui
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-dockerhub-on-demand.yml
+++ b/.github/workflows/push-dockerhub-on-demand.yml
@@ -42,6 +42,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -66,11 +68,13 @@ jobs:
       -
         name: Branch name
         id: branch_name
+        env:
+          DITTO_VERSION_INPUT: ${{ inputs.dittoVersion }}
         run: |
-          echo "IMAGE_TAG=${{ inputs.dittoVersion }}" >> $GITHUB_ENV
-          echo "IMAGE_MINOR_TAG=$(echo ${{ inputs.dittoVersion }} | cut -d. -f-2)" >> $GITHUB_ENV
-          echo "IMAGE_MAJOR_TAG=$(echo ${{ inputs.dittoVersion }} | cut -d. -f-1)" >> $GITHUB_ENV
-          echo "MILESTONE_OR_RC_SUFFIX=$(echo ${{ inputs.dittoVersion }} | cut -d- -f2)" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$DITTO_VERSION_INPUT" >> $GITHUB_ENV
+          echo "IMAGE_MINOR_TAG=$(echo "$DITTO_VERSION_INPUT" | cut -d. -f-2)" >> $GITHUB_ENV
+          echo "IMAGE_MAJOR_TAG=$(echo "$DITTO_VERSION_INPUT" | cut -d. -f-1)" >> $GITHUB_ENV
+          echo "MILESTONE_OR_RC_SUFFIX=$(echo "$DITTO_VERSION_INPUT" | cut -d- -f2)" >> $GITHUB_ENV
       -
         name: Building Docker images for tag
         run: |

--- a/.github/workflows/push-dockerhub-on-demand.yml
+++ b/.github/workflows/push-dockerhub-on-demand.yml
@@ -35,15 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+      -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3 # setup buildx in order to do build and push multi-architecture images
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 # setup buildx in order to do build and push multi-architecture images
       -
         name: Inspect buildx builder
         run: |
@@ -54,7 +59,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: eclipsedittobot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -77,7 +82,7 @@ jobs:
       -
         name: Build and push ditto-policies
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-policies'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -96,7 +101,7 @@ jobs:
       -
         name: Build and push ditto-things
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-things'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -115,7 +120,7 @@ jobs:
       -
         name: Build and push ditto-gateway
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-gateway'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -134,7 +139,7 @@ jobs:
       -
         name: Build and push ditto-thingsearch
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-things-search'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -153,7 +158,7 @@ jobs:
       -
         name: Build and push ditto-connectivity
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-connectivity'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -172,7 +177,7 @@ jobs:
             eclipse/ditto-connectivity:latest
       -
         name: Use Node.js 18.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       -
@@ -186,7 +191,7 @@ jobs:
       -
         name: Build and push ditto-ui
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-ui'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: ./ui
           file: ui/Dockerfile
@@ -201,7 +206,7 @@ jobs:
       -
         name: Build and push ditto-policies milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-policies'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -217,7 +222,7 @@ jobs:
       -
         name: Build and push ditto-things milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-things'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -233,7 +238,7 @@ jobs:
       -
         name: Build and push ditto-gateway milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-gateway'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -249,7 +254,7 @@ jobs:
       -
         name: Build and push ditto-thingsearch milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-things-search'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -265,7 +270,7 @@ jobs:
       -
         name: Build and push ditto-connectivity milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-connectivity'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -282,7 +287,7 @@ jobs:
       -
         name: Build and push ditto-ui milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-ui'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: ./ui
           file: ui/Dockerfile

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -27,6 +27,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -15,6 +15,9 @@ on:
     tags:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -20,15 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+      -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3 # setup buildx in order to do build and push multi-architecture images
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0 # setup buildx in order to do build and push multi-architecture images
       -
         name: Inspect buildx builder
         run: |
@@ -39,7 +44,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: eclipsedittobot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -62,7 +67,7 @@ jobs:
       -
         name: Build and push ditto-policies
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -81,7 +86,7 @@ jobs:
       -
         name: Build and push ditto-things
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -100,7 +105,7 @@ jobs:
       -
         name: Build and push ditto-gateway
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -119,7 +124,7 @@ jobs:
       -
         name: Build and push ditto-thingsearch
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -138,7 +143,7 @@ jobs:
       -
         name: Build and push ditto-connectivity
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -157,7 +162,7 @@ jobs:
             eclipse/ditto-connectivity:latest
       -
         name: Use Node.js 18.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       -
@@ -171,7 +176,7 @@ jobs:
       -
         name: Build and push ditto-ui
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: ./ui
           file: ui/Dockerfile
@@ -186,7 +191,7 @@ jobs:
       -
         name: Build and push ditto-policies milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -202,7 +207,7 @@ jobs:
       -
         name: Build and push ditto-things milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -218,7 +223,7 @@ jobs:
       -
         name: Build and push ditto-gateway milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -234,7 +239,7 @@ jobs:
       -
         name: Build and push ditto-thingsearch milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -250,7 +255,7 @@ jobs:
       -
         name: Build and push ditto-connectivity milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           file: dockerfile-release
@@ -267,7 +272,7 @@ jobs:
       -
         name: Build and push ditto-ui milestone/RC
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: ./ui
           file: ui/Dockerfile

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -98,6 +98,7 @@ jobs:
           ref: ${{ env.DITTO_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ditto
+          persist-credentials: false
 
       - name: Checkout ditto-testing repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,6 +107,7 @@ jobs:
           ref: ${{ env.DITTO_TESTING_BRANCH }}
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ditto-testing
+          persist-credentials: false
 
       - name: Checkout ditto-clients repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -114,6 +116,7 @@ jobs:
           ref: 'master'
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ditto-clients
+          persist-credentials: false
 
       - name: Set up JDK 25
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,9 +54,16 @@ run-name: >-
   System Tests • ${{ inputs.ditto_repo }}@${{ inputs.ditto_branch }}
   • ${{ inputs.ditto_testing_repo }}@${{ inputs.ditto_testing_branch }}
 
+permissions:
+  contents: read
+
 jobs:
   system-tests:
     runs-on: ditto-runner
+    permissions:
+      contents: read
+      # required by dorny/test-reporter to publish results to the GitHub Checks API
+      checks: write
     env:
       DITTO_BRANCH: ${{ github.event.inputs.ditto_branch }}
       DITTO_REPO: ${{ github.event.inputs.ditto_repo }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -92,7 +92,7 @@ jobs:
             echo "EXTRA_DOCKER_ARGS: ${{ env.EXTRA_DOCKER_ARGS }}"
 
       - name: Checkout Ditto code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{env.DITTO_REPO }}
           ref: ${{ env.DITTO_BRANCH }}
@@ -100,7 +100,7 @@ jobs:
           path: ditto
 
       - name: Checkout ditto-testing repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ env.DITTO_TESTING_REPO }}
           ref: ${{ env.DITTO_TESTING_BRANCH }}
@@ -108,7 +108,7 @@ jobs:
           path: ditto-testing
 
       - name: Checkout ditto-clients repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: 'eclipse-ditto/ditto-clients'
           ref: 'master'
@@ -116,7 +116,7 @@ jobs:
           path: ditto-clients
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           distribution: 'temurin'
           cache: 'maven'
@@ -205,7 +205,7 @@ jobs:
             -e DITTO_VERSION=$DITTO_VERSION \
             -e FORK_COUNT=$FORK_COUNT \
              ${{ env.EXTRA_DOCKER_ARGS || '' }} \
-             maven:3.9.12-eclipse-temurin-25 \
+             maven:3.9.12-eclipse-temurin-25@sha256:4f82a03a7d6679281952d628131299b1be88d7030a49c6a2b7d2ba2642e44e3e \
             mvn verify -am -amd --batch-mode --errors \
                 --projects=:system \
                 -Dtest.environment=docker-compose \
@@ -244,7 +244,7 @@ jobs:
           -e DITTO_VERSION=$DITTO_VERSION \
           -e FORK_COUNT=$FORK_COUNT \
           ${{ env.EXTRA_DOCKER_ARGS || '' }} \
-          maven:3.9.12-eclipse-temurin-25 \
+          maven:3.9.12-eclipse-temurin-25@sha256:4f82a03a7d6679281952d628131299b1be88d7030a49c6a2b7d2ba2642e44e3e \
           mvn verify -am -amd --batch-mode --errors --update-snapshots \
               --projects=:sync-completely-enabled \
               -Dtest.environment=docker-compose \
@@ -286,7 +286,7 @@ jobs:
           -e DITTO_VERSION=$DITTO_VERSION \
           -e FORK_COUNT=$FORK_COUNT \
           ${{ env.EXTRA_DOCKER_ARGS || '' }} \
-          maven:3.9.12-eclipse-temurin-25 \
+          maven:3.9.12-eclipse-temurin-25@sha256:4f82a03a7d6679281952d628131299b1be88d7030a49c6a2b7d2ba2642e44e3e \
           mvn verify -am -amd --batch-mode --errors --update-snapshots \
               --projects=:sync-event-processing-enabled \
               -Dtest.environment=docker-compose \
@@ -330,7 +330,7 @@ jobs:
           -e DITTO_VERSION=$DITTO_VERSION \
           -e FORK_COUNT=$FORK_COUNT \
           ${{ env.EXTRA_DOCKER_ARGS || '' }} \
-          maven:3.9.12-eclipse-temurin-25 \
+          maven:3.9.12-eclipse-temurin-25@sha256:4f82a03a7d6679281952d628131299b1be88d7030a49c6a2b7d2ba2642e44e3e \
           mvn verify -am -amd --batch-mode --errors --update-snapshots \
               --projects=:sync-tags-streaming-enabled \
               -Dtest.environment=docker-compose \
@@ -353,14 +353,14 @@ jobs:
 
       - name: Upload test results
         if:  env.GITHUB_ACTOR != 'nektos/act'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: system-test-results-${{ env.DITTO_BRANCH_NO_SLASH }}-${{ github.run_number }}
           path: 'ditto-testing/system*/**/target/failsafe-reports/**/*.xml'
           
       - name: Upload services logs
         if:  env.GITHUB_ACTOR != 'nektos/act'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: system-services-logs
           path: 'ditto-testing/docker/*.log'
@@ -372,7 +372,7 @@ jobs:
         working-directory: ditto-testing
 
       - name: Publish Test Results
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2.7.0
         with:
           name: Test Results | ${{ env.DITTO_BRANCH_NO_SLASH }} ${{ github.run_number }}
           path: ./system*/**/target/failsafe-reports/TEST*.xml

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -26,9 +26,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Install npm dependencies

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -32,6 +32,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js 18.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -21,6 +21,9 @@ on:
     paths:
       - 'ui/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+name: zizmor workflow lint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Advisory mode: findings are uploaded to the GitHub Security tab via
+      # SARIF (advanced-security: true by default in the action) but do NOT
+      # fail the build. Existing findings (permissions, template-injection,
+      # etc.) will be addressed in follow-up PRs. Once cleaned up, remove
+      # continue-on-error to make this a gating check.
+      - name: Run zizmor
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -43,11 +43,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Advisory mode: findings are uploaded to the GitHub Security tab via
-      # SARIF (advanced-security: true by default in the action) but do NOT
-      # fail the build. Existing findings (permissions, template-injection,
-      # etc.) will be addressed in follow-up PRs. Once cleaned up, remove
-      # continue-on-error to make this a gating check.
+      # Gating check: SARIF findings are uploaded to the GitHub Security tab
+      # (advanced-security: true by default in the action) AND fail the build.
+      # If new findings appear from legitimate workflow changes, fix them or
+      # add a scoped `# zizmor: ignore[<rule>]` comment with justification.
       - name: Run zizmor
-        continue-on-error: true
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# zizmor configuration — scoped suppressions with written justification.
+# https://docs.zizmor.sh/configuration/
+#
+# This file lists findings we have knowingly accepted. Every entry must be
+# justified. Do NOT add new entries without a comment explaining the reason.
+
+rules:
+  cache-poisoning:
+    ignore:
+      # PR/build-validation workflows: run on pull_request and push to master
+      # but do NOT publish artifacts to any registry. A poisoned cache cannot
+      # leak into released images because these workflows don't build images.
+      - maven.yml
+      - ui-ci.yml
+
+      # Release/publish workflows: setup-node is invoked without a `cache:`
+      # input, so caching is not enabled on this step. Zizmor flags the
+      # action defensively because it is cache-capable; the actual runtime
+      # behaviour does not populate or restore any cache here.
+      - docker-nightly.yml
+      - push-dockerhub.yml
+      - push-dockerhub-on-demand.yml


### PR DESCRIPTION
**Background**                                                                                                                                                                                                                      
                                                                                                                                                                                                                                  
  The https://www.stepsecurity.io/blog/harden-runner-detection-aqua-security-trivy-action-supply-chain-attack — where an attacker force-pushed 76 of 77 version tags in aquasecurity/trivy-action to malicious commits — showed that any CI workflow consuming third-party actions by mutable reference (tags, branches) is one upstream compromise away from shipping attacker code. Ditto's workflows were in that category.                                  
                                                                                                                                                                                                                                  
  This PR applies the hardening baseline recommended by the Eclipse Foundation Security Team in https://blog.mbarbero.com/ (Mikaël Barbero, 2026-03-24), adapted to Ditto's specific workflows.                                   
   
  **What changed**                                                                                                                                                                                                                    
                                                            
  1. Every third-party action pinned to commit SHA. 17 distinct actions across 10 workflows. Each uses: owner/name@vX is now uses: owner/name@<full-40-char-sha> # <exact-semver>. SHAs resolved and verified with https://github.com/suzuki-shunsuke/pinact (the tool cited in the Eclipse blog post) — not by hand. A tag can be silently repointed; a SHA cannot.
                                                                                                                                                                                                                                  
  2. .github/dependabot.yml added. Weekly github-actions ecosystem updates, grouped into a single PR, with a 7-day cooldown so we don't adopt a compromised release during the first 24 hours of an incident. Config matches the  Eclipse security team's template verbatim.
                                                                                                                                                                                                                                  
  ▎ Dependabot still needs to be enabled at the repo level (Settings → Security → Dependabot). The file alone is not enough — Eclipse Foundation admins can flip this on.                                                         
   
  3. step-security/harden-runner added in audit mode to every GitHub-hosted job (9 workflows, 11 jobs). Records network egress and file modifications without blocking. Had this been active during the Trivy incident, exfiltration to the typo-squatted scan.aquasecurtiy.org domain would have been immediately visible. The self-hosted ditto-runner job in system-tests.yml is intentionally excluded — harden-runner is designed for GitHub-hosted runners and needs runner-owner validation before enabling.                                                                                                                                                                     
                                                            
  4. Docker image pinned by digest. maven:3.9.12-eclipse-temurin-25 → maven:3.9.12-eclipse-temurin-25@sha256:4f82a03a... in all 4 uses in system-tests.yml. Container tags have the same mutability problem as action tags.       
   
  5. Supply-chain linters added/run:                                                                                                                                                                                              
  - https://github.com/boostsecurityio/poutine run locally: zero failures on unpinnable_action, injection, default_permissions_on_risky_events, known_vulnerability_in_build_component, and all other blocking rules. The 6  note-level findings are informational flags on unverified-creator actions (dorny, helm, jitterbit, peaceiris) — widely used but not on GitHub's Marketplace verified list. No action required.                                  
  - [zizmor](https://github.com/zizmorcore/zizmor) added as a new CI job (`.github/workflows/zizmor.yml`). Runs on every PR (and push to `master`) that touches  `.github/workflows/**` or `.github/dependabot.yml`, uploads SARIF to the GitHub Security tab, and is **gating** — the action fails CI on new findings. Accepted findings  are tracked in `.github/zizmor.yml` with a written justification per entry (currently: scoped `cache-poisoning` suppressions for workflows that don't publish artifacts or don't populate a cache). This complements harden-runner: zizmor catches issues at lint time, harden-runner catches anomalies at runtime.
   6. **Default `GITHUB_TOKEN` permissions narrowed to read-only.** Every workflow now declares an explicit top-level `permissions: contents: read` block, with job-level  elevation only where actually needed: `gh-pages.yml` keeps `contents: write` on the deploy job (publishes to the `gh-pages` branch), and `system-tests.yml` adds `checks:  write` on its single job (required by `dorny/test-reporter` to publish results to the Checks API). The DockerHub publishers (`push-dockerhub*.yml`, `helm-chart-release.yml`, `docker-nightly.yml`) need no elevation — they auth to Docker Hub via `DOCKER_HUB_TOKEN`, not `GITHUB_TOKEN`. This clears 12 medium-severity  `excessive-permissions` findings from zizmor and makes least-privilege explicit at the file level rather than relying on the org/repo default.