### PR TITLE
Add transitiveImports for selective multi-level policy import resolution

### DIFF
--- a/documentation/src/main/resources/jsonschema/policy.json
+++ b/documentation/src/main/resources/jsonschema/policy.json
@@ -57,6 +57,15 @@
                   }
                 }
               }
+            },
+            "transitiveImports": {
+              "title": "Transitive imports",
+              "type": "array",
+              "description": "List of policy IDs from the imported policy's own imports that should be resolved transitively before extracting entries. This enables multi-level import chains where a template policy defines resources and an intermediate policy adds subjects via entriesAdditions.",
+              "items": {
+                "type": "string",
+                "description": "Policy ID of a policy that the imported policy itself imports from."
+              }
             }
           }
         }

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -7618,6 +7618,141 @@ paths:
                 $ref: '#/components/schemas/AdvancedError'
         '412':
           $ref: '#/components/responses/PreconditionFailed'
+  '/api/2/policies/{policyId}/imports/{importedPolicyId}/transitiveImports':
+    get:
+      summary: Retrieve the transitive resolution policy IDs of a specific policy import
+      description: |-
+        Returns the "transitiveImports" array of the policy import identified by the `policyId` path
+        parameter and the `importedPolicyId` path parameter.
+
+        The array lists policy IDs from the imported policy's own imports that should be resolved
+        transitively before extracting entries. This enables multi-level import chains.
+      tags:
+        - Policies
+      parameters:
+        - $ref: '#/components/parameters/PolicyIdPathParam'
+        - $ref: '#/components/parameters/ImportedPolicyIdPathParam'
+        - $ref: '#/components/parameters/IfMatchHeaderParamHash'
+        - $ref: '#/components/parameters/IfNoneMatchHeaderParam'
+        - $ref: '#/components/parameters/TimeoutParam'
+      responses:
+        '200':
+          description: The request successfully returned. The transitiveImports array is returned.
+          headers:
+            ETag:
+              description: |-
+                The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+                "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransitiveImports'
+        '304':
+          $ref: '#/components/responses/NotModified'
+        '400':
+          description: |-
+            The request could not be completed. Possible reasons:
+
+              * the `policyId` or the `importedPolicyId` does not conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.dev/ditto/basic-namespaces-and-names.html#namespaced-id))
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '401':
+          description: The request could not be completed due to missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '404':
+          description: |-
+            The request could not be completed. The policy with the given ID or
+            the policy import was not found in the context of the authenticated
+            user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
+    put:
+      summary: Modify the transitive resolution policy IDs of a specific policy import
+      description: |-
+        Modify the "transitiveImports" array of the policy import identified by the `policyId` path
+        parameter and the `importedPolicyId` path parameter.
+
+        The array lists policy IDs from the imported policy's own imports that should be resolved
+        transitively before extracting entries.
+      tags:
+        - Policies
+      parameters:
+        - $ref: '#/components/parameters/PolicyIdPathParam'
+        - $ref: '#/components/parameters/ImportedPolicyIdPathParam'
+        - $ref: '#/components/parameters/IfMatchHeaderParamHash'
+        - $ref: '#/components/parameters/IfNoneMatchHeaderParam'
+        - $ref: '#/components/parameters/IfEqualHeaderParam'
+        - $ref: '#/components/parameters/TimeoutParam'
+        - $ref: '#/components/parameters/ResponseRequiredParam'
+      responses:
+        '204':
+          description: The transitiveImports array was successfully updated.
+          headers:
+            ETag:
+              description: |-
+                The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+                "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+              schema:
+                type: string
+        '400':
+          description: |-
+            The request could not be completed. Possible reasons:
+
+              * the `policyId` or the `importedPolicyId` does not conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.dev/ditto/basic-namespaces-and-names.html#namespaced-id))
+              * the JSON body is not a valid JSON array of policy ID strings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '401':
+          description: The request could not be completed due to missing authentication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '403':
+          description: |-
+            The request could not be completed. Possible reasons:
+            * the caller has insufficient permissions.
+              You need `WRITE` permission on the `policy:/imports/{importedPolicyId}` resource,
+              without any revoke in a deeper path of the policy resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '404':
+          description: |-
+            The request could not be completed. The policy with the given ID or
+            the policy import was not found in the context of the authenticated
+            user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvancedError'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
+        '413':
+          $ref: '#/components/responses/EntityTooLarge'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitiveImports'
+            example:
+              - 'org.eclipse.ditto:policy-template'
+        description: JSON array of policy IDs to resolve transitively.
+        required: true
   '/api/2/policies/{policyId}/importsAliases':
     get:
       summary: Retrieve all imports aliases of a policy
@@ -11071,6 +11206,10 @@ components:
       properties:
         entries:
           $ref: '#/components/schemas/PolicyEntries'
+        imports:
+          $ref: '#/components/schemas/PolicyImports'
+        importsAliases:
+          $ref: '#/components/schemas/ImportsAliases'
       required:
         - entries
     Policy:
@@ -11084,6 +11223,8 @@ components:
           $ref: '#/components/schemas/PolicyEntries'
         imports:
           $ref: '#/components/schemas/PolicyImports'
+        importsAliases:
+          $ref: '#/components/schemas/ImportsAliases'
       required:
         - policyId
         - entries
@@ -11120,6 +11261,8 @@ components:
             description: Label of a policy entry to import from the referenced policy.
         entriesAdditions:
           $ref: '#/components/schemas/EntriesAdditions'
+        transitiveImports:
+          $ref: '#/components/schemas/TransitiveImports'
       example:
         entries:
           - default
@@ -11323,6 +11466,20 @@ components:
             grant:
               - READ
             revoke: []
+    TransitiveImports:
+      type: array
+      description: |-
+        List of policy IDs from the imported policy's own imports that should be resolved transitively
+        before extracting entries. This enables multi-level import chains where a template policy defines
+        resources and an intermediate policy adds subjects via "entriesAdditions".
+
+        Each entry is the policy ID of a policy that the directly imported policy itself imports from.
+        Only the listed policy IDs are resolved — this is an explicit whitelist, not a recursive flag.
+      items:
+        type: string
+        description: Policy ID of a policy that the imported policy itself imports from.
+      example:
+        - 'org.eclipse.ditto:policy-template'
     ImportsAliases:
       type: object
       description: |-

--- a/documentation/src/main/resources/openapi/sources/api-2-index.yml
+++ b/documentation/src/main/resources/openapi/sources/api-2-index.yml
@@ -145,6 +145,8 @@ paths:
     $ref: "./paths/policies/entriesAdditions.yml"
   '/api/2/policies/{policyId}/imports/{importedPolicyId}/entriesAdditions/{label}':
     $ref: "./paths/policies/entryAddition.yml"
+  '/api/2/policies/{policyId}/imports/{importedPolicyId}/transitiveImports':
+    $ref: "./paths/policies/transitiveImports.yml"
   '/api/2/policies/{policyId}/importsAliases':
     $ref: "./paths/policies/importsAliases.yml"
   '/api/2/policies/{policyId}/importsAliases/{label}':
@@ -443,6 +445,8 @@ components:
       $ref: "./schemas/policies/entriesAdditions.yml"
     EntryAddition:
       $ref: "./schemas/policies/entryAddition.yml"
+    TransitiveImports:
+      $ref: "./schemas/policies/transitiveImports.yml"
     ImportsAliases:
       $ref: "./schemas/policies/importsAliases.yml"
     ImportsAlias:

--- a/documentation/src/main/resources/openapi/sources/paths/policies/transitiveImports.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/policies/transitiveImports.yml
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+get:
+  summary: Retrieve the transitive resolution policy IDs of a specific policy import
+  description: |-
+    Returns the "transitiveImports" array of the policy import identified by the `policyId` path
+    parameter and the `importedPolicyId` path parameter.
+
+    The array lists policy IDs from the imported policy's own imports that should be resolved
+    transitively before extracting entries. This enables multi-level import chains.
+  tags:
+    - Policies
+  parameters:
+    - $ref: '../../parameters/policyIdPathParam.yml'
+    - $ref: '../../parameters/importedPolicyIdPathParam.yml'
+    - $ref: '../../parameters/ifMatchHeaderParamHash.yml'
+    - $ref: '../../parameters/ifNoneMatchHeaderParam.yml'
+    - $ref: '../../parameters/timeoutParam.yml'
+  responses:
+    '200':
+      description: The request successfully returned. The transitiveImports array is returned.
+      headers:
+        ETag:
+          description: |-
+            The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+            "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/policies/transitiveImports.yml'
+    '304':
+      $ref: '../../responses/notModified.yml'
+    '400':
+      description: |-
+        The request could not be completed. Possible reasons:
+
+          * the `policyId` or the `importedPolicyId` does not conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.dev/ditto/basic-namespaces-and-names.html#namespaced-id))
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '401':
+      description: The request could not be completed due to missing authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '404':
+      description: |-
+        The request could not be completed. The policy with the given ID or
+        the policy import was not found in the context of the authenticated
+        user.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
+put:
+  summary: Modify the transitive resolution policy IDs of a specific policy import
+  description: |-
+    Modify the "transitiveImports" array of the policy import identified by the `policyId` path
+    parameter and the `importedPolicyId` path parameter.
+
+    The array lists policy IDs from the imported policy's own imports that should be resolved
+    transitively before extracting entries.
+  tags:
+    - Policies
+  parameters:
+    - $ref: '../../parameters/policyIdPathParam.yml'
+    - $ref: '../../parameters/importedPolicyIdPathParam.yml'
+    - $ref: '../../parameters/ifMatchHeaderParamHash.yml'
+    - $ref: '../../parameters/ifNoneMatchHeaderParam.yml'
+    - $ref: '../../parameters/ifEqualHeaderParam.yml'
+    - $ref: '../../parameters/timeoutParam.yml'
+    - $ref: '../../parameters/responseRequiredParam.yml'
+  responses:
+    '204':
+      description: The transitiveImports array was successfully updated.
+      headers:
+        ETag:
+          description: |-
+            The (current server-side) ETag for this (sub-)resource. For top-level resources it is in the format
+            "rev:[revision]", for sub-resources it has the format "hash:[calculated-hash]".
+          schema:
+            type: string
+    '400':
+      description: |-
+        The request could not be completed. Possible reasons:
+
+          * the `policyId` or the `importedPolicyId` does not conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.dev/ditto/basic-namespaces-and-names.html#namespaced-id))
+          * the JSON body is not a valid JSON array of policy ID strings
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '401':
+      description: The request could not be completed due to missing authentication.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '403':
+      description: |-
+        The request could not be completed. Possible reasons:
+        * the caller has insufficient permissions.
+          You need `WRITE` permission on the `policy:/imports/{importedPolicyId}` resource,
+          without any revoke in a deeper path of the policy resource.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '404':
+      description: |-
+        The request could not be completed. The policy with the given ID or
+        the policy import was not found in the context of the authenticated
+        user.
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/errors/advancedError.yml'
+    '412':
+      $ref: '../../responses/preconditionFailed.yml'
+    '413':
+      $ref: '../../responses/entityTooLarge.yml'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../schemas/policies/transitiveImports.yml'
+        example:
+          - "org.eclipse.ditto:policy-template"
+    description: |-
+      JSON array of policy IDs to resolve transitively.
+    required: true

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/newPolicy.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/newPolicy.yml
@@ -13,5 +13,9 @@ description: Policy consisting of policy entries
 properties:
   entries:
     $ref: 'policyEntries.yml'
+  imports:
+    $ref: 'policyImports.yml'
+  importsAliases:
+    $ref: 'importsAliases.yml'
 required:
   - entries

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/policy.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/policy.yml
@@ -18,6 +18,8 @@ properties:
     $ref: 'policyEntries.yml'
   imports:
     $ref: 'policyImports.yml'
+  importsAliases:
+    $ref: 'importsAliases.yml'
 required:
   - policyId
   - entries

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/policyImport.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/policyImport.yml
@@ -23,6 +23,8 @@ properties:
       description: Label of a policy entry to import from the referenced policy.
   entriesAdditions:
     $ref: 'entriesAdditions.yml'
+  transitiveImports:
+    $ref: 'transitiveImports.yml'
 example:
   entries: [ "default", "import" ]
   entriesAdditions:

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/transitiveImports.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/transitiveImports.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+type: array
+description: |-
+  List of policy IDs from the imported policy's own imports that should be resolved transitively
+  before extracting entries. This enables multi-level import chains where a template policy defines
+  resources and an intermediate policy adds subjects via "entriesAdditions".
+
+  Each entry is the policy ID of a policy that the directly imported policy itself imports from.
+  Only the listed policy IDs are resolved — this is an explicit whitelist, not a recursive flag.
+items:
+  type: string
+  description: Policy ID of a policy that the imported policy itself imports from.
+example:
+  - "org.eclipse.ditto:policy-template"

--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -708,8 +708,20 @@ labels are rewritten with import prefixes (e.g., `ROLE` becomes `imported:<D-id>
 * The listed policy IDs must be imports of the directly imported policy. Non-matching IDs are silently
   ignored.
 * The importing policy's own ID **must not** appear in `transitiveImports` (cycle prevention).
+  Cross-policy cycles (e.g., A→B→C→A) are **not** detected at write time because detection would
+  require loading the full transitive graph on every PUT. Instead, cycles are broken gracefully at
+  resolution time via a visited set and a depth limit (max 10 levels). If the depth limit is reached,
+  resolution stops and returns the entries resolved so far.
 * Transitive policy IDs are tracked in the search index (`__referencedPolicies`), so changes to the
   template policy trigger re-indexing of all dependent things.
+* **Label collisions:** If the directly imported policy transitively imports two policies that both
+  export an entry with the same label (e.g., both export `X`), both entries survive resolution and
+  produce entries with the same prefixed label (e.g., `imported:<B-id>/X`). The resulting policy will
+  contain both entries, with the first-encountered entry taking precedence during merge. To avoid
+  confusion, use distinct entry labels across imported policies in the same chain.
+* **Lenient transitive IDs:** Policy IDs listed in `transitiveImports` that do not match any of the
+  directly imported policy's actual imports are silently ignored at resolution time. This allows
+  forward references (the intermediate policy's import may be added later).
 
 The `transitiveImports` array is managed via dedicated API endpoints:
 * `GET/PUT /api/2/policies/{id}/imports/{importedPolicyId}/transitiveImports`

--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -583,6 +583,137 @@ The entries of the importing policy and the entries of the imported policy are m
 {% include note.html content="The sanity check, ensuring that at least one subject has WRITE permission on the policy's root resource, is *not* applied for policies defining policy imports. So pay attention that you don't lock yourself out when creating/modifying such policies."
 %}
 
+### Transitive import resolution
+
+By default, policy imports are resolved one level deep: if policy A imports from policy B, A gets B's
+inline entries only. If B itself imports entries from policy C, those entries are **not** visible to A.
+
+The `transitiveImports` field on a policy import enables selective multi-level resolution. It contains
+an explicit list of policy IDs that the directly imported policy itself imports from, which should be
+resolved before extracting entries.
+
+#### Why `transitiveImports` requires `entriesAdditions`
+
+Transitive import resolution is a natural complement to `entriesAdditions` — and would be meaningless
+without it. Before `entriesAdditions`, imported entries were always taken as-is from the imported
+policy's persisted entries. There was no mechanism for an intermediate policy to *add* anything to entries
+it imported from elsewhere, so resolving through it would yield nothing beyond what a direct import
+already provides.
+
+`entriesAdditions` changes this by allowing an intermediate policy to hold **per-import state** (subjects,
+resources, namespaces) that only materializes during resolution. For example, a global template defines
+roles with resources, and each regional policy adds its own subjects via `entriesAdditions`. Those
+subjects are not part of the template's persisted entries — they exist only in the intermediate policy's
+import configuration and are applied when that intermediate policy resolves its own import.
+
+A consuming policy that directly imports the global template gets the raw entries (empty subjects).
+A consuming policy that directly imports the intermediate policy gets nothing (its inline entries are
+empty). Only by resolving *through* the intermediate policy — which is what `transitiveImports`
+does — can the consuming policy obtain the combined result: template resources merged with the
+intermediate policy's subject additions.
+
+#### Use case: template-based policy hierarchies
+
+A typical three-level hierarchy:
+
+**1. Global template** (`acme:fleet-roles`) defines roles with resources and `allowedImportAdditions`:
+
+```json
+{
+  "policyId": "acme:fleet-roles",
+  "entries": {
+    "driver": {
+      "subjects": {},
+      "resources": {
+        "thing:/features/location": { "grant": ["READ"], "revoke": [] },
+        "thing:/features/fuel": { "grant": ["READ"], "revoke": [] },
+        "message:/features/fuel/inbox": { "grant": ["WRITE"], "revoke": [] }
+      },
+      "namespaces": ["acme.vehicle"],
+      "allowedImportAdditions": ["subjects"],
+      "importable": "implicit"
+    }
+  }
+}
+```
+
+**2. Regional fleet policy** (`acme:fleet-west`) imports the template and adds drivers via
+`entriesAdditions`:
+
+```json
+{
+  "policyId": "acme:fleet-west",
+  "imports": {
+    "acme:fleet-roles": {
+      "entriesAdditions": {
+        "driver": {
+          "subjects": {
+            "oauth2:alice@acme.com": { "type": "employee" },
+            "oauth2:bob@acme.com": { "type": "employee" }
+          }
+        }
+      }
+    }
+  },
+  "entries": {}
+}
+```
+
+**3. Vehicle policy** needs the `driver` entry with resources from the template AND subjects from the
+fleet policy. It uses `transitiveImports` to resolve through the intermediate policy:
+
+```json
+{
+  "policyId": "acme.vehicle:truck-42",
+  "imports": {
+    "acme:fleet-west": {
+      "entries": ["driver"],
+      "transitiveImports": ["acme:fleet-roles"]
+    }
+  }
+}
+```
+
+At resolution time:
+1. The directly imported policy `fleet-west` is loaded (its inline entries are empty)
+2. Because `transitiveImports` lists `fleet-roles`, that import on `fleet-west` is resolved first
+3. `fleet-roles`'s `driver` entry is merged into `fleet-west`, applying `fleet-west`'s
+   `entriesAdditions` (subjects Alice and Bob)
+4. The vehicle policy then extracts `driver` from the enriched result — getting both the resources from
+   the template and the subjects from the fleet policy
+
+Without `transitiveImports`, this composition would be impossible: a direct import of `fleet-roles`
+yields the entry without subjects, and a direct import of `fleet-west` yields nothing (no inline entries).
+
+#### Deeper nesting
+
+`transitiveImports` supports chains deeper than two levels. If each level in the chain declares its own
+`transitiveImports`, the resolution recurses naturally. For example, A → B → C → D works when:
+* A's import of B has `transitiveImports: ["C"]`
+* B's import of C has `transitiveImports: ["D"]`
+* C's import of D has `entriesAdditions` (adding subjects)
+* D has inline entries (the template)
+
+An important consequence: **`entriesAdditions` are applied at the level that declares them, not at higher
+levels.** In the chain above, C's `entriesAdditions` are applied when resolving C's import of D. The
+`transitiveImports` at B and A merely open the doors so that resolution can reach down to where the
+additions are declared. A higher-level policy (e.g., B) cannot use its own `entriesAdditions` to target
+entries that were transitively resolved at a lower level, because after transitive resolution the entry
+labels are rewritten with import prefixes (e.g., `ROLE` becomes `imported:<D-id>/ROLE`).
+
+#### Key rules
+
+* `transitiveImports` is an explicit **whitelist** — only the listed policy IDs are resolved. This is
+  not a recursive flag; it prevents surprise permission expansion and keeps the dependency graph auditable.
+* The listed policy IDs must be imports of the directly imported policy. Non-matching IDs are silently
+  ignored.
+* The importing policy's own ID **must not** appear in `transitiveImports` (cycle prevention).
+* Transitive policy IDs are tracked in the search index (`__referencedPolicies`), so changes to the
+  template policy trigger re-indexing of all dependent things.
+
+The `transitiveImports` array is managed via dedicated API endpoints:
+* `GET/PUT /api/2/policies/{id}/imports/{importedPolicyId}/transitiveImports`
+
 ### Limitations
 
 When managing and using policy imports the following limitations apply:

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyImportsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyImportsRoute.java
@@ -14,12 +14,16 @@ package org.eclipse.ditto.gateway.service.endpoints.routes.policies;
 
 import static org.eclipse.ditto.base.model.exceptions.DittoJsonException.wrapJsonRuntimeException;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.model.EntriesAdditions;
 import org.eclipse.ditto.policies.model.EntryAddition;
 import org.eclipse.ditto.policies.model.ImportedLabels;
@@ -35,11 +39,13 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImpo
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntries;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesAdditions;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntryAddition;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportTransitiveImports;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntries;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntriesAdditions;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntryAddition;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportTransitiveImports;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImports;
 
 import org.apache.pekko.http.javadsl.server.PathMatchers;
@@ -53,6 +59,7 @@ final class PolicyImportsRoute extends AbstractRoute {
 
     private static final String PATH_SUFFIX_ENTRIES = "entries";
     private static final String PATH_SUFFIX_ENTRIES_ADDITIONS = "entriesAdditions";
+    private static final String PATH_SUFFIX_TRANSITIVE_IMPORTS = "transitiveImports";
 
     /**
      * Constructs the {@code /imports} route builder.
@@ -76,6 +83,7 @@ final class PolicyImportsRoute extends AbstractRoute {
                 policyImportEntries(ctx, dittoHeaders, policyId),
                 policyImportEntriesAdditions(ctx, dittoHeaders, policyId),
                 policyImportEntriesAdditionsEntry(ctx, dittoHeaders, policyId),
+                policyImportTransitiveImports(ctx, dittoHeaders, policyId),
                 policyImport(ctx, dittoHeaders, policyId)
         );
     }
@@ -241,6 +249,49 @@ final class PolicyImportsRoute extends AbstractRoute {
     private static EntryAddition createEntryAdditionForPut(final String jsonString, final CharSequence label) {
         final JsonObject jsonObject = wrapJsonRuntimeException(() -> JsonFactory.newObject(jsonString));
         return PoliciesModelFactory.newEntryAddition(Label.of(label), jsonObject);
+    }
+
+    /*
+     * Describes {@code /imports/<importedPolicyId>/transitiveImports} route.
+     */
+    private Route policyImportTransitiveImports(final RequestContext ctx, final DittoHeaders dittoHeaders,
+            final PolicyId policyId) {
+
+        return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), importedPolicyId ->
+                rawPathPrefix(PathMatchers.slash().concat(PATH_SUFFIX_TRANSITIVE_IMPORTS), () ->
+                        pathEndOrSingleSlash(() ->
+                                concat(
+                                        get(() -> // GET /imports/<importedPolicyId>/transitiveImports
+                                                handlePerRequest(ctx,
+                                                        RetrievePolicyImportTransitiveImports.of(policyId,
+                                                                PolicyId.of(importedPolicyId), dittoHeaders))
+                                        ),
+                                        put(() -> // PUT /imports/<importedPolicyId>/transitiveImports
+                                                ensureMediaTypeJsonWithFallbacksThenExtractDataBytes(ctx,
+                                                        dittoHeaders,
+                                                        payloadSource ->
+                                                                handlePerRequest(ctx, dittoHeaders,
+                                                                        payloadSource,
+                                                                        transitiveImportsJson ->
+                                                                                ModifyPolicyImportTransitiveImports.of(
+                                                                                        policyId,
+                                                                                        PolicyId.of(importedPolicyId),
+                                                                                        createTransitiveImportsForPut(transitiveImportsJson),
+                                                                                        dittoHeaders)))
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+
+    private static List<PolicyId> createTransitiveImportsForPut(final String jsonString) {
+        final JsonArray jsonArray = wrapJsonRuntimeException(() -> JsonFactory.newArray(jsonString));
+        return jsonArray.stream()
+                .filter(JsonValue::isString)
+                .map(JsonValue::asString)
+                .map(PolicyId::of)
+                .collect(Collectors.toList());
     }
 
     /*

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyImportsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyImportsRoute.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.PolicyImportInvalidException;
 import org.eclipse.ditto.policies.model.PolicyImports;
 import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicyImportEntryAddition;
@@ -287,8 +288,16 @@ final class PolicyImportsRoute extends AbstractRoute {
 
     private static List<PolicyId> createTransitiveImportsForPut(final String jsonString) {
         final JsonArray jsonArray = wrapJsonRuntimeException(() -> JsonFactory.newArray(jsonString));
+        jsonArray.forEach(element -> {
+            if (!element.isString()) {
+                throw PolicyImportInvalidException.newBuilder()
+                        .message("The 'transitiveImports' array contains a non-string element: " + element)
+                        .description("Every element in 'transitiveImports' must be a string " +
+                                "representing a valid policy ID.")
+                        .build();
+            }
+        });
         return jsonArray.stream()
-                .filter(JsonValue::isString)
                 .map(JsonValue::asString)
                 .map(PolicyId::of)
                 .collect(Collectors.toList());

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -50,29 +50,30 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
         this.namespacePoliciesConfig = namespacePoliciesConfig;
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
-                        .whenCompleteAsync(((policyEnforcerEntry, throwable) -> {
-                                    if (throwable != null || policyEnforcerEntry == null) {
-                                        return;
+                        .thenApplyAsync(policyEnforcerEntry -> {
+                                    // Register import mappings eagerly (before the cache entry becomes
+                                    // visible to readers) to avoid a window where the entry is cached
+                                    // but invalidation of an imported policy cannot cascade to it.
+                                    if (policyEnforcerEntry != null) {
+                                        policyEnforcerEntry.get()
+                                                .flatMap(PolicyEnforcer::getPolicy)
+                                                .map(Policy::getPolicyImports)
+                                                .ifPresent(imports -> {
+                                                    deregisterImportMappings(policyId);
+                                                    if (!imports.isEmpty()) {
+                                                        imports.stream().forEach(policyImport -> {
+                                                            registerImportMapping(
+                                                                    policyImport.getImportedPolicyId(), policyId);
+                                                            policyImport.getTransitiveImports()
+                                                                    .forEach(transitivePolicyId ->
+                                                                            registerImportMapping(
+                                                                                    transitivePolicyId, policyId));
+                                                        });
+                                                    }
+                                                });
                                     }
-                                    policyEnforcerEntry.get()
-                                            .flatMap(PolicyEnforcer::getPolicy)
-                                            .map(Policy::getPolicyImports)
-                                            .ifPresent(imports -> {
-                                                // Remove stale mappings from previous loads of this policy
-                                                // before registering the current import relationships.
-                                                deregisterImportMappings(policyId);
-                                                if (!imports.isEmpty()) {
-                                                    imports.stream().forEach(policyImport -> {
-                                                        registerImportMapping(
-                                                                policyImport.getImportedPolicyId(), policyId);
-                                                        policyImport.getTransitiveImports()
-                                                                .forEach(transitivePolicyId ->
-                                                                        registerImportMapping(
-                                                                                transitivePolicyId, policyId));
-                                                    });
-                                                }
-                                            });
-                                }),
+                                    return policyEnforcerEntry;
+                                },
                                 cacheDispatcher
                         ),
                 cacheConfig,
@@ -159,10 +160,14 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
         // Invalidate the changed policy itself
         final boolean directlyCached = delegate.invalidateConditionally(policyId, valueCondition);
 
-        // Invalidate all policies that explicitly import the changed policy, and for each such
-        // importer that is itself a namespace root, also invalidate its namespace dependents.
-        final Set<PolicyId> importingPolicies =
-                Optional.ofNullable(policyIdToImportingMap.remove(policyId)).orElseGet(Set::of);
+        // Only remove the reverse-mapping when the primary cache entry was actually invalidated.
+        // Otherwise importers that remain cached would lose their cascade-invalidation link.
+        final Set<PolicyId> importingPolicies;
+        if (directlyCached) {
+            importingPolicies = Optional.ofNullable(policyIdToImportingMap.remove(policyId)).orElseGet(Set::of);
+        } else {
+            importingPolicies = Optional.ofNullable(policyIdToImportingMap.get(policyId)).orElseGet(Set::of);
+        }
         final boolean indirectlyCachedViaImport = importingPolicies.stream()
                 .map(importingPolicyId -> {
                     final boolean importerInvalidated =

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -50,27 +50,58 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
         this.namespacePoliciesConfig = namespacePoliciesConfig;
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
-                        .whenCompleteAsync(((policyEnforcerEntry, throwable) -> policyEnforcerEntry.get()
-                                .flatMap(PolicyEnforcer::getPolicy)
-                                .map(Policy::getPolicyImports)
-                                .filter(imports -> !imports.isEmpty())
-                                .ifPresent(imports -> imports.stream()
-                                        .map(PolicyImport::getImportedPolicyId)
-                                        .forEach(importedPolicyId -> policyIdToImportingMap.compute(
-                                                importedPolicyId, (importedPolicyId1, importingPolicyIds) -> {
-                                                    final Set<PolicyId> newImportingPolicyIds =
-                                                            importingPolicyIds == null ? new HashSet<>() :
-                                                                    importingPolicyIds;
-                                                    newImportingPolicyIds.add(policyId);
-                                                    return newImportingPolicyIds;
-                                                })))
-                                ),
+                        .whenCompleteAsync(((policyEnforcerEntry, throwable) -> {
+                                    if (throwable != null || policyEnforcerEntry == null) {
+                                        return;
+                                    }
+                                    policyEnforcerEntry.get()
+                                            .flatMap(PolicyEnforcer::getPolicy)
+                                            .map(Policy::getPolicyImports)
+                                            .ifPresent(imports -> {
+                                                // Remove stale mappings from previous loads of this policy
+                                                // before registering the current import relationships.
+                                                deregisterImportMappings(policyId);
+                                                if (!imports.isEmpty()) {
+                                                    imports.stream().forEach(policyImport -> {
+                                                        registerImportMapping(
+                                                                policyImport.getImportedPolicyId(), policyId);
+                                                        policyImport.getTransitiveImports()
+                                                                .forEach(transitivePolicyId ->
+                                                                        registerImportMapping(
+                                                                                transitivePolicyId, policyId));
+                                                    });
+                                                }
+                                            });
+                                }),
                                 cacheDispatcher
                         ),
                 cacheConfig,
                 "policy_enforcer_cache",
                 cacheDispatcher
         );
+    }
+
+    /**
+     * Removes {@code importingPolicyId} from all value sets in the import mapping.
+     * Called before re-registering mappings on policy reload so that stale entries
+     * (e.g. from removed imports or transitive imports) don't accumulate.
+     */
+    private void deregisterImportMappings(final PolicyId importingPolicyId) {
+        policyIdToImportingMap.forEach((importedId, importingSet) ->
+                policyIdToImportingMap.computeIfPresent(importedId, (id, set) -> {
+                    set.remove(importingPolicyId);
+                    return set.isEmpty() ? null : set;
+                })
+        );
+    }
+
+    private void registerImportMapping(final PolicyId importedPolicyId, final PolicyId importingPolicyId) {
+        policyIdToImportingMap.compute(importedPolicyId, (id, importingPolicyIds) -> {
+            final Set<PolicyId> newImportingPolicyIds =
+                    importingPolicyIds == null ? new HashSet<>() : importingPolicyIds;
+            newImportingPolicyIds.add(importingPolicyId);
+            return newImportingPolicyIds;
+        });
     }
 
     @Override

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
@@ -151,6 +151,132 @@ public final class PolicyEnforcerCacheTest {
     }
 
     @Test
+    public void transitiveImportChangeCascadeInvalidatesToImportingPolicy() throws Exception {
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final var underTest = new PolicyEnforcerCache(
+                cacheLoader,
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
+        );
+
+        // Template policy (C) → imported by intermediate (B) → transitively imported by leaf (A)
+        final var templatePolicyId = PolicyId.generateRandom();
+        final var intermediatePolicyId = PolicyId.generateRandom();
+        final var leafPolicyId = PolicyId.generateRandom();
+        final var unrelatedPolicyId = PolicyId.generateRandom();
+
+        new TestKit(actorSystem) {{
+            // Intermediate policy imports from template (direct import)
+            final Policy intermediatePolicy = Policy.newBuilder(intermediatePolicyId)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(templatePolicyId))
+                    .build();
+
+            // Leaf policy imports from intermediate with transitiveImports listing the template
+            final List<Label> noLabels = Collections.emptyList();
+            final Policy leafPolicy = Policy.newBuilder(leafPolicyId)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(intermediatePolicyId,
+                            PoliciesModelFactory.newEffectedImportedLabels(
+                                    noLabels, null,
+                                    Collections.singletonList(templatePolicyId))))
+                    .build();
+
+            final Policy templatePolicy = Policy.newBuilder(templatePolicyId).build();
+            final Policy unrelatedPolicy = Policy.newBuilder(unrelatedPolicyId).build();
+
+            // Load all policies into cache
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(leafPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            // Verify all served from cache
+            verifyLoadedFromCache(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(leafPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            // When: template policy changes
+            underTest.invalidate(templatePolicyId);
+
+            // Then: template, intermediate (direct importer), AND leaf (transitive importer) are invalidated
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(leafPolicy, underTest, cacheLoader);
+            // Unrelated policy is still cached
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+        }};
+    }
+
+    @Test
+    public void removingTransitiveImportsStopsInvalidationCascade() throws Exception {
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final var underTest = new PolicyEnforcerCache(
+                cacheLoader,
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
+        );
+
+        final var templatePolicyId = PolicyId.generateRandom();
+        final var intermediatePolicyId = PolicyId.generateRandom();
+        final var leafPolicyId = PolicyId.generateRandom();
+
+        new TestKit(actorSystem) {{
+            final Policy templatePolicy = Policy.newBuilder(templatePolicyId).build();
+            final Policy intermediatePolicy = Policy.newBuilder(intermediatePolicyId)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(templatePolicyId))
+                    .build();
+
+            final List<Label> noLabels = Collections.emptyList();
+            final Policy leafPolicyWithTransitive = Policy.newBuilder(leafPolicyId)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(intermediatePolicyId,
+                            PoliciesModelFactory.newEffectedImportedLabels(
+                                    noLabels, null,
+                                    Collections.singletonList(templatePolicyId))))
+                    .build();
+
+            // Phase 1: Load all policies. Leaf has transitiveImports → template cascades to leaf.
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(leafPolicyWithTransitive, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            underTest.invalidate(templatePolicyId);
+            // Template change invalidates: template, intermediate (direct), leaf (transitive)
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(leafPolicyWithTransitive, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            // Phase 2: Invalidate template again — this clears the import mapping for templatePolicyId.
+            // Then reload all three, but this time the leaf has NO transitiveImports.
+            // The fresh mapping for templatePolicyId will only contain {intermediate}, not {leaf}.
+            final Policy leafPolicyWithoutTransitive = Policy.newBuilder(leafPolicyId)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(intermediatePolicyId))
+                    .build();
+
+            underTest.invalidate(templatePolicyId);
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(leafPolicyWithoutTransitive, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            // Phase 3: Template changes again → leaf should NO LONGER be invalidated
+            // because leafPolicyWithoutTransitive did not register templatePolicyId as a dependency.
+            underTest.invalidate(templatePolicyId);
+            verifyLoadedFromCacheLoader(templatePolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(intermediatePolicy, underTest, cacheLoader);
+            // Leaf is still cached — template change no longer cascades to it
+            verifyLoadedFromCache(leafPolicyWithoutTransitive, underTest, cacheLoader);
+        }};
+    }
+
+    @Test
     public void policyTagInvalidatesCachedPoliciesInNamespacesOfChangedRootPolicy() throws Exception {
         final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
         final ExecutionContextExecutor executor = actorSystem.dispatcher();

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/EffectedImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/EffectedImports.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.policies.model;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -76,6 +78,17 @@ public interface EffectedImports extends Jsonifiable.WithFieldSelectorAndPredica
     }
 
     /**
+     * Returns the list of {@link PolicyId}s that the imported policy itself imports from, which should be
+     * resolved transitively before extracting entries.
+     *
+     * @return the list of transitive policy IDs to resolve, or an empty list if none are defined.
+     * @since 3.9.0
+     */
+    default List<PolicyId> getTransitiveImports() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Returns all non-hidden marked fields of this EffectedImports.
      *
      * @return a JSON object representation of this EffectedImports including only non-hidden marked fields.
@@ -109,6 +122,16 @@ public interface EffectedImports extends Jsonifiable.WithFieldSelectorAndPredica
          */
         public static final JsonFieldDefinition<JsonObject> ENTRIES_ADDITIONS =
                 JsonFactory.newJsonObjectFieldDefinition("entriesAdditions", FieldType.REGULAR,
+                        JsonSchemaVersion.V_2);
+
+        /**
+         * JSON field containing the list of policy IDs from the imported policy's own imports that should be
+         * resolved transitively before extracting entries.
+         *
+         * @since 3.9.0
+         */
+        public static final JsonFieldDefinition<JsonArray> TRANSITIVE_IMPORTS =
+                JsonFactory.newJsonArrayFieldDefinition("transitiveImports", FieldType.REGULAR,
                         JsonSchemaVersion.V_2);
 
         private JsonFields() {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableEffectedImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableEffectedImports.java
@@ -15,8 +15,11 @@ package org.eclipse.ditto.policies.model;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 import static org.eclipse.ditto.base.model.exceptions.DittoJsonException.wrapJsonRuntimeException;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -28,6 +31,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -42,11 +46,16 @@ final class ImmutableEffectedImports implements EffectedImports {
 
     private final ImportedLabels importedLabels;
     @Nullable private final EntriesAdditions entriesAdditions;
+    private final List<PolicyId> transitiveImports;
 
     private ImmutableEffectedImports(final ImportedLabels importedLabels,
-            @Nullable final EntriesAdditions entriesAdditions) {
+            @Nullable final EntriesAdditions entriesAdditions,
+            @Nullable final List<PolicyId> transitiveImports) {
         this.importedLabels = importedLabels;
         this.entriesAdditions = entriesAdditions;
+        this.transitiveImports = transitiveImports != null
+                ? Collections.unmodifiableList(new ArrayList<>(transitiveImports))
+                : Collections.emptyList();
     }
 
     /**
@@ -57,7 +66,7 @@ final class ImmutableEffectedImports implements EffectedImports {
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static EffectedImports of(final Iterable<Label> labels) {
-        return of(labels, null);
+        return of(labels, null, null);
     }
 
     /**
@@ -71,11 +80,29 @@ final class ImmutableEffectedImports implements EffectedImports {
      */
     public static EffectedImports of(final Iterable<Label> labels,
             @Nullable final EntriesAdditions entriesAdditions) {
+        return of(labels, entriesAdditions, null);
+    }
+
+    /**
+     * Returns a new {@code EffectedImports} object of the given {@code importedLabels},
+     * {@code entriesAdditions}, and {@code transitiveImports} policy IDs.
+     *
+     * @param labels the labels of the policy entries which should be added from the imported policy.
+     * @param entriesAdditions additional subjects/resources to merge into imported entries, or {@code null}.
+     * @param transitiveImports list of policy IDs from the imported policy's own imports that should be
+     *        resolved transitively before extracting entries, or {@code null}.
+     * @return a new {@code EffectedImports} object.
+     * @throws NullPointerException if {@code labels} is {@code null}.
+     * @since 3.9.0
+     */
+    public static EffectedImports of(final Iterable<Label> labels,
+            @Nullable final EntriesAdditions entriesAdditions,
+            @Nullable final List<PolicyId> transitiveImports) {
 
         final ImportedLabels importedLabels =
                 toImportedEntries(toSet(checkNotNull(labels, "importedLabels")));
 
-        return new ImmutableEffectedImports(importedLabels, entriesAdditions);
+        return new ImmutableEffectedImports(importedLabels, entriesAdditions, transitiveImports);
     }
 
     private static Collection<Label> toSet(final Iterable<Label> iterable) {
@@ -110,7 +137,14 @@ final class ImmutableEffectedImports implements EffectedImports {
         final EntriesAdditions entriesAdditions = jsonObject.getValue(JsonFields.ENTRIES_ADDITIONS)
                 .map(ImmutableEntriesAdditions::fromJson)
                 .orElse(null);
-        return of(importedLabels, entriesAdditions);
+        final List<PolicyId> transitiveImports = jsonObject.getValue(JsonFields.TRANSITIVE_IMPORTS)
+                .map(array -> array.stream()
+                        .filter(JsonValue::isString)
+                        .map(JsonValue::asString)
+                        .map(PolicyId::of)
+                        .collect(Collectors.toList()))
+                .orElse(null);
+        return of(importedLabels, entriesAdditions, transitiveImports);
     }
 
     private static Set<Label> getImportedEntries(final JsonObject jsonObject) {
@@ -135,12 +169,24 @@ final class ImmutableEffectedImports implements EffectedImports {
     }
 
     @Override
+    public List<PolicyId> getTransitiveImports() {
+        return transitiveImports;
+    }
+
+    @Override
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         final JsonObjectBuilder builder = JsonFactory.newObjectBuilder()
                 .set(JsonFields.ENTRIES, importedLabels.toJson(), predicate);
         if (entriesAdditions != null && !entriesAdditions.isEmpty()) {
             builder.set(JsonFields.ENTRIES_ADDITIONS, entriesAdditions.toJson(schemaVersion, thePredicate), predicate);
+        }
+        if (!transitiveImports.isEmpty()) {
+            final JsonArray transitiveArray = transitiveImports.stream()
+                    .map(PolicyId::toString)
+                    .map(JsonFactory::newValue)
+                    .collect(JsonCollectors.valuesToArray());
+            builder.set(JsonFields.TRANSITIVE_IMPORTS, transitiveArray, predicate);
         }
         return builder.build();
     }
@@ -155,12 +201,13 @@ final class ImmutableEffectedImports implements EffectedImports {
         }
         final ImmutableEffectedImports that = (ImmutableEffectedImports) o;
         return Objects.equals(importedLabels, that.importedLabels) &&
-                Objects.equals(entriesAdditions, that.entriesAdditions);
+                Objects.equals(entriesAdditions, that.entriesAdditions) &&
+                Objects.equals(transitiveImports, that.transitiveImports);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(importedLabels, entriesAdditions);
+        return Objects.hash(importedLabels, entriesAdditions, transitiveImports);
     }
 
     @Override
@@ -168,6 +215,7 @@ final class ImmutableEffectedImports implements EffectedImports {
         return getClass().getSimpleName() + " [" +
                 "importedLabels=" + importedLabels +
                 ", entriesAdditions=" + entriesAdditions +
+                ", transitiveImports=" + transitiveImports +
                 "]";
     }
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableEffectedImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableEffectedImports.java
@@ -138,11 +138,22 @@ final class ImmutableEffectedImports implements EffectedImports {
                 .map(ImmutableEntriesAdditions::fromJson)
                 .orElse(null);
         final List<PolicyId> transitiveImports = jsonObject.getValue(JsonFields.TRANSITIVE_IMPORTS)
-                .map(array -> array.stream()
-                        .filter(JsonValue::isString)
-                        .map(JsonValue::asString)
-                        .map(PolicyId::of)
-                        .collect(Collectors.toList()))
+                .map(array -> {
+                    array.forEach(element -> {
+                        if (!element.isString()) {
+                            throw PolicyImportInvalidException.newBuilder()
+                                    .message("The 'transitiveImports' array contains a non-string element: " +
+                                            element)
+                                    .description("Every element in 'transitiveImports' must be a string " +
+                                            "representing a valid policy ID.")
+                                    .build();
+                        }
+                    });
+                    return array.stream()
+                            .map(JsonValue::asString)
+                            .map(PolicyId::of)
+                            .collect(Collectors.toList());
+                })
                 .orElse(null);
         return of(importedLabels, entriesAdditions, transitiveImports);
     }

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PoliciesModelFactory.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PoliciesModelFactory.java
@@ -947,6 +947,51 @@ public final class PoliciesModelFactory {
     }
 
     /**
+     * Returns a new {@link EffectedImports} containing the optionally passed policy entry labels, entries
+     * additions, and transitive resolution policy IDs.
+     *
+     * @param importedLabels the labels of the policy entries which should be imported.
+     * @param entriesAdditions the additional subjects/resources to merge into imported entries, or {@code null}.
+     * @param transitiveImports list of policy IDs from the imported policy's own imports that should be
+     *        resolved transitively before extracting entries, or {@code null}.
+     * @return the new {@code EffectedImports}.
+     * @since 3.9.0
+     */
+    public static EffectedImports newEffectedImportedLabels(@Nullable final Iterable<Label> importedLabels,
+            @Nullable final EntriesAdditions entriesAdditions,
+            @Nullable final List<PolicyId> transitiveImports) {
+
+        return ImmutableEffectedImports.of(getOrEmptyCollection(importedLabels), entriesAdditions,
+                transitiveImports);
+    }
+
+    /**
+     * Creates a new {@link PolicyImport} from an existing import, replacing only the transitive imports list
+     * while preserving the imported labels and entries additions.
+     *
+     * @param existingImport the existing import to base the new import on.
+     * @param newTransitiveImports the new list of policy IDs for transitive resolution.
+     * @return the new PolicyImport with updated transitive imports.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @since 3.9.0
+     */
+    public static PolicyImport policyImportWithTransitiveImports(final PolicyImport existingImport,
+            final List<PolicyId> newTransitiveImports) {
+        checkNotNull(existingImport, "existingImport");
+        checkNotNull(newTransitiveImports, "newTransitiveImports");
+
+        final ImportedLabels labels = existingImport.getEffectedImports()
+                .map(EffectedImports::getImportedLabels)
+                .orElse(noImportedEntries());
+        final EntriesAdditions entriesAdditions = existingImport.getEffectedImports()
+                .flatMap(EffectedImports::getEntriesAdditions)
+                .orElse(null);
+        final EffectedImports newEffectedImports =
+                newEffectedImportedLabels(labels, entriesAdditions, newTransitiveImports);
+        return newPolicyImport(existingImport.getImportedPolicyId(), newEffectedImports);
+    }
+
+    /**
      * Returns a new immutable instance of {@link ImportedLabels} containing the given entry labels.
      *
      * @param entryLabels the entryLabels to initialise the result with.

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImport.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImport.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.policies.model;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -76,6 +78,19 @@ public interface PolicyImport extends Jsonifiable.WithFieldSelectorAndPredicate<
      */
     default Optional<EntriesAdditions> getEntriesAdditions() {
         return getEffectedImports().flatMap(EffectedImports::getEntriesAdditions);
+    }
+
+    /**
+     * Returns the list of {@link PolicyId}s from the imported policy's own imports that should be resolved
+     * transitively before extracting entries.
+     *
+     * @return the list of transitive PolicyIds, or an empty list if none are defined.
+     * @since 3.9.0
+     */
+    default List<PolicyId> getTransitiveImports() {
+        return getEffectedImports()
+                .map(EffectedImports::getTransitiveImports)
+                .orElse(Collections.emptyList());
     }
 
     /**

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImporter.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImporter.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.policies.model;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,12 @@ import javax.annotation.Nullable;
  */
 public final class PolicyImporter {
 
+    /**
+     * Maximum depth for transitive import resolution. Prevents infinite recursion caused by mutual
+     * transitive cycles (e.g., A→B with transitiveImports=["C"], B→C with transitiveImports=["A"]).
+     */
+    static final int MAX_TRANSITIVE_RESOLUTION_DEPTH = 10;
+
     private PolicyImporter() {
         throw new AssertionError();
     }
@@ -51,36 +58,155 @@ public final class PolicyImporter {
      */
     public static CompletionStage<Set<PolicyEntry>> mergeImportedPolicyEntries(final Policy policy,
             final Function<PolicyId, CompletionStage<Optional<Policy>>> policyLoader) {
-        return policy.getPolicyImports().stream()
-                .map(policyImport -> {
-                    final PolicyId importedPolicyId = policyImport.getImportedPolicyId();
-                    final CompletionStage<Optional<Policy>> loadedPolicyOptCs = policyLoader.apply(importedPolicyId);
-                    return loadedPolicyOptCs.thenApply(loadedPolicyOpt -> loadedPolicyOpt.map(loadedPolicy -> {
+        final List<PolicyImport> imports = policy.getPolicyImports().stream().collect(Collectors.toList());
+        return mergeImportedPolicyEntries(policy.getEntriesSet(), imports, policyLoader, 0, true,
+                Collections.emptySet());
+    }
+
+    /**
+     * Resolves the given {@code policyImports} using the {@code policyLoader}, merging the resulting entries
+     * with the provided {@code baseEntries}. All imports are resolved in parallel; their entry sets are
+     * collected in a single pass to avoid O(n²) intermediate copies.
+     *
+     * @param baseEntries the policy's own entries (starting set for the merge).
+     * @param policyImports the imports to resolve.
+     * @param policyLoader a function to load imported policies, e.g. provided by a cache.
+     * @param depth current transitive resolution depth.
+     * @param applyImportPrefix whether to prefix imported entry labels with the imported policy ID.
+     * @param visited policy IDs already being resolved in the current chain (cycle detection).
+     * @return a combined set of {@code baseEntries} merged with entries from all resolved imports.
+     */
+    private static CompletionStage<Set<PolicyEntry>> mergeImportedPolicyEntries(
+            final Set<PolicyEntry> baseEntries,
+            final List<PolicyImport> policyImports,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyLoader,
+            final int depth, final boolean applyImportPrefix,
+            final Set<PolicyId> visited) {
+
+        if (policyImports.isEmpty()) {
+            return CompletableFuture.completedFuture(baseEntries);
+        }
+
+        final List<CompletableFuture<Set<PolicyEntry>>> importFutures = policyImports.stream()
+                .map(policyImport -> resolveImport(policyImport, policyLoader, depth, applyImportPrefix,
+                        visited).toCompletableFuture())
+                .collect(Collectors.toList());
+
+        return CompletableFuture.allOf(importFutures.toArray(CompletableFuture[]::new))
+                .thenApply(ignored -> {
+                    final Set<PolicyEntry> result = new LinkedHashSet<>(baseEntries);
+                    for (final CompletableFuture<Set<PolicyEntry>> future : importFutures) {
+                        result.addAll(future.join());
+                    }
+                    return Collections.unmodifiableSet(result);
+                });
+    }
+
+    /**
+     * Resolves a single policy import: loads the imported policy, optionally resolves its transitive
+     * imports, then filters and rewrites the resulting entries.
+     */
+    private static CompletionStage<Set<PolicyEntry>> resolveImport(
+            final PolicyImport policyImport,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyLoader,
+            final int depth, final boolean applyImportPrefix,
+            final Set<PolicyId> visited) {
+
+        final PolicyId importedPolicyId = policyImport.getImportedPolicyId();
+        return policyLoader.apply(importedPolicyId).thenCompose(loadedPolicyOpt ->
+                loadedPolicyOpt.map(loadedPolicy -> {
+                    final List<PolicyId> transitiveIds = policyImport.getTransitiveImports();
+                    final CompletionStage<Set<PolicyEntry>> resolvedEntriesCs;
+                    if (!transitiveIds.isEmpty()) {
+                        resolvedEntriesCs = resolveTransitiveImports(
+                                loadedPolicy, transitiveIds, policyLoader, depth, visited);
+                    } else {
+                        resolvedEntriesCs = CompletableFuture.completedFuture(loadedPolicy.getEntriesSet());
+                    }
+                    return resolvedEntriesCs.thenApply(resolvedEntries -> {
                         final ImportedLabels importedLabels = policyImport.getEffectedImports()
                                 .map(EffectedImports::getImportedLabels)
                                 .orElse(ImportedLabels.none());
                         final EntriesAdditions entriesAdditions = policyImport.getEntriesAdditions()
                                 .orElse(null);
-                        return rewriteImportedLabels(importedPolicyId, loadedPolicy, importedLabels,
-                                entriesAdditions);
-                    }).orElse(Collections.emptySet()));
-                })
-                .reduce(CompletableFuture.completedFuture(policy.getEntriesSet()), PolicyImporter::combineSets,
-                        PolicyImporter::combineSets);
+                        return rewriteImportedLabels(importedPolicyId, resolvedEntries,
+                                importedLabels, entriesAdditions, applyImportPrefix);
+                    });
+                }).orElse(CompletableFuture.completedFuture(Collections.emptySet())));
+    }
+
+    /**
+     * Resolves only the specified transitive imports on the loaded policy.
+     * Filters the loaded policy's imports to only those that appear in {@code transitiveIds},
+     * resolves those imports into entries, and returns the combined entry set (loaded policy's own
+     * entries plus resolved transitive entries).
+     * <p>
+     * Entries resolved from transitive imports are added with their original labels (no import prefix),
+     * so that the outer resolution can correctly apply the single import prefix and match {@code entries}
+     * filters and {@code entriesAdditions} keys.
+     * <p>
+     * Cycle detection: transitive IDs that appear in {@code visited} are skipped to prevent infinite
+     * recursion. Each level creates an immutable copy of the visited set with the current transitive IDs
+     * added, so parallel import processing within {@code mergeImportedPolicyEntries} is safe.
+     *
+     * @param loadedPolicy the directly imported policy (persisted state).
+     * @param transitiveIds the whitelisted policy IDs to resolve transitively.
+     * @param policyLoader a function to load policies by ID.
+     * @param depth the current transitive resolution depth (bounded by {@link #MAX_TRANSITIVE_RESOLUTION_DEPTH}).
+     * @param visited policy IDs already being resolved in the current chain (cycle detection).
+     * @return the loaded policy's entries merged with entries from the transitive imports.
+     * @since 3.9.0
+     */
+    private static CompletionStage<Set<PolicyEntry>> resolveTransitiveImports(
+            final Policy loadedPolicy,
+            final List<PolicyId> transitiveIds,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyLoader,
+            final int depth,
+            final Set<PolicyId> visited) {
+
+        if (depth >= MAX_TRANSITIVE_RESOLUTION_DEPTH) {
+            return CompletableFuture.completedFuture(loadedPolicy.getEntriesSet());
+        }
+
+        // Filter out already-visited transitive IDs to break cycles
+        final Set<PolicyId> transitiveIdSet = new LinkedHashSet<>(transitiveIds);
+        transitiveIdSet.removeAll(visited);
+
+        final List<PolicyImport> filteredImportsList = loadedPolicy.getPolicyImports().stream()
+                .filter(imp -> transitiveIdSet.contains(imp.getImportedPolicyId()))
+                .collect(Collectors.toList());
+
+        if (filteredImportsList.isEmpty()) {
+            return CompletableFuture.completedFuture(loadedPolicy.getEntriesSet());
+        }
+
+        // Immutable snapshot: current visited set + transitive IDs being resolved at this level.
+        // Each recursive call gets its own copy, so parallel import processing is safe.
+        final Set<PolicyId> newVisited = new HashSet<>(visited);
+        newVisited.addAll(transitiveIdSet);
+        final Set<PolicyId> unmodifiableVisited = Collections.unmodifiableSet(newVisited);
+
+        // Resolve filtered imports without label prefixing — the entries are merged into the
+        // loaded policy's entries as if they were its own inline entries. The outer resolution
+        // applies the prefix.
+        return mergeImportedPolicyEntries(loadedPolicy.getEntriesSet(), filteredImportsList,
+                policyLoader, depth + 1, false, unmodifiableVisited);
     }
 
     private static Set<PolicyEntry> rewriteImportedLabels(final PolicyId importedPolicyId,
-            final Policy importedPolicy, final Collection<Label> importedLabels,
-            @Nullable final EntriesAdditions entriesAdditions) {
+            final Set<PolicyEntry> importedEntries, final Collection<Label> importedLabels,
+            @Nullable final EntriesAdditions entriesAdditions, final boolean applyImportPrefix) {
 
-        return importedPolicy.getEntriesSet().stream()
+        return importedEntries.stream()
                 .flatMap(importedEntry -> importEntry(importedLabels, importedEntry))
-                .map(entry -> applyAdditionsAndRewrite(importedPolicyId, entry, entriesAdditions))
+                .map(entry -> applyAdditionsAndRewrite(importedPolicyId, entry, entriesAdditions,
+                        applyImportPrefix))
                 .collect(Collectors.toSet());
     }
 
     private static PolicyEntry applyAdditionsAndRewrite(final PolicyId importedPolicyId,
-            final PolicyEntry entry, @Nullable final EntriesAdditions entriesAdditions) {
+            final PolicyEntry entry, @Nullable final EntriesAdditions entriesAdditions,
+            final boolean applyImportPrefix) {
 
         Subjects mergedSubjects = entry.getSubjects();
         Resources mergedResources = entry.getResources();
@@ -104,8 +230,12 @@ public final class PolicyImporter {
             }
         }
 
+        final Label finalLabel = applyImportPrefix
+                ? PoliciesModelFactory.newImportedLabel(importedPolicyId, entry.getLabel())
+                : entry.getLabel();
+
         return PoliciesModelFactory.newPolicyEntry(
-                PoliciesModelFactory.newImportedLabel(importedPolicyId, entry.getLabel()),
+                finalLabel,
                 mergedSubjects,
                 mergedResources,
                 mergedNamespaces,
@@ -167,12 +297,5 @@ public final class PolicyImporter {
                 : new LinkedHashSet<>();
         merged.addAll(additionalNamespaces);
         return new ArrayList<>(merged);
-    }
-
-    private static CompletionStage<Set<PolicyEntry>> combineSets(final CompletionStage<Set<PolicyEntry>> set1Cs,
-            final CompletionStage<Set<PolicyEntry>> set2Cs) {
-        return set1Cs.thenCombine(set2Cs,
-                (set1, set2) -> Stream.concat(set1.stream(), set2.stream()).collect(Collectors.toSet())
-        );
     }
 }

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImporter.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImporter.java
@@ -39,8 +39,18 @@ public final class PolicyImporter {
     /**
      * Maximum depth for transitive import resolution. Prevents infinite recursion caused by mutual
      * transitive cycles (e.g., A→B with transitiveImports=["C"], B→C with transitiveImports=["A"]).
+     * <p>
+     * When this limit is reached, resolution stops and returns the loaded policy's own entries without
+     * recursing further. This is intentionally silent at the model layer (no SLF4J dependency in model
+     * modules). Callers that need diagnostics should check the resolved entry count or implement their
+     * own depth tracking.
+     * <p>
+     * Cross-policy cycles (A→B→C→A) are not rejected at write time because cycle detection across
+     * multiple independently-managed policies would require loading the full transitive graph on every
+     * PUT. Instead, cycles are broken gracefully at resolution time via the {@code visited} set and
+     * this depth limit.
      */
-    static final int MAX_TRANSITIVE_RESOLUTION_DEPTH = 10;
+    public static final int MAX_TRANSITIVE_RESOLUTION_DEPTH = 10;
 
     private PolicyImporter() {
         throw new AssertionError();
@@ -67,6 +77,11 @@ public final class PolicyImporter {
      * Resolves the given {@code policyImports} using the {@code policyLoader}, merging the resulting entries
      * with the provided {@code baseEntries}. All imports are resolved in parallel; their entry sets are
      * collected in a single pass to avoid O(n²) intermediate copies.
+     *
+     * <p>
+     * <b>Merge precedence:</b> The result uses a {@link LinkedHashSet}, so when two imports produce entries
+     * with the same label, the first-encountered entry wins (based on import declaration order). This is
+     * a deterministic, order-dependent merge — not a conflict error.
      *
      * @param baseEntries the policy's own entries (starting set for the merge).
      * @param policyImports the imports to resolve.
@@ -172,6 +187,8 @@ public final class PolicyImporter {
         final Set<PolicyId> transitiveIdSet = new LinkedHashSet<>(transitiveIds);
         transitiveIdSet.removeAll(visited);
 
+        // Filter the loaded policy's imports to only those matching the transitive whitelist.
+        // IDs that don't match any actual import are silently ignored (lenient / forward-reference semantics).
         final List<PolicyImport> filteredImportsList = loadedPolicy.getPolicyImports().stream()
                 .filter(imp -> transitiveIdSet.contains(imp.getImportedPolicyId()))
                 .collect(Collectors.toList());
@@ -261,6 +278,8 @@ public final class PolicyImporter {
         return templateSubjects.setSubjects(additionalSubjects);
     }
 
+    // Note: inner merge is O(k) per resource due to immutable copy-on-write in Resources.setResource.
+    // The overall merge across all entries is O(n·k) where n = entries and k = resources per entry.
     private static Resources mergeResources(final Resources templateResources, final Resources additionalResources) {
         Resources result = templateResources;
         for (final Resource additionalResource : additionalResources) {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyImports.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.policies.model;
 
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.ditto.base.model.json.FieldType;
@@ -131,6 +133,25 @@ public interface PolicyImports extends Iterable<PolicyImport>, Jsonifiable.WithF
      * @return a sequential stream of the PolicyImports of this container.
      */
     Stream<PolicyImport> stream();
+
+    /**
+     * Returns the set of all policy IDs that are expected to be referenced by these imports,
+     * including directly imported IDs and transitive IDs declared via {@code transitiveImports}.
+     * <p>
+     * This is the single source of truth for both search index tracking
+     * ({@code __referencedPolicies}) and background sync consistency checks.
+     *
+     * @return the set of expected referenced policy IDs.
+     * @since 3.9.0
+     */
+    default Set<PolicyId> getExpectedReferencedPolicyIds() {
+        final Set<PolicyId> result = stream()
+                .map(PolicyImport::getImportedPolicyId)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        stream().flatMap(imp -> imp.getTransitiveImports().stream())
+                .forEach(result::add);
+        return result;
+    }
 
     /**
      * Returns all non hidden marked fields of this PolicyImports.

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyImportsValidator.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyImportsValidator.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.policies.model.signals.commands;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.policies.model.PolicyId;
@@ -31,6 +33,18 @@ public final class PolicyImportsValidator {
         if (policyImports.stream().anyMatch(policyImport -> policyImport.getImportedPolicyId().equals(importingPolicyId))) {
             throw PolicyImportInvalidException.newBuilder().build();
         }
+        // Validate that no transitiveImports entry references the importing policy itself (cycle prevention)
+        policyImports.stream()
+                .flatMap(policyImport -> policyImport.getTransitiveImports().stream())
+                .filter(transitiveId -> transitiveId.equals(importingPolicyId))
+                .findAny()
+                .ifPresent(selfRef -> {
+                    throw PolicyImportInvalidException.newBuilder()
+                            .message("The policy import contains a transitive resolution of the policy itself.")
+                            .description("The 'transitiveImports' array must not contain the importing policy's " +
+                                    "own ID '" + importingPolicyId + "'.")
+                            .build();
+                });
         return policyImports;
     }
 
@@ -38,7 +52,48 @@ public final class PolicyImportsValidator {
         if (policyImport.getImportedPolicyId().equals(importingPolicyId)) {
             throw PolicyImportInvalidException.newBuilder().build();
         }
+        // Validate that no transitiveImports entry references the importing policy itself (cycle prevention)
+        policyImport.getTransitiveImports().stream()
+                .filter(transitiveId -> transitiveId.equals(importingPolicyId))
+                .findAny()
+                .ifPresent(selfRef -> {
+                    throw PolicyImportInvalidException.newBuilder()
+                            .message("The policy import contains a transitive resolution of the policy itself.")
+                            .description("The 'transitiveImports' array must not contain the importing policy's " +
+                                    "own ID '" + importingPolicyId + "'.")
+                            .build();
+                });
         return policyImport;
+    }
+
+    /**
+     * Validates that the given {@code transitiveImports} list does not introduce a cycle by referencing the
+     * importing policy itself.
+     *
+     * @param importingPolicyId the ID of the policy that declares the import.
+     * @param importedPolicyId the ID of the directly imported policy.
+     * @param transitiveImports the list of policy IDs to resolve transitively.
+     * @return the validated {@code transitiveImports} list.
+     * @throws PolicyImportInvalidException if the importing policy's own ID appears in {@code transitiveImports}.
+     * @since 3.9.0
+     */
+    public static List<PolicyId> validateTransitiveImports(final PolicyId importingPolicyId,
+            final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports) {
+        if (importedPolicyId.equals(importingPolicyId)) {
+            throw PolicyImportInvalidException.newBuilder().build();
+        }
+        transitiveImports.stream()
+                .filter(transitiveId -> transitiveId.equals(importingPolicyId))
+                .findAny()
+                .ifPresent(selfRef -> {
+                    throw PolicyImportInvalidException.newBuilder()
+                            .message("The policy import contains a transitive resolution of the policy itself.")
+                            .description("The 'transitiveImports' array must not contain the importing policy's " +
+                                    "own ID '" + importingPolicyId + "'.")
+                            .build();
+                });
+        return transitiveImports;
     }
 
 }

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyImportsValidator.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyImportsValidator.java
@@ -23,6 +23,13 @@ import org.eclipse.ditto.policies.model.PolicyImports;
 
 /**
  * Validator for policy imports.
+ * <p>
+ * <b>Cycle detection limitation:</b> This validator only catches one-hop self-references (the importing
+ * policy's own ID appearing as a direct import or in {@code transitiveImports}). Cross-policy cycles
+ * (e.g., A→B→C→A) are <em>not</em> detected at write time because cycle detection across multiple
+ * independently-managed policies would require loading the full transitive graph on every PUT. Instead,
+ * cycles are broken gracefully at resolution time via a visited set and depth limit in
+ * {@link org.eclipse.ditto.policies.model.PolicyImporter}.
  */
 public final class PolicyImportsValidator {
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyResource.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/PolicyResource.java
@@ -36,6 +36,7 @@ public enum PolicyResource {
     POLICY_IMPORT_ENTRIES,
     POLICY_IMPORT_ENTRIES_ADDITIONS,
     POLICY_IMPORT_ENTRY_ADDITION,
+    POLICY_IMPORT_TRANSITIVE_IMPORTS,
     POLICY_ENTRIES,
     POLICY_ENTRY,
     POLICY_ENTRY_RESOURCES,
@@ -58,6 +59,8 @@ public enum PolicyResource {
                                 .add(EffectedImports.JsonFields.ENTRIES_ADDITIONS,
                                         ResourceMap.newBuilder(POLICY_IMPORT_ENTRIES_ADDITIONS)
                                                 .addOne(POLICY_IMPORT_ENTRY_ADDITION))
+                                .add(EffectedImports.JsonFields.TRANSITIVE_IMPORTS,
+                                        POLICY_IMPORT_TRANSITIVE_IMPORTS)
                                 .end())
                 )
                 .add(Policy.JsonFields.IMPORTS_ALIASES, ResourceMap.newBuilder(POLICY_IMPORTS_ALIASES)

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImports.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import static org.eclipse.ditto.base.model.exceptions.DittoJsonException.wrapJsonRuntimeException;
+
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonParsableCommand;
@@ -186,11 +188,13 @@ public final class ModifyPolicyImportTransitiveImports
 
     @Override
     public ModifyPolicyImportTransitiveImports setEntity(final JsonValue entity) {
-        final List<PolicyId> policyIds = entity.asArray().stream()
-                .map(JsonValue::asString)
-                .map(PolicyId::of)
-                .collect(Collectors.toList());
-        return of(policyId, importedPolicyId, policyIds, getDittoHeaders());
+        return wrapJsonRuntimeException(() -> {
+            final List<PolicyId> policyIds = entity.asArray().stream()
+                    .map(JsonValue::asString)
+                    .map(PolicyId::of)
+                    .collect(Collectors.toList());
+            return of(policyId, importedPolicyId, policyIds, getDittoHeaders());
+        });
     }
 
     @Override

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImports.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.signals.commands.modify;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandSizeValidator;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyImportsValidator;
+
+/**
+ * This command modifies the resolve transitively configuration of a Policy import.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableCommand(typePrefix = PolicyCommand.TYPE_PREFIX, name = ModifyPolicyImportTransitiveImports.NAME)
+public final class ModifyPolicyImportTransitiveImports
+        extends AbstractCommand<ModifyPolicyImportTransitiveImports>
+        implements PolicyModifyCommand<ModifyPolicyImportTransitiveImports> {
+
+    /**
+     * NAME of this command.
+     */
+    public static final String NAME = "modifyPolicyImportTransitiveImports";
+
+    /**
+     * Type of this command.
+     */
+    public static final String TYPE = TYPE_PREFIX + NAME;
+
+    static final JsonFieldDefinition<String> JSON_IMPORTED_POLICY_ID =
+            JsonFactory.newStringFieldDefinition("importedPolicyId", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    static final JsonFieldDefinition<JsonArray> JSON_TRANSITIVE_IMPORTS =
+            JsonFactory.newJsonArrayFieldDefinition("transitiveImports", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private final PolicyId policyId;
+    private final PolicyId importedPolicyId;
+    private final List<PolicyId> transitiveImports;
+
+    private ModifyPolicyImportTransitiveImports(final PolicyId policyId, final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports, final DittoHeaders dittoHeaders) {
+        super(TYPE, dittoHeaders);
+        this.policyId = checkNotNull(policyId, "policyId");
+        this.importedPolicyId = checkNotNull(importedPolicyId, "importedPolicyId");
+        this.transitiveImports = Collections.unmodifiableList(
+                checkNotNull(transitiveImports, "transitiveImports"));
+
+        PolicyImportsValidator.validateTransitiveImports(policyId, importedPolicyId, transitiveImports);
+
+        final JsonArray jsonArray = this.transitiveImports.stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+        PolicyCommandSizeValidator.getInstance()
+                .ensureValidSize(() -> jsonArray.toString().length(), () -> dittoHeaders);
+    }
+
+    /**
+     * Creates a command for modifying the resolve transitively configuration of a Policy import.
+     *
+     * @param policyId the identifier of the Policy.
+     * @param importedPolicyId the identifier of the imported Policy.
+     * @param transitiveImports the list of Policy IDs to resolve transitively.
+     * @param dittoHeaders the headers of the command.
+     * @return the command.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static ModifyPolicyImportTransitiveImports of(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports,
+            final DittoHeaders dittoHeaders) {
+
+        return new ModifyPolicyImportTransitiveImports(policyId, importedPolicyId, transitiveImports,
+                dittoHeaders);
+    }
+
+    /**
+     * Creates a command for modifying the resolve transitively configuration of a Policy import from a JSON string.
+     *
+     * @param jsonString the JSON string of which the command is to be created.
+     * @param dittoHeaders the headers of the command.
+     * @return the command.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonString} is empty.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * format.
+     */
+    public static ModifyPolicyImportTransitiveImports fromJson(final String jsonString,
+            final DittoHeaders dittoHeaders) {
+        return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
+    }
+
+    /**
+     * Creates a command for modifying the resolve transitively configuration of a Policy import from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the command is to be created.
+     * @param dittoHeaders the headers of the command.
+     * @return the command.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static ModifyPolicyImportTransitiveImports fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new CommandJsonDeserializer<ModifyPolicyImportTransitiveImports>(TYPE, jsonObject)
+                .deserialize(() -> {
+                    final PolicyId policyId = PolicyId.of(
+                            jsonObject.getValueOrThrow(PolicyCommand.JsonFields.JSON_POLICY_ID));
+                    final PolicyId importedPolicyId =
+                            PolicyId.of(jsonObject.getValueOrThrow(JSON_IMPORTED_POLICY_ID));
+                    final JsonArray transitiveImportsArray =
+                            jsonObject.getValueOrThrow(JSON_TRANSITIVE_IMPORTS);
+                    final List<PolicyId> transitiveImports = transitiveImportsArray.stream()
+                            .map(JsonValue::asString)
+                            .map(PolicyId::of)
+                            .collect(Collectors.toList());
+
+                    return of(policyId, importedPolicyId, transitiveImports, dittoHeaders);
+                });
+    }
+
+    /**
+     * Returns the identifier of the imported Policy.
+     *
+     * @return the identifier of the imported Policy.
+     */
+    public PolicyId getImportedPolicyId() {
+        return importedPolicyId;
+    }
+
+    /**
+     * Returns the list of Policy IDs to resolve transitively.
+     *
+     * @return the list of Policy IDs to resolve transitively.
+     */
+    public List<PolicyId> getTransitiveImports() {
+        return transitiveImports;
+    }
+
+    @Override
+    public Optional<JsonValue> getEntity(final JsonSchemaVersion schemaVersion) {
+        final JsonArray jsonArray = transitiveImports.stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+        return Optional.of(jsonArray);
+    }
+
+    @Override
+    public ModifyPolicyImportTransitiveImports setEntity(final JsonValue entity) {
+        final List<PolicyId> policyIds = entity.asArray().stream()
+                .map(JsonValue::asString)
+                .map(PolicyId::of)
+                .collect(Collectors.toList());
+        return of(policyId, importedPolicyId, policyIds, getDittoHeaders());
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        final String path = "/imports/" + importedPolicyId + "/transitiveImports";
+        return JsonPointer.of(path);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(PolicyCommand.JsonFields.JSON_POLICY_ID, policyId.toString(), predicate);
+        jsonObjectBuilder.set(JSON_IMPORTED_POLICY_ID, importedPolicyId.toString(), predicate);
+        final JsonArray jsonArray = transitiveImports.stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+        jsonObjectBuilder.set(JSON_TRANSITIVE_IMPORTS, jsonArray, predicate);
+    }
+
+    @Override
+    public Category getCategory() {
+        return Category.MODIFY;
+    }
+
+    @Override
+    public PolicyId getEntityId() {
+        return policyId;
+    }
+
+    @Override
+    public ModifyPolicyImportTransitiveImports setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(policyId, importedPolicyId, transitiveImports, dittoHeaders);
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof ModifyPolicyImportTransitiveImports;
+    }
+
+    @SuppressWarnings("squid:MethodCyclomaticComplexity")
+    @Override
+    public boolean equals(@Nullable final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ModifyPolicyImportTransitiveImports that = (ModifyPolicyImportTransitiveImports) obj;
+        return that.canEqual(this) &&
+                Objects.equals(policyId, that.policyId) &&
+                Objects.equals(importedPolicyId, that.importedPolicyId) &&
+                Objects.equals(transitiveImports, that.transitiveImports) &&
+                super.equals(obj);
+    }
+
+    @SuppressWarnings("squid:S109")
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), policyId, importedPolicyId, transitiveImports);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", policyId=" + policyId +
+                ", importedPolicyId=" + importedPolicyId +
+                ", transitiveImports=" + transitiveImports + "]";
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImportsResponse.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/modify/ModifyPolicyImportTransitiveImportsResponse.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.signals.commands.modify;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommandResponse;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommandResponse;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponseHttpStatusValidator;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponseJsonDeserializer;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandResponse;
+
+/**
+ * Response to a {@link ModifyPolicyImportTransitiveImports} command.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableCommandResponse(type = ModifyPolicyImportTransitiveImportsResponse.TYPE)
+public final class ModifyPolicyImportTransitiveImportsResponse
+        extends AbstractCommandResponse<ModifyPolicyImportTransitiveImportsResponse>
+        implements PolicyModifyCommandResponse<ModifyPolicyImportTransitiveImportsResponse> {
+
+    /**
+     * Type of this response.
+     */
+    public static final String TYPE = TYPE_PREFIX + ModifyPolicyImportTransitiveImports.NAME;
+
+    static final JsonFieldDefinition<String> JSON_IMPORTED_POLICY_ID =
+            JsonFactory.newStringFieldDefinition("importedPolicyId", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private static final HttpStatus HTTP_STATUS = HttpStatus.NO_CONTENT;
+
+    private static final CommandResponseJsonDeserializer<ModifyPolicyImportTransitiveImportsResponse>
+            JSON_DESERIALIZER =
+            CommandResponseJsonDeserializer.newInstance(TYPE,
+                    context -> {
+                        final JsonObject jsonObject = context.getJsonObject();
+                        return new ModifyPolicyImportTransitiveImportsResponse(
+                                PolicyId.of(jsonObject.getValueOrThrow(
+                                        PolicyCommandResponse.JsonFields.JSON_POLICY_ID)),
+                                PolicyId.of(jsonObject.getValueOrThrow(JSON_IMPORTED_POLICY_ID)),
+                                context.getDeserializedHttpStatus(),
+                                context.getDittoHeaders()
+                        );
+                    });
+
+    private final PolicyId policyId;
+    private final PolicyId importedPolicyId;
+
+    private ModifyPolicyImportTransitiveImportsResponse(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final HttpStatus statusCode,
+            final DittoHeaders dittoHeaders) {
+
+        super(TYPE, statusCode, dittoHeaders);
+        this.policyId = checkNotNull(policyId, "policyId");
+        this.importedPolicyId = checkNotNull(importedPolicyId, "importedPolicyId");
+    }
+
+    /**
+     * Creates a response to a {@code ModifyPolicyImportTransitiveImports} command.
+     *
+     * @param policyId the Policy ID of the modified resolve transitively configuration.
+     * @param importedPolicyId the imported Policy ID.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static ModifyPolicyImportTransitiveImportsResponse modified(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final DittoHeaders dittoHeaders) {
+
+        return new ModifyPolicyImportTransitiveImportsResponse(policyId, importedPolicyId, HTTP_STATUS,
+                dittoHeaders);
+    }
+
+    /**
+     * Returns a new instance of {@code ModifyPolicyImportTransitiveImportsResponse} for the specified arguments.
+     *
+     * @param policyId the Policy ID of the modified resource.
+     * @param importedPolicyId the imported Policy ID.
+     * @param httpStatus the status of the response.
+     * @param dittoHeaders the headers of the response.
+     * @return the {@code ModifyPolicyImportTransitiveImportsResponse} instance.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code httpStatus} is not allowed for a
+     * {@code ModifyPolicyImportTransitiveImportsResponse}.
+     */
+    public static ModifyPolicyImportTransitiveImportsResponse newInstance(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final HttpStatus httpStatus,
+            final DittoHeaders dittoHeaders) {
+
+        return new ModifyPolicyImportTransitiveImportsResponse(policyId,
+                importedPolicyId,
+                CommandResponseHttpStatusValidator.validateHttpStatus(httpStatus,
+                        Collections.singleton(HTTP_STATUS),
+                        ModifyPolicyImportTransitiveImportsResponse.class),
+                dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a {@code ModifyPolicyImportTransitiveImports} command from a JSON string.
+     *
+     * @param jsonString the JSON string of which the response is to be created.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonString} is empty.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * format.
+     */
+    public static ModifyPolicyImportTransitiveImportsResponse fromJson(final String jsonString,
+            final DittoHeaders dittoHeaders) {
+        return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a {@code ModifyPolicyImportTransitiveImports} command from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the response is to be created.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static ModifyPolicyImportTransitiveImportsResponse fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return JSON_DESERIALIZER.deserialize(jsonObject, dittoHeaders);
+    }
+
+    /**
+     * Returns the imported PolicyId.
+     *
+     * @return the imported PolicyId.
+     */
+    public PolicyId getImportedPolicyId() {
+        return importedPolicyId;
+    }
+
+    @Override
+    public Optional<JsonValue> getEntity(final JsonSchemaVersion schemaVersion) {
+        return Optional.empty();
+    }
+
+    @Override
+    public ModifyPolicyImportTransitiveImportsResponse setEntity(final JsonValue entity) {
+        return this;
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        final String path = "/imports/" + importedPolicyId + "/transitiveImports";
+        return JsonPointer.of(path);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(PolicyCommandResponse.JsonFields.JSON_POLICY_ID, policyId.toString(), predicate);
+        jsonObjectBuilder.set(JSON_IMPORTED_POLICY_ID, importedPolicyId.toString(), predicate);
+    }
+
+    @Override
+    public ModifyPolicyImportTransitiveImportsResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return modified(policyId, importedPolicyId, dittoHeaders);
+    }
+
+    @Override
+    public PolicyId getEntityId() {
+        return policyId;
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof ModifyPolicyImportTransitiveImportsResponse;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ModifyPolicyImportTransitiveImportsResponse that =
+                (ModifyPolicyImportTransitiveImportsResponse) o;
+        return that.canEqual(this) &&
+                Objects.equals(policyId, that.policyId) &&
+                Objects.equals(importedPolicyId, that.importedPolicyId) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), policyId, importedPolicyId);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", policyId=" + policyId +
+                ", importedPolicyId=" + importedPolicyId +
+                "]";
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyImportTransitiveImports.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyImportTransitiveImports.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.signals.commands.query;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
+
+/**
+ * Command which retrieves the resolve transitively configuration of a Policy import based on the passed in Policy ID
+ * and imported Policy ID.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableCommand(typePrefix = PolicyCommand.TYPE_PREFIX, name = RetrievePolicyImportTransitiveImports.NAME)
+public final class RetrievePolicyImportTransitiveImports
+        extends AbstractCommand<RetrievePolicyImportTransitiveImports>
+        implements PolicyQueryCommand<RetrievePolicyImportTransitiveImports> {
+
+    /**
+     * Name of the "Retrieve Policy Import Resolve Transitively" command.
+     */
+    public static final String NAME = "retrievePolicyImportTransitiveImports";
+
+    /**
+     * Type of this command.
+     */
+    public static final String TYPE = TYPE_PREFIX + NAME;
+
+    static final JsonFieldDefinition<String> JSON_IMPORTED_POLICY_ID =
+            JsonFactory.newStringFieldDefinition("importedPolicyId", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private final PolicyId policyId;
+    private final PolicyId importedPolicyId;
+
+    private RetrievePolicyImportTransitiveImports(final PolicyId importedPolicyId, final PolicyId policyId,
+            final DittoHeaders dittoHeaders) {
+        super(TYPE, dittoHeaders);
+        this.policyId = checkNotNull(policyId, "Policy identifier");
+        this.importedPolicyId = checkNotNull(importedPolicyId, "Imported Policy ID");
+    }
+
+    /**
+     * Returns a command for retrieving the resolve transitively configuration of a specific Policy import with the
+     * given ID and imported Policy ID.
+     *
+     * @param policyId the ID of a single Policy whose Policy import resolve transitively configuration will be
+     * retrieved by this command.
+     * @param importedPolicyId the specified importedPolicyId for which to retrieve the resolve transitively
+     * configuration for.
+     * @param dittoHeaders the optional command headers of the request.
+     * @return a Command for retrieving the resolve transitively configuration of one Policy import with the
+     * {@code policyId} and {@code importedPolicyId} which is readable from the passed authorization context.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static RetrievePolicyImportTransitiveImports of(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final DittoHeaders dittoHeaders) {
+        return new RetrievePolicyImportTransitiveImports(importedPolicyId, policyId, dittoHeaders);
+    }
+
+    /**
+     * Creates a new {@code RetrievePolicyImportTransitiveImports} from a JSON string.
+     *
+     * @param jsonString the JSON string of which a new RetrievePolicyImportTransitiveImports instance is to be
+     * created.
+     * @param dittoHeaders the optional command headers of the request.
+     * @return the {@code RetrievePolicyImportTransitiveImports} which was created from the given JSON string.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonString} is empty.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * format.
+     */
+    public static RetrievePolicyImportTransitiveImports fromJson(final String jsonString,
+            final DittoHeaders dittoHeaders) {
+        final JsonObject jsonObject = JsonFactory.newObject(jsonString);
+
+        return fromJson(jsonObject, dittoHeaders);
+    }
+
+    /**
+     * Creates a new {@code RetrievePolicyImportTransitiveImports} from a JSON object.
+     *
+     * @param jsonObject the JSON object of which a new RetrievePolicyImportTransitiveImports instance is to be
+     * created.
+     * @param dittoHeaders the optional command headers of the request.
+     * @return the {@code RetrievePolicyImportTransitiveImports} which was created from the given JSON object.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static RetrievePolicyImportTransitiveImports fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new CommandJsonDeserializer<RetrievePolicyImportTransitiveImports>(TYPE, jsonObject)
+                .deserialize(() -> {
+                    final PolicyId policyId = PolicyId.of(
+                            jsonObject.getValueOrThrow(PolicyCommand.JsonFields.JSON_POLICY_ID));
+                    final PolicyId importedPolicyId =
+                            PolicyId.of(jsonObject.getValueOrThrow(JSON_IMPORTED_POLICY_ID));
+
+                    return of(policyId, importedPolicyId, dittoHeaders);
+                });
+    }
+
+    /**
+     * Returns the identifier of the imported Policy of the {@code PolicyImport} to retrieve the resolve transitively
+     * configuration for.
+     *
+     * @return the identifier of the imported Policy.
+     */
+    public PolicyId getImportedPolicyId() {
+        return importedPolicyId;
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        final String path = "/imports/" + importedPolicyId + "/transitiveImports";
+        return JsonPointer.of(path);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(PolicyCommand.JsonFields.JSON_POLICY_ID, policyId.toString(), predicate);
+        jsonObjectBuilder.set(JSON_IMPORTED_POLICY_ID, importedPolicyId.toString(), predicate);
+    }
+
+    @Override
+    public PolicyId getEntityId() {
+        return policyId;
+    }
+
+    @Override
+    public RetrievePolicyImportTransitiveImports setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(policyId, importedPolicyId, dittoHeaders);
+    }
+
+    @SuppressWarnings({"squid:MethodCyclomaticComplexity", "squid:S1067", "OverlyComplexMethod"})
+    @Override
+    public boolean equals(@Nullable final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final RetrievePolicyImportTransitiveImports that = (RetrievePolicyImportTransitiveImports) obj;
+        return that.canEqual(this) &&
+                Objects.equals(policyId, that.policyId) &&
+                Objects.equals(importedPolicyId, that.importedPolicyId) &&
+                super.equals(that);
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof RetrievePolicyImportTransitiveImports;
+    }
+
+    @SuppressWarnings("squid:S109")
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), policyId, importedPolicyId);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", policyId=" + policyId +
+                ", importedPolicyId=" + importedPolicyId +
+                "]";
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyImportTransitiveImportsResponse.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyImportTransitiveImportsResponse.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.signals.commands.query;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommandResponse;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommandResponse;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponseJsonDeserializer;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandResponse;
+
+/**
+ * Response to a {@link RetrievePolicyImportTransitiveImports} command.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableCommandResponse(type = RetrievePolicyImportTransitiveImportsResponse.TYPE)
+public final class RetrievePolicyImportTransitiveImportsResponse
+        extends AbstractCommandResponse<RetrievePolicyImportTransitiveImportsResponse>
+        implements PolicyQueryCommandResponse<RetrievePolicyImportTransitiveImportsResponse> {
+
+    /**
+     * Type of this response.
+     */
+    public static final String TYPE = TYPE_PREFIX + RetrievePolicyImportTransitiveImports.NAME;
+
+    static final JsonFieldDefinition<String> JSON_IMPORTED_POLICY_ID =
+            JsonFactory.newStringFieldDefinition("importedPolicyId", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    static final JsonFieldDefinition<JsonArray> JSON_TRANSITIVE_IMPORTS =
+            JsonFactory.newJsonArrayFieldDefinition("transitiveImports", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private static final HttpStatus HTTP_STATUS = HttpStatus.OK;
+
+    private static final CommandResponseJsonDeserializer<RetrievePolicyImportTransitiveImportsResponse>
+            JSON_DESERIALIZER =
+            CommandResponseJsonDeserializer.newInstance(TYPE,
+                    context -> {
+                        final JsonObject jsonObject = context.getJsonObject();
+                        return new RetrievePolicyImportTransitiveImportsResponse(
+                                PolicyId.of(jsonObject.getValueOrThrow(
+                                        PolicyCommandResponse.JsonFields.JSON_POLICY_ID)),
+                                PolicyId.of(jsonObject.getValueOrThrow(JSON_IMPORTED_POLICY_ID)),
+                                jsonObject.getValueOrThrow(JSON_TRANSITIVE_IMPORTS),
+                                context.getDeserializedHttpStatus(),
+                                context.getDittoHeaders()
+                        );
+                    });
+
+    private final PolicyId policyId;
+    private final PolicyId importedPolicyId;
+    private final JsonArray transitiveImports;
+
+    private RetrievePolicyImportTransitiveImportsResponse(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final JsonArray transitiveImports,
+            final HttpStatus statusCode,
+            final DittoHeaders dittoHeaders) {
+
+        super(TYPE, statusCode, dittoHeaders);
+        this.policyId = checkNotNull(policyId, "policyId");
+        this.importedPolicyId = checkNotNull(importedPolicyId, "importedPolicyId");
+        this.transitiveImports = checkNotNull(transitiveImports, "transitiveImports");
+    }
+
+    /**
+     * Creates a response to a {@code RetrievePolicyImportTransitiveImports} command.
+     *
+     * @param policyId the Policy ID of the retrieved resolve transitively configuration.
+     * @param importedPolicyId the imported Policy ID.
+     * @param transitiveImports the retrieved resolve transitively list of Policy IDs.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static RetrievePolicyImportTransitiveImportsResponse of(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports,
+            final DittoHeaders dittoHeaders) {
+
+        final JsonArray jsonArray = checkNotNull(transitiveImports, "transitiveImports").stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+
+        return new RetrievePolicyImportTransitiveImportsResponse(policyId, importedPolicyId, jsonArray,
+                HTTP_STATUS, dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a {@code RetrievePolicyImportTransitiveImports} command.
+     *
+     * @param policyId the Policy ID of the retrieved resolve transitively configuration.
+     * @param importedPolicyId the imported Policy ID.
+     * @param transitiveImports the retrieved resolve transitively as JSON array.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static RetrievePolicyImportTransitiveImportsResponse of(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final JsonArray transitiveImports,
+            final DittoHeaders dittoHeaders) {
+
+        return new RetrievePolicyImportTransitiveImportsResponse(policyId, importedPolicyId, transitiveImports,
+                HTTP_STATUS, dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a {@code RetrievePolicyImportTransitiveImports} command from a JSON string.
+     *
+     * @param jsonString the JSON string of which the response is to be created.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonString} is empty.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * format.
+     */
+    public static RetrievePolicyImportTransitiveImportsResponse fromJson(final String jsonString,
+            final DittoHeaders dittoHeaders) {
+        return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a {@code RetrievePolicyImportTransitiveImports} command from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the response is to be created.
+     * @param dittoHeaders the headers of the preceding command.
+     * @return the response.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static RetrievePolicyImportTransitiveImportsResponse fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return JSON_DESERIALIZER.deserialize(jsonObject, dittoHeaders);
+    }
+
+    /**
+     * Returns the retrieved resolve transitively list of Policy IDs.
+     *
+     * @return the retrieved resolve transitively list of Policy IDs.
+     */
+    public List<PolicyId> getTransitiveImports() {
+        return transitiveImports.stream()
+                .map(JsonValue::asString)
+                .map(PolicyId::of)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public JsonValue getEntity(final JsonSchemaVersion schemaVersion) {
+        return transitiveImports;
+    }
+
+    @Override
+    public RetrievePolicyImportTransitiveImportsResponse setEntity(final JsonValue entity) {
+        checkNotNull(entity, "entity");
+        return of(policyId, importedPolicyId, entity.asArray(), getDittoHeaders());
+    }
+
+    @Override
+    public RetrievePolicyImportTransitiveImportsResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(policyId, importedPolicyId, transitiveImports, dittoHeaders);
+    }
+
+    @Override
+    public PolicyId getEntityId() {
+        return policyId;
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        final String path = "/imports/" + importedPolicyId + "/transitiveImports";
+        return JsonPointer.of(path);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(PolicyCommandResponse.JsonFields.JSON_POLICY_ID, policyId.toString(), predicate);
+        jsonObjectBuilder.set(JSON_IMPORTED_POLICY_ID, importedPolicyId.toString(), predicate);
+        jsonObjectBuilder.set(JSON_TRANSITIVE_IMPORTS, transitiveImports, predicate);
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof RetrievePolicyImportTransitiveImportsResponse;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RetrievePolicyImportTransitiveImportsResponse that =
+                (RetrievePolicyImportTransitiveImportsResponse) o;
+        return that.canEqual(this) &&
+                Objects.equals(policyId, that.policyId) &&
+                Objects.equals(importedPolicyId, that.importedPolicyId) &&
+                Objects.equals(transitiveImports, that.transitiveImports) &&
+                super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), policyId, importedPolicyId, transitiveImports);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", policyId=" + policyId +
+                ", importedPolicyId=" + importedPolicyId +
+                ", transitiveImports=" + transitiveImports +
+                "]";
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyImportTransitiveImportsModified.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyImportTransitiveImportsModified.java
@@ -26,6 +26,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import static org.eclipse.ditto.base.model.exceptions.DittoJsonException.wrapJsonRuntimeException;
+
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonParsableEvent;
@@ -189,12 +191,14 @@ public final class PolicyImportTransitiveImportsModified
 
     @Override
     public PolicyImportTransitiveImportsModified setEntity(final JsonValue entity) {
-        final List<PolicyId> policyIds = entity.asArray().stream()
-                .map(JsonValue::asString)
-                .map(PolicyId::of)
-                .collect(Collectors.toList());
-        return of(getPolicyEntityId(), importedPolicyId, policyIds,
-                getRevision(), getTimestamp().orElse(null), getDittoHeaders(), getMetadata().orElse(null));
+        return wrapJsonRuntimeException(() -> {
+            final List<PolicyId> policyIds = entity.asArray().stream()
+                    .map(JsonValue::asString)
+                    .map(PolicyId::of)
+                    .collect(Collectors.toList());
+            return of(getPolicyEntityId(), importedPolicyId, policyIds,
+                    getRevision(), getTimestamp().orElse(null), getDittoHeaders(), getMetadata().orElse(null));
+        });
     }
 
     @Override

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyImportTransitiveImportsModified.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/events/PolicyImportTransitiveImportsModified.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.signals.events;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.PolicyId;
+
+/**
+ * This event is emitted after the resolve transitively configuration of a Policy import was modified.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableEvent(name = PolicyImportTransitiveImportsModified.NAME, typePrefix = PolicyEvent.TYPE_PREFIX)
+public final class PolicyImportTransitiveImportsModified
+        extends AbstractPolicyEvent<PolicyImportTransitiveImportsModified>
+        implements PolicyEvent<PolicyImportTransitiveImportsModified> {
+
+    /**
+     * Name of this event.
+     */
+    public static final String NAME = "policyImportTransitiveImportsModified";
+
+    /**
+     * Type of this event.
+     */
+    public static final String TYPE = TYPE_PREFIX + NAME;
+
+    static final JsonFieldDefinition<String> JSON_IMPORTED_POLICY_ID =
+            JsonFactory.newStringFieldDefinition("importedPolicyId", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    static final JsonFieldDefinition<JsonArray> JSON_TRANSITIVE_IMPORTS =
+            JsonFactory.newJsonArrayFieldDefinition("transitiveImports", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private final PolicyId importedPolicyId;
+    private final List<PolicyId> transitiveImports;
+
+    private PolicyImportTransitiveImportsModified(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports,
+            final long revision,
+            @Nullable final Instant timestamp,
+            final DittoHeaders dittoHeaders,
+            @Nullable final Metadata metadata) {
+
+        super(TYPE, checkNotNull(policyId, "policyId"), revision, timestamp, dittoHeaders, metadata);
+        this.importedPolicyId = checkNotNull(importedPolicyId, "importedPolicyId");
+        this.transitiveImports = Collections.unmodifiableList(
+                checkNotNull(transitiveImports, "transitiveImports"));
+    }
+
+    /**
+     * Constructs a new {@code PolicyImportTransitiveImportsModified} object indicating the modification of the
+     * resolve transitively configuration.
+     *
+     * @param policyId the identifier of the Policy to which the modified import belongs.
+     * @param importedPolicyId the identifier of the imported Policy.
+     * @param transitiveImports the modified list of Policy IDs to resolve transitively.
+     * @param revision the revision of the Policy.
+     * @param timestamp the timestamp of this event.
+     * @param dittoHeaders the headers of the command which was the cause of this event.
+     * @param metadata the metadata to apply for the event.
+     * @return the created PolicyImportTransitiveImportsModified.
+     * @throws NullPointerException if any argument but {@code timestamp} and {@code metadata} is {@code null}.
+     */
+    public static PolicyImportTransitiveImportsModified of(final PolicyId policyId,
+            final PolicyId importedPolicyId,
+            final List<PolicyId> transitiveImports,
+            final long revision,
+            @Nullable final Instant timestamp,
+            final DittoHeaders dittoHeaders,
+            @Nullable final Metadata metadata) {
+
+        return new PolicyImportTransitiveImportsModified(policyId, importedPolicyId, transitiveImports,
+                revision, timestamp, dittoHeaders, metadata);
+    }
+
+    /**
+     * Creates a new {@code PolicyImportTransitiveImportsModified} from a JSON string.
+     *
+     * @param jsonString the JSON string from which a new PolicyImportTransitiveImportsModified instance is to be
+     * created.
+     * @param dittoHeaders the headers of the command which was the cause of this event.
+     * @return the {@code PolicyImportTransitiveImportsModified} which was created from the given JSON string.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * 'PolicyImportTransitiveImportsModified' format.
+     */
+    public static PolicyImportTransitiveImportsModified fromJson(final String jsonString,
+            final DittoHeaders dittoHeaders) {
+        return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
+    }
+
+    /**
+     * Creates a new {@code PolicyImportTransitiveImportsModified} from a JSON object.
+     *
+     * @param jsonObject the JSON object from which a new PolicyImportTransitiveImportsModified instance is to be
+     * created.
+     * @param dittoHeaders the headers of the command which was the cause of this event.
+     * @return the {@code PolicyImportTransitiveImportsModified} which was created from the given JSON object.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * 'PolicyImportTransitiveImportsModified' format.
+     */
+    public static PolicyImportTransitiveImportsModified fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new EventJsonDeserializer<PolicyImportTransitiveImportsModified>(TYPE, jsonObject)
+                .deserialize((revision, timestamp, metadata) -> {
+                    final String extractedPolicyId =
+                            jsonObject.getValueOrThrow(PolicyEvent.JsonFields.POLICY_ID);
+                    final PolicyId policyId = PolicyId.of(extractedPolicyId);
+                    final PolicyId importedPolicyId =
+                            PolicyId.of(jsonObject.getValueOrThrow(JSON_IMPORTED_POLICY_ID));
+                    final JsonArray transitiveImportsArray =
+                            jsonObject.getValueOrThrow(JSON_TRANSITIVE_IMPORTS);
+                    final List<PolicyId> transitiveImports = transitiveImportsArray.stream()
+                            .map(JsonValue::asString)
+                            .map(PolicyId::of)
+                            .collect(Collectors.toList());
+
+                    return of(policyId, importedPolicyId, transitiveImports, revision, timestamp,
+                            dittoHeaders, metadata);
+                });
+    }
+
+    /**
+     * Returns the identifier of the imported Policy.
+     *
+     * @return the identifier of the imported Policy.
+     */
+    public PolicyId getImportedPolicyId() {
+        return importedPolicyId;
+    }
+
+    /**
+     * Returns the modified list of Policy IDs to resolve transitively.
+     *
+     * @return the modified resolve transitively list.
+     */
+    public List<PolicyId> getTransitiveImports() {
+        return transitiveImports;
+    }
+
+    @Override
+    public Optional<JsonValue> getEntity(final JsonSchemaVersion schemaVersion) {
+        final JsonArray jsonArray = transitiveImports.stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+        return Optional.of(jsonArray);
+    }
+
+    @Override
+    public PolicyImportTransitiveImportsModified setEntity(final JsonValue entity) {
+        final List<PolicyId> policyIds = entity.asArray().stream()
+                .map(JsonValue::asString)
+                .map(PolicyId::of)
+                .collect(Collectors.toList());
+        return of(getPolicyEntityId(), importedPolicyId, policyIds,
+                getRevision(), getTimestamp().orElse(null), getDittoHeaders(), getMetadata().orElse(null));
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        final String path = "/imports/" + importedPolicyId + "/transitiveImports";
+        return JsonPointer.of(path);
+    }
+
+    @Override
+    public PolicyImportTransitiveImportsModified setRevision(final long revision) {
+        return of(getPolicyEntityId(), importedPolicyId, transitiveImports, revision,
+                getTimestamp().orElse(null), getDittoHeaders(), getMetadata().orElse(null));
+    }
+
+    @Override
+    public PolicyImportTransitiveImportsModified setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(getPolicyEntityId(), importedPolicyId, transitiveImports, getRevision(),
+                getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder,
+            final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(JSON_IMPORTED_POLICY_ID, importedPolicyId.toString(), predicate);
+        final JsonArray jsonArray = transitiveImports.stream()
+                .map(PolicyId::toString)
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray());
+        jsonObjectBuilder.set(JSON_TRANSITIVE_IMPORTS, jsonArray, predicate);
+    }
+
+    @SuppressWarnings("squid:S109")
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hashCode(importedPolicyId);
+        result = prime * result + Objects.hashCode(transitiveImports);
+        return result;
+    }
+
+    @SuppressWarnings("squid:MethodCyclomaticComplexity")
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (null == o || getClass() != o.getClass()) {
+            return false;
+        }
+        final PolicyImportTransitiveImportsModified that = (PolicyImportTransitiveImportsModified) o;
+        return that.canEqual(this) &&
+                Objects.equals(importedPolicyId, that.importedPolicyId) &&
+                Objects.equals(transitiveImports, that.transitiveImports) &&
+                super.equals(that);
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof PolicyImportTransitiveImportsModified;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", importedPolicyId=" + importedPolicyId +
+                ", transitiveImports=" + transitiveImports +
+                "]";
+    }
+
+}

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableEffectedImportsTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableEffectedImportsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.ditto.policies.model.assertions.DittoPolicyAssertions.
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -64,6 +65,51 @@ public final class ImmutableEffectedImportsTest {
     @Test
     public void testGetEntriesAdditionsEmpty() {
         assertThat(underTest.getEntriesAdditions()).isEmpty();
+    }
+
+    @Test
+    public void testToAndFromJsonWithTransitiveImports() {
+        final List<PolicyId> transitiveImports =
+                Collections.singletonList(PolicyId.of("ns", "template"));
+        final EntriesAdditions entriesAdditions = ImmutableEntriesAdditions.of(Collections.singletonList(
+                ImmutableEntryAddition.of(Label.of("IncludedEntry1"),
+                        Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "extraUser")),
+                        null)));
+
+        final EffectedImports withTransitive = ImmutableEffectedImports.of(
+                Arrays.asList(Label.of("IncludedEntry1"), Label.of("IncludedEntry2")),
+                entriesAdditions,
+                transitiveImports);
+
+        final JsonObject json = withTransitive.toJson();
+        final EffectedImports fromJson = ImmutableEffectedImports.fromJson(json);
+
+        // Round-trip equality
+        assertThat(withTransitive).isEqualTo(fromJson);
+        // JSON contains the transitiveImports key with expected content
+        assertThat(json.contains("transitiveImports")).isTrue();
+        assertThat(json.getValue("transitiveImports")).isPresent();
+        assertThat(json.getValue("transitiveImports").get().asArray().get(0).get().asString())
+                .isEqualTo("ns:template");
+    }
+
+    @Test
+    public void testGetTransitiveImportsReturnsEmptyListByDefault() {
+        // underTest is created with just labels (no transitiveImports)
+        assertThat(underTest.getTransitiveImports()).isEmpty();
+    }
+
+    @Test
+    public void testTransitiveImportsNotSerializedWhenEmpty() {
+        final EffectedImports withEmptyTransitive = ImmutableEffectedImports.of(
+                Arrays.asList(Label.of("IncludedEntry1"), Label.of("IncludedEntry2")),
+                null,
+                Collections.emptyList());
+
+        final JsonObject json = withEmptyTransitive.toJson();
+
+        // JSON should NOT contain transitiveImports key when empty
+        assertThat(json.contains("transitiveImports")).isFalse();
     }
 
     @Test

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutablePolicyImportTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutablePolicyImportTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.ditto.policies.model.assertions.DittoPolicyAssertions.
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
@@ -66,6 +67,25 @@ public final class ImmutablePolicyImportTest {
 
         final PolicyImport policyImport = ImmutablePolicyImport.fromJson(IMPORTED_POLICY_ID, jsonObject);
         assertThat(policyImport.getEffectedImports()).isEmpty();
+    }
+
+    @Test
+    public void testGetTransitiveImportsDelegation() {
+        final List<PolicyId> transitiveImports = Arrays.asList(
+                PolicyId.of("ns", "templateA"),
+                PolicyId.of("ns", "templateB"));
+
+        final EffectedImports effectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(Label.of("IncludedPolicyImport1")),
+                null,
+                transitiveImports);
+
+        final PolicyImport policyImport = ImmutablePolicyImport.of(IMPORTED_POLICY_ID, effectedImports);
+
+        assertThat(policyImport.getTransitiveImports()).hasSize(2);
+        assertThat(policyImport.getTransitiveImports()).containsExactly(
+                PolicyId.of("ns", "templateA"),
+                PolicyId.of("ns", "templateB"));
     }
 
     @Test

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
@@ -791,6 +791,483 @@ public final class PolicyImporterTest {
                 .hasValueSatisfying(ns -> assertThat(ns).contains("com.acme", "org.example", "org.example.*"));
     }
 
+    @Test
+    public void transitiveResolutionMergesEntriesFromTransitivePolicy() {
+        // Policy C (template) has a "ROLE" entry with implicit importability and allows subject additions
+        final PolicyId policyIdC = PolicyId.of("com.example", "templateC");
+        final Label roleLabel = Label.of("ROLE");
+        final ResourceKey roleResourceKey = ResourceKey.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                JsonPointer.of("attributes"));
+        final Resource roleResource = Resource.newInstance(roleResourceKey,
+                EffectedPermissions.newInstance(
+                        Permissions.newInstance(TestConstants.Policy.PERMISSION_READ,
+                                TestConstants.Policy.PERMISSION_WRITE),
+                        Permissions.none()));
+        final Subject templateSubject = Subject.newInstance(SubjectIssuer.GOOGLE, "templateGroup");
+        final PolicyEntry roleEntryInC = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(templateSubject),
+                Resources.newInstance(roleResource),
+                ImportableType.IMPLICIT,
+                ALLOWED_SUBJECTS);
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(roleEntryInC));
+
+        // Policy B (intermediate) imports from C and adds a subject to "ROLE" via entriesAdditions
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediateB");
+        final Subject additionalSubjectFromB = Subject.newInstance(SubjectIssuer.GOOGLE, "bUser");
+        final EntriesAdditions bAdditions = PoliciesModelFactory.newEntriesAdditions(
+                Collections.singletonList(
+                        PoliciesModelFactory.newEntryAddition(roleLabel,
+                                Subjects.newInstance(additionalSubjectFromB), null)));
+        final EffectedImports bEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), bAdditions);
+        final PolicyImport bImportOfC = PoliciesModelFactory.newPolicyImport(policyIdC, bEffectedImports);
+        // B has no inline entries (empty entries), only an import of C
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(bImportOfC)),
+                Collections.emptyList());
+
+        // Policy A imports from B, requesting transitive resolution of C
+        final EffectedImports aEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(roleLabel),
+                null,
+                Collections.singletonList(policyIdC));
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .set(KNOWN_POLICY_ENTRY_OWN)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffectedImports))
+                .build();
+
+        // Policy loader returns B and C
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // Find the ROLE entry imported via B (single prefix — transitive resolution does not double-prefix)
+        final Label importedRoleLabel = PoliciesModelFactory.newImportedLabel(policyIdB, roleLabel);
+        final PolicyEntry mergedEntry = entries.stream()
+                .filter(e -> e.getLabel().equals(importedRoleLabel))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected transitively resolved ROLE entry not found"));
+
+        // Should contain BOTH resources from C AND subjects from B's entriesAdditions
+        assertThat(mergedEntry.getResources().getResource(roleResourceKey)).isPresent();
+        assertThat(mergedEntry.getSubjects().getSubject(templateSubject.getId())).isPresent();
+        assertThat(mergedEntry.getSubjects().getSubject(additionalSubjectFromB.getId())).isPresent();
+    }
+
+    @Test
+    public void transitiveResolutionIgnoredWhenTransitiveImportsIsEmpty() {
+        // Same setup as the transitive test, but A's import has NO transitiveImports
+        final PolicyId policyIdC = PolicyId.of("com.example", "templateC2");
+        final Label roleLabel = Label.of("ROLE");
+        final PolicyEntry roleEntryInC = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "templateGroup")),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("attributes"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.IMPLICIT,
+                ALLOWED_SUBJECTS);
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(roleEntryInC));
+
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediateB2");
+        final EntriesAdditions bAdditions = PoliciesModelFactory.newEntriesAdditions(
+                Collections.singletonList(
+                        PoliciesModelFactory.newEntryAddition(roleLabel,
+                                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "bUser")),
+                                null)));
+        final EffectedImports bEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), bAdditions);
+        final PolicyImport bImportOfC = PoliciesModelFactory.newPolicyImport(policyIdC, bEffectedImports);
+        // B has no inline entries, only an import of C
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(bImportOfC)),
+                Collections.emptyList());
+
+        // A imports from B WITHOUT transitiveImports
+        final EffectedImports aEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(roleLabel));
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .set(KNOWN_POLICY_ENTRY_OWN)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffectedImports))
+                .build();
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // Without transitive resolution, B has no inline entries, so ROLE should NOT appear
+        assertThat(entries).containsExactlyInAnyOrder(KNOWN_POLICY_ENTRY_OWN);
+    }
+
+    @Test
+    public void transitiveResolutionIgnoresNonexistentTransitiveId() {
+        // B has no import of "nonexistent:policy"
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediateB3");
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.emptyList());
+
+        // A imports from B with transitiveImports pointing to a nonexistent policy
+        final PolicyId nonexistentId = PolicyId.of("nonexistent", "policy");
+        final EffectedImports aEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(),
+                null,
+                Collections.singletonList(nonexistentId));
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .set(KNOWN_POLICY_ENTRY_OWN)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffectedImports))
+                .build();
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // No error, result contains only A's own entry
+        assertThat(entries).containsExactlyInAnyOrder(KNOWN_POLICY_ENTRY_OWN);
+    }
+
+    @Test
+    public void transitiveResolutionDoesNotAffectOtherImports() {
+        // Policy C (template)
+        final PolicyId policyIdC = PolicyId.of("com.example", "templateC4");
+        final Label roleLabel = Label.of("ROLE");
+        final PolicyEntry roleEntryInC = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "templateGroup")),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("attributes"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.IMPLICIT,
+                Collections.emptySet());
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(roleEntryInC));
+
+        // Policy B (intermediate) imports from C
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediateB4");
+        final PolicyImport bImportOfC = PoliciesModelFactory.newPolicyImport(policyIdC, (EffectedImports) null);
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(bImportOfC)),
+                Collections.emptyList());
+
+        // Policy D has inline entries (no transitiveImports needed)
+        final PolicyId policyIdD = PolicyId.of("com.example", "directD");
+        final Label dLabel = Label.of("DirectEntry");
+        final PolicyEntry dEntry = ImmutablePolicyEntry.of(dLabel,
+                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "dUser")),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("features"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.IMPLICIT,
+                Collections.emptySet());
+        final Policy policyD = ImmutablePolicy.of(policyIdD, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(dEntry));
+
+        // A imports from B (with transitiveImports for C) AND from D (without transitiveImports)
+        final EffectedImports aEffectedImportsForB = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(),
+                null,
+                Collections.singletonList(policyIdC));
+        final EffectedImports aEffectedImportsForD = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList());
+
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .set(KNOWN_POLICY_ENTRY_OWN)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffectedImportsForB))
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdD, aEffectedImportsForD))
+                .build();
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            } else if (policyIdD.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyD));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // D's entries should be imported normally (implicit entry)
+        final Label importedDLabel = PoliciesModelFactory.newImportedLabel(policyIdD, dLabel);
+        assertThat(entries.stream().anyMatch(e -> e.getLabel().equals(importedDLabel))).isTrue();
+
+        // B's transitive entries from C should also be resolved (single prefix — no double-prefix)
+        final Label importedRoleLabel = PoliciesModelFactory.newImportedLabel(policyIdB, roleLabel);
+        assertThat(entries.stream().anyMatch(e -> e.getLabel().equals(importedRoleLabel))).isTrue();
+
+        // A's own entry should be preserved
+        assertThat(entries.stream().anyMatch(e -> e.getLabel().equals(END_USER_LABEL))).isTrue();
+    }
+
+    @Test
+    public void transitiveResolutionWorksAcrossThreeLevels() {
+        // 3-level chain: A → B → C → D
+        // D has inline entry "ROLE" with resources (the template)
+        // C imports D with entriesAdditions adding subject "cUser" (the intermediate — adds subjects)
+        // B imports C with transitiveImports: ["D"] (pass-through — enables C's import of D to be resolved)
+        // A imports B with transitiveImports: ["C"] (leaf — enables B's import of C to be resolved)
+        // Result: A should see ROLE with resources from D + subjects from C's entriesAdditions
+
+        final PolicyId policyIdD = PolicyId.of("com.example", "templateD");
+        final PolicyId policyIdC = PolicyId.of("com.example", "intermediateC");
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediateB");
+        final Label roleLabel = Label.of("ROLE");
+
+        final Subject templateSubject = Subject.newInstance(SubjectIssuer.GOOGLE, "templateGroup");
+        final Subject subjectFromC = Subject.newInstance(SubjectIssuer.GOOGLE, "cUser");
+        final ResourceKey roleResourceKey = ResourceKey.newInstance(
+                TestConstants.Policy.RESOURCE_TYPE, JsonPointer.of("attributes"));
+
+        // D: template with inline entry ROLE (resources + allowedImportAdditions)
+        final Set<AllowedImportAddition> allowedSubjects =
+                Collections.singleton(AllowedImportAddition.SUBJECTS);
+        final PolicyEntry roleEntryInD = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(templateSubject),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("attributes"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.IMPLICIT,
+                allowedSubjects);
+        final Policy policyD = ImmutablePolicy.of(policyIdD, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(roleEntryInD));
+
+        // C: imports from D with entriesAdditions adding "cUser" (no transitiveImports — D has inline entries)
+        final EntriesAdditions cAdditions = PoliciesModelFactory.newEntriesAdditions(
+                Collections.singletonList(
+                        PoliciesModelFactory.newEntryAddition(roleLabel,
+                                Subjects.newInstance(subjectFromC), null)));
+        final EffectedImports cEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), cAdditions);
+        final PolicyImport cImportOfD = PoliciesModelFactory.newPolicyImport(policyIdD, cEffectedImports);
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(cImportOfD)),
+                Collections.emptyList());
+
+        // B: imports from C with transitiveImports: ["D"] (resolve C's import of D)
+        // B is a pass-through — no entriesAdditions of its own
+        final EffectedImports bEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), null, Collections.singletonList(policyIdD));
+        final PolicyImport bImportOfC = PoliciesModelFactory.newPolicyImport(policyIdC, bEffectedImports);
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(bImportOfC)),
+                Collections.emptyList());
+
+        // A: imports from B with transitiveImports: ["C"] (resolve B's import of C)
+        final EffectedImports aEffectedImports = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(roleLabel),
+                null,
+                Collections.singletonList(policyIdC));
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffectedImports))
+                .build();
+
+        // Policy loader returns all policies
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            } else if (policyIdD.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyD));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // The ROLE entry resolved through 3 levels gets a single prefix from the outer import (B)
+        final Label importedRoleLabel = PoliciesModelFactory.newImportedLabel(policyIdB, roleLabel);
+        final PolicyEntry mergedEntry = entries.stream()
+                .filter(e -> e.getLabel().equals(importedRoleLabel))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "Expected 3-level transitively resolved ROLE entry not found. Available labels: " +
+                                entries.stream().map(e -> e.getLabel().toString()).collect(
+                                        java.util.stream.Collectors.joining(", "))));
+
+        // Should contain resources from D (template)
+        assertThat(mergedEntry.getResources().getResource(roleResourceKey)).isPresent();
+        // Should contain the template subject from D
+        assertThat(mergedEntry.getSubjects().getSubject(templateSubject.getId())).isPresent();
+        // Should contain subject added by C's entriesAdditions
+        assertThat(mergedEntry.getSubjects().getSubject(subjectFromC.getId())).isPresent();
+    }
+
+    @Test
+    public void mutualTransitiveCycleDoesNotCauseInfiniteRecursion() {
+        // 3-policy cycle that passes write-time validation (no policy references itself):
+        // A imports B with transitiveImports=["C"]  (C != A → valid)
+        // B imports C with transitiveImports=["A"]  (A != B → valid)
+        // C imports A with transitiveImports=["B"]  (B != C → valid)
+        // At resolution time, this creates an infinite cycle that the depth limit must break.
+        final PolicyId policyIdA = PolicyId.of("com.example", "cycleA");
+        final PolicyId policyIdB = PolicyId.of("com.example", "cycleB");
+        final PolicyId policyIdC = PolicyId.of("com.example", "cycleC");
+        final Label roleLabel = Label.of("ROLE");
+
+        final PolicyEntry roleEntry = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "user")),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("attributes"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.IMPLICIT);
+
+        // C imports A with transitiveImports=["B"]
+        final EffectedImports cEffected = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), null, Collections.singletonList(policyIdB));
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(
+                        PoliciesModelFactory.newPolicyImport(policyIdA, cEffected))),
+                Collections.singletonList(roleEntry));
+
+        // B imports C with transitiveImports=["A"]
+        final EffectedImports bEffected = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), null, Collections.singletonList(policyIdA));
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(
+                        PoliciesModelFactory.newPolicyImport(policyIdC, bEffected))),
+                Collections.emptyList());
+
+        // A imports B with transitiveImports=["C"]
+        final EffectedImports aEffected = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), null, Collections.singletonList(policyIdC));
+        final Policy policyA = ImmutablePolicy.of(policyIdA, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(
+                        PoliciesModelFactory.newPolicyImport(policyIdB, aEffected))),
+                Collections.emptyList());
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdA.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyA));
+            } else if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        // Must complete without StackOverflowError — depth limit breaks the cycle
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // Resolution completes (depth limit prevents infinite recursion) and produces some entries
+        assertThat(entries).isNotNull();
+    }
+
+    @Test
+    public void transitiveResolutionWorksWithExplicitImportableType() {
+        // C has an EXPLICIT entry "ROLE". B imports C. A imports B with entries=["ROLE"] + transitiveImports=["C"].
+        // Without the label prefix fix, the EXPLICIT entry would be silently dropped due to label mismatch.
+        final PolicyId policyIdC = PolicyId.of("com.example", "explicitTemplateC");
+        final PolicyId policyIdB = PolicyId.of("com.example", "explicitIntermediateB");
+        final Label roleLabel = Label.of("ROLE");
+        final ResourceKey roleResourceKey = ResourceKey.newInstance(
+                TestConstants.Policy.RESOURCE_TYPE, JsonPointer.of("attributes"));
+
+        // C has EXPLICIT entry "ROLE"
+        final PolicyEntry roleEntryInC = ImmutablePolicyEntry.of(roleLabel,
+                Subjects.newInstance(Subject.newInstance(SubjectIssuer.GOOGLE, "templateGroup")),
+                Resources.newInstance(Resource.newInstance(TestConstants.Policy.RESOURCE_TYPE,
+                        JsonPointer.of("attributes"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                ImportableType.EXPLICIT);
+        final Policy policyC = ImmutablePolicy.of(policyIdC, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null, emptyPolicyImports(),
+                Collections.singletonList(roleEntryInC));
+
+        // B imports C (no entriesAdditions, no transitiveImports — C has inline entries)
+        final EffectedImports bEffected = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(roleLabel));
+        final Policy policyB = ImmutablePolicy.of(policyIdB, PolicyLifecycle.ACTIVE,
+                PolicyRevision.newInstance(1), null, null, null,
+                PoliciesModelFactory.newPolicyImports(Collections.singletonList(
+                        PoliciesModelFactory.newPolicyImport(policyIdC, bEffected))),
+                Collections.emptyList());
+
+        // A imports B with entries=["ROLE"] and transitiveImports=["C"]
+        final EffectedImports aEffected = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.singletonList(roleLabel), null, Collections.singletonList(policyIdC));
+        final Policy policyA = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB, aEffected))
+                .build();
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = (id) -> {
+            if (policyIdB.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyB));
+            } else if (policyIdC.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(policyC));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Set<PolicyEntry> entries =
+                PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
+
+        // The EXPLICIT "ROLE" entry from C should be imported via B with a single prefix
+        final Label importedRoleLabel = PoliciesModelFactory.newImportedLabel(policyIdB, roleLabel);
+        final PolicyEntry mergedEntry = entries.stream()
+                .filter(e -> e.getLabel().equals(importedRoleLabel))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "Expected EXPLICIT ROLE entry not found. Available labels: " +
+                                entries.stream().map(e -> e.getLabel().toString()).collect(
+                                        java.util.stream.Collectors.joining(", "))));
+
+        assertThat(mergedEntry.getResources().getResource(roleResourceKey)).isPresent();
+    }
+
     private static Policy createImportedPolicy(final PolicyId importedPolicyId) {
         final List<PolicyEntry> policyEntries =
                 Arrays.asList(policyEntry(ImportableType.IMPLICIT), policyEntry(ImportableType.EXPLICIT),

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
@@ -1200,8 +1200,11 @@ public final class PolicyImporterTest {
         final Set<PolicyEntry> entries =
                 PolicyImporter.mergeImportedPolicyEntries(policyA, loader).toCompletableFuture().join();
 
-        // Resolution completes (depth limit prevents infinite recursion) and produces some entries
-        assertThat(entries).isNotNull();
+        // Resolution terminates and produces C's ROLE entry via the chain A → B → (transitive C) → ROLE.
+        // The cycle (A→B→C→A) is broken by the visited-set; only the first traversal contributes entries.
+        assertThat(entries).isNotEmpty();
+        assertThat(entries).hasSize(1);
+        assertThat(entries.iterator().next().getLabel().toString()).contains("ROLE");
     }
 
     @Test

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifyPolicyImportTransitiveImportsStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifyPolicyImportTransitiveImportsStrategy.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.service.persistence.actors.strategies.commands;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
+import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
+import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
+import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportTransitiveImports;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportTransitiveImportsResponse;
+import org.eclipse.ditto.policies.model.signals.events.PolicyEvent;
+import org.eclipse.ditto.policies.model.signals.events.PolicyImportTransitiveImportsModified;
+import org.eclipse.ditto.policies.service.common.config.PolicyConfig;
+
+/**
+ * This strategy handles the {@link ModifyPolicyImportTransitiveImports} command.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+final class ModifyPolicyImportTransitiveImportsStrategy
+        extends AbstractPolicyCommandStrategy<ModifyPolicyImportTransitiveImports, PolicyEvent<?>> {
+
+    ModifyPolicyImportTransitiveImportsStrategy(final PolicyConfig policyConfig) {
+        super(ModifyPolicyImportTransitiveImports.class, policyConfig);
+    }
+
+    @Override
+    protected Result<PolicyEvent<?>> doApply(final Context<PolicyId> context,
+            @Nullable final Policy policy,
+            final long nextRevision,
+            final ModifyPolicyImportTransitiveImports command,
+            @Nullable final Metadata metadata) {
+
+        final Policy nonNullPolicy = checkNotNull(policy, "policy");
+        final PolicyId policyId = context.getState();
+        final PolicyId importedPolicyId = command.getImportedPolicyId();
+        final List<PolicyId> transitiveImports = command.getTransitiveImports();
+        final DittoHeaders dittoHeaders = command.getDittoHeaders();
+
+        final Optional<PolicyImport> optionalImport =
+                nonNullPolicy.getPolicyImports().getPolicyImport(importedPolicyId);
+        if (optionalImport.isPresent()) {
+            final PolicyImportTransitiveImportsModified event =
+                    PolicyImportTransitiveImportsModified.of(policyId, importedPolicyId, transitiveImports,
+                            nextRevision, getEventTimestamp(), dittoHeaders, metadata);
+            final WithDittoHeaders response = appendETagHeaderIfProvided(command,
+                    ModifyPolicyImportTransitiveImportsResponse.modified(policyId, importedPolicyId,
+                            createCommandResponseDittoHeaders(dittoHeaders, nextRevision)),
+                    nonNullPolicy);
+            return ResultFactory.newMutationResult(command, event, response);
+        } else {
+            return ResultFactory.newErrorResult(
+                    policyImportNotFound(policyId, importedPolicyId, dittoHeaders), command);
+        }
+    }
+
+    @Override
+    public Optional<EntityTag> previousEntityTag(final ModifyPolicyImportTransitiveImports command,
+            @Nullable final Policy previousEntity) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<EntityTag> nextEntityTag(final ModifyPolicyImportTransitiveImports command,
+            @Nullable final Policy newEntity) {
+        return Optional.empty();
+    }
+}

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/PolicyCommandStrategies.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/PolicyCommandStrategies.java
@@ -90,6 +90,10 @@ public final class PolicyCommandStrategies
         addStrategy(new ModifyPolicyImportEntryAdditionStrategy(policyConfig));
         addStrategy(new DeletePolicyImportEntryAdditionStrategy(policyConfig));
 
+        // Policy Import Resolve Transitively
+        addStrategy(new RetrievePolicyImportTransitiveImportsStrategy(policyConfig));
+        addStrategy(new ModifyPolicyImportTransitiveImportsStrategy(policyConfig));
+
         // Subject Aliases
         addStrategy(new RetrieveImportsAliasesStrategy(policyConfig));
         addStrategy(new ModifyImportsAliasesStrategy(policyConfig));

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/RetrievePolicyImportTransitiveImportsStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/RetrievePolicyImportTransitiveImportsStrategy.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.service.persistence.actors.strategies.commands;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
+import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
+import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
+import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportTransitiveImports;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportTransitiveImportsResponse;
+import org.eclipse.ditto.policies.model.signals.events.PolicyEvent;
+import org.eclipse.ditto.policies.service.common.config.PolicyConfig;
+
+/**
+ * This strategy handles the {@link RetrievePolicyImportTransitiveImports} command.
+ *
+ * @since 3.9.0
+ */
+final class RetrievePolicyImportTransitiveImportsStrategy
+        extends AbstractPolicyQueryCommandStrategy<RetrievePolicyImportTransitiveImports> {
+
+    RetrievePolicyImportTransitiveImportsStrategy(final PolicyConfig policyConfig) {
+        super(RetrievePolicyImportTransitiveImports.class, policyConfig);
+    }
+
+    @Override
+    protected Result<PolicyEvent<?>> doApply(final Context<PolicyId> context,
+            @Nullable final Policy policy,
+            final long nextRevision,
+            final RetrievePolicyImportTransitiveImports command,
+            @Nullable final Metadata metadata) {
+
+        final PolicyId policyId = context.getState();
+        final PolicyId importedPolicyId = command.getImportedPolicyId();
+        final DittoHeaders dittoHeaders = command.getDittoHeaders();
+        if (policy != null) {
+            final Optional<PolicyImport> optionalImport =
+                    policy.getPolicyImports().getPolicyImport(importedPolicyId);
+            if (optionalImport.isPresent()) {
+                final PolicyImport policyImport = optionalImport.get();
+                final List<PolicyId> transitiveImports = policyImport.getEffectedImports()
+                        .map(ei -> ei.getTransitiveImports())
+                        .orElse(Collections.emptyList());
+                final WithDittoHeaders response = appendETagHeaderIfProvided(command,
+                        RetrievePolicyImportTransitiveImportsResponse.of(policyId, importedPolicyId,
+                                transitiveImports,
+                                createCommandResponseDittoHeaders(dittoHeaders, nextRevision - 1)),
+                        policy);
+                return ResultFactory.newQueryResult(command, response);
+            }
+        }
+        return ResultFactory.newErrorResult(
+                policyImportNotFound(policyId, importedPolicyId, dittoHeaders), command);
+    }
+
+    @Override
+    public Optional<EntityTag> nextEntityTag(final RetrievePolicyImportTransitiveImports command,
+            @Nullable final Policy newEntity) {
+        return Optional.empty();
+    }
+}

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/events/PolicyEventStrategies.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/events/PolicyEventStrategies.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.policies.model.signals.events.PolicyImportsDeleted;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportModified;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntriesAdditionsModified;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntriesModified;
+import org.eclipse.ditto.policies.model.signals.events.PolicyImportTransitiveImportsModified;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionCreated;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionDeleted;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionModified;
@@ -89,6 +90,7 @@ public final class PolicyEventStrategies extends AbstractEventStrategies<PolicyE
         addStrategy(PolicyEntryImportableModified.class, new PolicyEntryImportableModifiedStrategy());
         addStrategy(PolicyImportEntriesModified.class, new PolicyImportEntriesModifiedStrategy());
         addStrategy(PolicyImportEntriesAdditionsModified.class, new PolicyImportEntriesAdditionsModifiedStrategy());
+        addStrategy(PolicyImportTransitiveImportsModified.class, new PolicyImportTransitiveImportsModifiedStrategy());
         addStrategy(PolicyImportEntryAdditionCreated.class, new PolicyImportEntryAdditionCreatedStrategy());
         addStrategy(PolicyImportEntryAdditionModified.class, new PolicyImportEntryAdditionModifiedStrategy());
         addStrategy(PolicyImportEntryAdditionDeleted.class, new PolicyImportEntryAdditionDeletedStrategy());

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/events/PolicyImportTransitiveImportsModifiedStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/events/PolicyImportTransitiveImportsModifiedStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.service.persistence.actors.strategies.events;
+
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyBuilder;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.signals.events.PolicyImportTransitiveImportsModified;
+
+/**
+ * This strategy handles {@link PolicyImportTransitiveImportsModified} events.
+ *
+ * @since 3.9.0
+ */
+final class PolicyImportTransitiveImportsModifiedStrategy
+        extends AbstractPolicyEventStrategy<PolicyImportTransitiveImportsModified> {
+
+    @Override
+    protected PolicyBuilder applyEvent(final PolicyImportTransitiveImportsModified event, final Policy policy,
+            final PolicyBuilder policyBuilder) {
+        final PolicyId importedPolicyId = event.getImportedPolicyId();
+        return policy.getPolicyImports().getPolicyImport(importedPolicyId)
+                .map(existingImport -> {
+                    final PolicyImport newImport = PoliciesModelFactory.policyImportWithTransitiveImports(
+                            existingImport, event.getTransitiveImports());
+                    return policyBuilder.setPolicyImports(
+                            policy.getPolicyImports().setPolicyImport(newImport));
+                })
+                .orElse(policyBuilder);
+    }
+
+}

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/adapter/policies/PolicyPathMatcher.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/adapter/policies/PolicyPathMatcher.java
@@ -42,6 +42,7 @@ final class PolicyPathMatcher implements PayloadPathMatcher {
         resourceNames.put(PolicyResource.POLICY_IMPORT_ENTRIES, "policyImportEntries");
         resourceNames.put(PolicyResource.POLICY_IMPORT_ENTRIES_ADDITIONS, "policyImportEntriesAdditions");
         resourceNames.put(PolicyResource.POLICY_IMPORT_ENTRY_ADDITION, "policyImportEntryAddition");
+        resourceNames.put(PolicyResource.POLICY_IMPORT_TRANSITIVE_IMPORTS, "policyImportTransitiveImports");
         resourceNames.put(PolicyResource.POLICY_ENTRIES, "policyEntries");
         resourceNames.put(PolicyResource.POLICY_ENTRY, "policyEntry");
         resourceNames.put(PolicyResource.POLICY_ENTRY_RESOURCES, "resources");

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractPolicyMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractPolicyMappingStrategies.java
@@ -412,6 +412,23 @@ abstract class AbstractPolicyMappingStrategies<T extends Jsonifiable.WithPredica
     }
 
     /**
+     * Extracts the resolve transitively list of {@code PolicyId}s from the payload value (a JSON array).
+     *
+     * @param adaptable the adaptable to extract from.
+     * @return the list of Policy IDs to resolve transitively.
+     * @since 3.9.0
+     */
+    protected static List<PolicyId> transitiveImportsFrom(final Adaptable adaptable) {
+        final JsonValue value = adaptable.getPayload().getValue()
+                .orElseThrow(() -> new NullPointerException("Payload value must not be null."));
+        final JsonArray jsonArray = value.isArray() ? value.asArray() : JsonArray.empty();
+        return jsonArray.stream()
+                .map(JsonValue::asString)
+                .map(PolicyId::of)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Extracts {@code EntriesAdditions} from the payload.
      *
      * @param adaptable the adaptable to extract from.

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyEventMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyEventMappingStrategies.java
@@ -36,6 +36,7 @@ import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntriesModifi
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionCreated;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionDeleted;
 import org.eclipse.ditto.policies.model.signals.events.PolicyImportEntryAdditionModified;
+import org.eclipse.ditto.policies.model.signals.events.PolicyImportTransitiveImportsModified;
 import org.eclipse.ditto.policies.model.signals.events.PolicyModified;
 import org.eclipse.ditto.policies.model.signals.events.ResourceCreated;
 import org.eclipse.ditto.policies.model.signals.events.ResourceDeleted;
@@ -90,6 +91,7 @@ final class PolicyEventMappingStrategies extends AbstractPolicyMappingStrategies
         addImportableEvents(mappingStrategies);
         addImportEntriesEvents(mappingStrategies);
         addImportEntriesAdditionsEvents(mappingStrategies);
+        addImportTransitiveImportsEvents(mappingStrategies);
         addPolicyImportsEvents(mappingStrategies);
         addImportsAliasesEvents(mappingStrategies);
         return mappingStrategies;
@@ -325,6 +327,18 @@ final class PolicyEventMappingStrategies extends AbstractPolicyMappingStrategies
                 adaptable -> PolicyImportEntryAdditionDeleted.of(policyIdFrom(adaptable),
                         importedPolicyIdFrom(adaptable),
                         entryAdditionLabelFromImportPath(adaptable.getPayload().getPath()),
+                        revisionFrom(adaptable),
+                        timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable),
+                        metadataFrom(adaptable)));
+    }
+
+    private static void addImportTransitiveImportsEvents(
+            final Map<String, JsonifiableMapper<PolicyEvent<?>>> mappingStrategies) {
+        mappingStrategies.put(PolicyImportTransitiveImportsModified.TYPE,
+                adaptable -> PolicyImportTransitiveImportsModified.of(policyIdFrom(adaptable),
+                        importedPolicyIdFrom(adaptable),
+                        transitiveImportsFrom(adaptable),
                         revisionFrom(adaptable),
                         timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable),

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyModifyCommandMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyModifyCommandMappingStrategies.java
@@ -35,6 +35,7 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImpo
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntries;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesAdditions;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntryAddition;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportTransitiveImports;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImports;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyResource;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyResources;
@@ -183,6 +184,13 @@ final class PolicyModifyCommandMappingStrategies extends AbstractPolicyMappingSt
                         policyIdFromTopicPath(adaptable.getTopicPath()),
                         importedPolicyIdFrom(adaptable),
                         entryAdditionLabelFromImportPath(adaptable.getPayload().getPath()),
+                        dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(ModifyPolicyImportTransitiveImports.TYPE,
+                adaptable -> ModifyPolicyImportTransitiveImports.of(
+                        policyIdFromTopicPath(adaptable.getTopicPath()),
+                        importedPolicyIdFrom(adaptable),
+                        transitiveImportsFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(DeletePolicyImports.TYPE,

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyModifyCommandResponseMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyModifyCommandResponseMappingStrategies.java
@@ -45,6 +45,7 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyEntr
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntriesAdditionsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportEntryAdditionResponse;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportTransitiveImportsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyImportsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyResponse;
@@ -94,6 +95,8 @@ final class PolicyModifyCommandResponseMappingStrategies implements MappingStrat
         addPolicyImportEntriesResponses(streamBuilder);
 
         addPolicyImportEntriesAdditionsResponses(streamBuilder);
+
+        addPolicyImportTransitiveImportsResponses(streamBuilder);
 
         addPolicyImportsResponses(streamBuilder);
 
@@ -302,6 +305,17 @@ final class PolicyModifyCommandResponseMappingStrategies implements MappingStrat
                         mappingContext.getImportedPolicyId(),
                         Label.of(mappingContext.getAdaptable().getPayload().getPath().get(3)
                                 .map(JsonKey::toString).orElse("")),
+                        mappingContext.getHttpStatusOrThrow(),
+                        mappingContext.getDittoHeaders())));
+    }
+
+    private static void addPolicyImportTransitiveImportsResponses(
+            final Consumer<AdaptableToSignalMapper<? extends PolicyModifyCommandResponse<?>>> streamBuilder) {
+
+        streamBuilder.accept(AdaptableToSignalMapper.of(ModifyPolicyImportTransitiveImportsResponse.TYPE,
+                mappingContext -> ModifyPolicyImportTransitiveImportsResponse.newInstance(
+                        mappingContext.getPolicyIdFromTopicPath(),
+                        mappingContext.getImportedPolicyId(),
                         mappingContext.getHttpStatusOrThrow(),
                         mappingContext.getDittoHeaders())));
     }

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandMappingStrategies.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImp
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntries;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntriesAdditions;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntryAddition;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportTransitiveImports;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImports;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResource;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResources;
@@ -124,6 +125,11 @@ final class PolicyQueryCommandMappingStrategies extends AbstractPolicyMappingStr
                         importedPolicyIdFrom(adaptable),
                         entryAdditionLabelFromImportPath(adaptable.getPayload().getPath()),
                         dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(RetrievePolicyImportTransitiveImports.TYPE,
+                adaptable -> RetrievePolicyImportTransitiveImports.of(
+                        policyIdFromTopicPath(adaptable.getTopicPath()),
+                        importedPolicyIdFrom(adaptable), dittoHeadersFrom(adaptable)));
 
         addImportsAliasesQueries(mappingStrategies);
 

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandResponseMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandResponseMappingStrategies.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyEnt
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntriesResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntriesAdditionsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportEntryAdditionResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportTransitiveImportsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyImportsResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyResponse;
@@ -66,6 +67,7 @@ final class PolicyQueryCommandResponseMappingStrategies
         addPolicyEntryImportableResponses(mappingStrategies);
         addPolicyImportEntriesResponses(mappingStrategies);
         addPolicyImportEntriesAdditionsResponses(mappingStrategies);
+        addPolicyImportTransitiveImportsResponses(mappingStrategies);
         addImportsAliasesResponses(mappingStrategies);
         return mappingStrategies;
     }
@@ -200,6 +202,20 @@ final class PolicyQueryCommandResponseMappingStrategies
                         importedPolicyIdFrom(adaptable),
                         entryAdditionLabelFromImportPath(adaptable.getPayload().getPath()),
                         getValueFromPayload(adaptable),
+                        dittoHeadersFrom(adaptable)));
+    }
+
+    private static void addPolicyImportTransitiveImportsResponses(
+            final Map<String, JsonifiableMapper<PolicyQueryCommandResponse<?>>> mappingStrategies) {
+
+        mappingStrategies.put(RetrievePolicyImportTransitiveImportsResponse.TYPE,
+                adaptable -> RetrievePolicyImportTransitiveImportsResponse.of(
+                        policyIdFromTopicPath(adaptable.getTopicPath()),
+                        importedPolicyIdFrom(adaptable),
+                        adaptable.getPayload().getValue()
+                                .filter(JsonValue::isArray)
+                                .map(JsonValue::asArray)
+                                .orElse(JsonArray.empty()),
                         dittoHeadersFrom(adaptable)));
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
@@ -281,6 +281,11 @@ public final class BackgroundSyncStream {
                 .map(PolicyImport::getImportedPolicyId)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
+        // Add transitive policy IDs declared via transitiveImports
+        thingPolicy.getPolicyImports().stream()
+                .flatMap(imp -> imp.getTransitiveImports().stream())
+                .forEach(expectedReferencedPolicyIds::add);
+
         final Optional<PolicyId> entityId = thingPolicy.getEntityId();
         final String namespace = thingPolicy.getNamespace().orElse("");
         final List<PolicyId> namespaceRootPolicyIds = namespacePoliciesConfig.getRootPoliciesForNamespace(namespace)

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
@@ -277,14 +277,8 @@ public final class BackgroundSyncStream {
     }
 
     private CompletionStage<Set<PolicyId>> getExpectedReferencedPolicyIds(final Policy thingPolicy) {
-        final Set<PolicyId> expectedReferencedPolicyIds = thingPolicy.getPolicyImports().stream()
-                .map(PolicyImport::getImportedPolicyId)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        // Add transitive policy IDs declared via transitiveImports
-        thingPolicy.getPolicyImports().stream()
-                .flatMap(imp -> imp.getTransitiveImports().stream())
-                .forEach(expectedReferencedPolicyIds::add);
+        final Set<PolicyId> expectedReferencedPolicyIds =
+                new LinkedHashSet<>(thingPolicy.getPolicyImports().getExpectedReferencedPolicyIds());
 
         final Optional<PolicyId> entityId = thingPolicy.getEntityId();
         final String namespace = thingPolicy.getNamespace().orElse("");

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
@@ -131,7 +131,7 @@ final class ResolvedPolicyCacheLoader
                     Policy result = resolvedPolicy;
                     for (final PolicyId rootId : rootPolicies) {
                         final Optional<Pair<Policy, Set<PolicyTag>>> rootPolicyOpt =
-                                futures.get(rootId).getNow(Optional.empty());
+                                futures.get(rootId).join();
                         if (rootPolicyOpt.isPresent()) {
                             referencedPolicies.addAll(rootPolicyOpt.get().second());
                             result = mergeImplicitEntries(rootPolicyOpt.get().first(), result);
@@ -158,6 +158,8 @@ final class ResolvedPolicyCacheLoader
 
         // Track transitive policy IDs as referenced policies for search index invalidation.
         // These lookups run in parallel with the main import resolution below.
+        // See also PolicyImports.getExpectedReferencedPolicyIds() for the authoritative set of
+        // referenced IDs (used in BackgroundSyncStream for consistency checks).
         final List<CompletableFuture<Void>> transitiveTagFutures = policy.getPolicyImports().stream()
                 .flatMap(imp -> imp.getTransitiveImports().stream())
                 .distinct()

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import org.apache.pekko.japi.Pair;
 import org.eclipse.ditto.internal.utils.cache.Cache;
@@ -67,7 +69,7 @@ final class ResolvedPolicyCacheLoader
                         final long revision = policy.getRevision().map(PolicyRevision::toLong)
                                 .orElseThrow(
                                         () -> new IllegalStateException("Bad SudoRetrievePolicyResponse: no revision"));
-                        final Set<PolicyTag> referencedPolicies = new LinkedHashSet<>();
+                        final Set<PolicyTag> referencedPolicies = ConcurrentHashMap.newKeySet();
 
                         if (policyIdResolvingImports.resolveImports()) {
                             return cacheFuture.thenComposeAsync(cache ->
@@ -154,7 +156,24 @@ final class ResolvedPolicyCacheLoader
             final Policy policy,
             final Set<PolicyTag> referencedPolicies) {
 
-        return policy.withResolvedImports(importedPolicyId ->
+        // Track transitive policy IDs as referenced policies for search index invalidation.
+        // These lookups run in parallel with the main import resolution below.
+        final List<CompletableFuture<Void>> transitiveTagFutures = policy.getPolicyImports().stream()
+                .flatMap(imp -> imp.getTransitiveImports().stream())
+                .distinct()
+                .map(transitivePolicyId ->
+                        cache.get(new PolicyIdResolvingImports(transitivePolicyId, false))
+                                .thenApply(entry -> entry.flatMap(Entry::get))
+                                .thenAccept(optionalRefPolicy -> optionalRefPolicy.ifPresent(refPair ->
+                                        addPolicyTag(refPair.first(), referencedPolicies)))
+                                .toCompletableFuture()
+                )
+                .collect(Collectors.toList());
+
+        final CompletableFuture<Void> allTransitiveTags =
+                CompletableFuture.allOf(transitiveTagFutures.toArray(CompletableFuture[]::new));
+
+        final CompletionStage<Policy> resolvedPolicyCs = policy.withResolvedImports(importedPolicyId ->
                 cache.get(new PolicyIdResolvingImports(importedPolicyId, false)) // don't transitively resolve imports, only 1 "level"
                         .thenApply(entry -> entry.flatMap(Entry::get))
                         .thenApply(optionalReferencedPolicy -> {
@@ -169,6 +188,9 @@ final class ResolvedPolicyCacheLoader
                             return optionalReferencedPolicy.map(Pair::first);
                         })
         );
+
+        // Wait for both transitive tag tracking and import resolution to complete
+        return resolvedPolicyCs.thenCombine(allTransitiveTags, (resolvedPolicy, ignored) -> resolvedPolicy);
     }
 
     private CompletableFuture<Optional<Pair<Policy, Set<PolicyTag>>>> resolveNamespaceRootPolicy(

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
@@ -32,8 +32,10 @@ import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyRevision;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyRevisionResponse;
 import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
 import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAccessibleException;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
@@ -204,6 +206,192 @@ public final class BackgroundSyncStreamTest {
             // the set-equality check fails and the entry is flagged as inconsistent.
             assertThat(inconsistentThingIds.toCompletableFuture().join())
                     .containsExactly("x:9-missing-root-tag");
+        }};
+    }
+
+    @Test
+    public void missingTransitiveImportPolicyTagInIndexTriggersReIndexing() {
+        // Scenario: A → B → C → D (3-level transitive chain)
+        // Policy A imports B with transitiveImports: ["C"]
+        // Policy B imports C with transitiveImports: ["D"]
+        // The indexed entry is missing the transitive policy tags for C and D
+        // → should be flagged as inconsistent and trigger re-indexing
+
+        final Duration toleranceWindow = Duration.ofHours(1L);
+        final PolicyId policyIdA = PolicyId.of("com.example.thing", "policy-a");
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediate-b");
+        final PolicyId policyIdC = PolicyId.of("com.example", "intermediate-c");
+        final PolicyId policyIdD = PolicyId.of("com.example", "template-d");
+
+        // Persisted thing uses policy A at revision 5
+        final Source<Metadata, NotUsed> persisted = Source.from(List.of(
+                Metadata.of(ThingId.of("x:10-transitive-missing"), 3L,
+                        PolicyTag.of(policyIdA, 5L), null, Set.of(), null)
+        ));
+        // Indexed entry has policy A tag and B tag, but is MISSING C and D tags
+        final Source<Metadata, NotUsed> indexed = Source.from(List.of(
+                Metadata.of(ThingId.of("x:10-transitive-missing"), 3L,
+                        PolicyTag.of(policyIdA, 5L), null,
+                        Set.of(PolicyTag.of(policyIdB, 2L)), null)
+        ));
+
+        new TestKit(actorSystem) {{
+            final BackgroundSyncStream underTest =
+                    BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
+                            Duration.ofSeconds(10L),
+                            DefaultNamespacePoliciesConfig.of(ConfigFactory.empty()));
+            final CompletionStage<List<String>> inconsistentThingIds =
+                    underTest.filterForInconsistencies(persisted, indexed)
+                            .map(metadata -> metadata.getThingId().toString())
+                            .runWith(Sink.seq(), actorSystem);
+
+            // BackgroundSyncStream retrieves policy A to check consistency
+            expectMsg(SudoRetrievePolicy.of(policyIdA, DittoHeaders.empty()));
+
+            // Policy A: imports B with transitiveImports: ["C"]
+            final Policy policyA = Policy.newBuilder(policyIdA)
+                    .setRevision(5L)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB,
+                            PoliciesModelFactory.newEffectedImportedLabels(
+                                    java.util.Collections.emptyList(), null,
+                                    List.of(policyIdC))))
+                    .build();
+            reply(SudoRetrievePolicyResponse.of(policyIdA, policyA, DittoHeaders.empty()));
+
+            // The expected referenced policy IDs are: B (direct import), C (transitiveImports from A's import of B)
+            // The indexed entry only has B → set mismatch → flagged as inconsistent
+            // No further messages expected since the set comparison already fails
+
+            assertThat(inconsistentThingIds.toCompletableFuture().join())
+                    .containsExactly("x:10-transitive-missing");
+        }};
+    }
+
+    @Test
+    public void transitiveImportPolicyTagsInIndexAreConsideredConsistent() {
+        // Same 3-level scenario, but the indexed entry HAS all the expected transitive policy tags
+        // → should be considered consistent (no re-indexing needed)
+
+        final Duration toleranceWindow = Duration.ofHours(1L);
+        final PolicyId policyIdA = PolicyId.of("com.example.thing", "policy-a2");
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediate-b2");
+        final PolicyId policyIdC = PolicyId.of("com.example", "intermediate-c2");
+        final PolicyId policyIdD = PolicyId.of("com.example", "template-d2");
+
+        // Policy A imports B with transitiveImports: ["C"]
+        // B imports C with transitiveImports: ["D"]
+        // Expected referenced policies: B, C, D (all transitive dependencies)
+
+        final Source<Metadata, NotUsed> persisted = Source.from(List.of(
+                Metadata.of(ThingId.of("x:11-transitive-consistent"), 3L,
+                        PolicyTag.of(policyIdA, 5L), null, Set.of(), null)
+        ));
+        // Indexed entry includes ALL expected transitive tags
+        final Source<Metadata, NotUsed> indexed = Source.from(List.of(
+                Metadata.of(ThingId.of("x:11-transitive-consistent"), 3L,
+                        PolicyTag.of(policyIdA, 5L), null,
+                        Set.of(PolicyTag.of(policyIdB, 2L),
+                                PolicyTag.of(policyIdC, 3L),
+                                PolicyTag.of(policyIdD, 4L)), null)
+        ));
+
+        new TestKit(actorSystem) {{
+            final BackgroundSyncStream underTest =
+                    BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
+                            Duration.ofSeconds(10L),
+                            DefaultNamespacePoliciesConfig.of(ConfigFactory.empty()));
+            final CompletionStage<List<String>> inconsistentThingIds =
+                    underTest.filterForInconsistencies(persisted, indexed)
+                            .map(metadata -> metadata.getThingId().toString())
+                            .runWith(Sink.seq(), actorSystem);
+
+            // BackgroundSyncStream retrieves policy A
+            expectMsg(SudoRetrievePolicy.of(policyIdA, DittoHeaders.empty()));
+
+            // Policy A: imports B with transitiveImports: ["C"]
+            // B's import of C has transitiveImports: ["D"]
+            final Policy policyA = Policy.newBuilder(policyIdA)
+                    .setRevision(5L)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB,
+                            PoliciesModelFactory.newEffectedImportedLabels(
+                                    java.util.Collections.emptyList(), null,
+                                    List.of(policyIdC, policyIdD))))
+                    .build();
+            reply(SudoRetrievePolicyResponse.of(policyIdA, policyA, DittoHeaders.empty()));
+
+            // Verify revision of each referenced policy (order is non-deterministic)
+            for (int i = 0; i < 3; i++) {
+                final SudoRetrievePolicyRevision revisionCmd =
+                        expectMsgClass(SudoRetrievePolicyRevision.class);
+                final PolicyId requestedId = revisionCmd.getEntityId();
+                final long revision;
+                if (requestedId.equals(policyIdB)) {
+                    revision = 2L;
+                } else if (requestedId.equals(policyIdC)) {
+                    revision = 3L;
+                } else if (requestedId.equals(policyIdD)) {
+                    revision = 4L;
+                } else {
+                    throw new AssertionError("Unexpected policy revision request for: " + requestedId);
+                }
+                reply(SudoRetrievePolicyRevisionResponse.of(requestedId, revision, DittoHeaders.empty()));
+            }
+
+            // All tags match → consistent → empty result
+            assertThat(inconsistentThingIds.toCompletableFuture().join()).isEmpty();
+        }};
+    }
+
+    @Test
+    public void removedTransitiveImportMakesStaleIndexEntryInconsistent() {
+        // Scenario: Policy A previously had transitiveImports: ["C"] on its import of B.
+        // The indexed entry has B and C in __referencedPolicies.
+        // Policy A is updated to remove transitiveImports (now only imports B without transitiveImports).
+        // The expected set is now just {B}, but the indexed entry still has {B, C}
+        // → the set-equality check fails and the entry is flagged as inconsistent for re-indexing.
+
+        final Duration toleranceWindow = Duration.ofHours(1L);
+        final PolicyId policyIdA = PolicyId.of("com.example.thing", "policy-a3");
+        final PolicyId policyIdB = PolicyId.of("com.example", "intermediate-b3");
+        final PolicyId policyIdC = PolicyId.of("com.example", "template-c3");
+
+        // Persisted thing uses policy A at revision 6 (updated, transitiveImports removed)
+        final Source<Metadata, NotUsed> persisted = Source.from(List.of(
+                Metadata.of(ThingId.of("x:12-transitive-removed"), 3L,
+                        PolicyTag.of(policyIdA, 6L), null, Set.of(), null)
+        ));
+        // Indexed entry still has the OLD __referencedPolicies with both B and C
+        final Source<Metadata, NotUsed> indexed = Source.from(List.of(
+                Metadata.of(ThingId.of("x:12-transitive-removed"), 3L,
+                        PolicyTag.of(policyIdA, 5L), null,
+                        Set.of(PolicyTag.of(policyIdB, 2L),
+                                PolicyTag.of(policyIdC, 3L)), null)
+        ));
+
+        new TestKit(actorSystem) {{
+            final BackgroundSyncStream underTest =
+                    BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
+                            Duration.ofSeconds(10L),
+                            DefaultNamespacePoliciesConfig.of(ConfigFactory.empty()));
+            final CompletionStage<List<String>> inconsistentThingIds =
+                    underTest.filterForInconsistencies(persisted, indexed)
+                            .map(metadata -> metadata.getThingId().toString())
+                            .runWith(Sink.seq(), actorSystem);
+
+            // BackgroundSyncStream retrieves policy A (updated version without transitiveImports)
+            expectMsg(SudoRetrievePolicy.of(policyIdA, DittoHeaders.empty()));
+
+            // Policy A now only imports B (no transitiveImports)
+            final Policy updatedPolicyA = Policy.newBuilder(policyIdA)
+                    .setRevision(6L)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(policyIdB))
+                    .build();
+            reply(SudoRetrievePolicyResponse.of(policyIdA, updatedPolicyA, DittoHeaders.empty()));
+
+            // Policy revision mismatch (indexed has rev 5, persisted has rev 6) already triggers
+            // inconsistency, but even if revisions matched, the set {B} ≠ {B, C} would catch it.
+            assertThat(inconsistentThingIds.toCompletableFuture().join())
+                    .containsExactly("x:12-transitive-removed");
         }};
     }
 


### PR DESCRIPTION
Adds a new optional `transitiveImports` field to policy imports that enables multi-level import resolution. This complements `entriesAdditions` by allowing consuming policies to resolve through intermediate policies that add subjects to template-defined entries.

Without this feature, policy imports are single-level: if policy A imports from B, and B imports from C with entriesAdditions, A cannot see C's entries enriched with B's subject additions. The `transitiveImports` field explicitly lists which of the imported policy's own imports should be resolved first.

Changes:
- Model: EffectedImports, PolicyImport, PoliciesModelFactory, PolicyImporter
- Validation: cycle prevention in PolicyImportsValidator, including dedicated validateTransitiveImports for the sub-resource endpoint
- Resolution: cycle detection via visited set + depth limit, single-prefix labels (no double-prefixing in transitive chains), O(n) allOf merge replacing O(n²) reduce/combineSets, no temp Policy copies in transitive resolution
- HTTP API: GET/PUT /imports/{id}/transitiveImports endpoint
- Signal commands: Retrieve/Modify + responses, event, strategies
- Protocol mapping: Ditto Protocol adapter for all new signals
- Cache: PolicyEnforcerCache tracks transitive IDs for cascade invalidation, deregisters stale mappings on policy reload, guards against NPE on exceptional cache load
- Search: ResolvedPolicyCacheLoader uses ConcurrentHashMap.newKeySet for thread safety, awaits transitive tag futures before returning; BackgroundSyncStream tracks transitive policy IDs in __referencedPolicies
- Documentation: basic-policy.md with examples, deeper nesting explanation
- OpenAPI: schema, path definition, api-2-index registration
- JSON Schema: policy.json updated
- Tests: PolicyImporterTest (2/3-level resolution, cycle detection, EXPLICIT importable with transitive), cache invalidation, search index consistency, model serialization round-trips

Closes: #2420