### PR TITLE
#2354 Add policy-view=resolved for effective policy view

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaderDefinition.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaderDefinition.java
@@ -679,7 +679,32 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
             JsonObject.class,
             true,
             false,
-            HeaderValueValidators.getJsonObjectValidator());
+            HeaderValueValidators.getJsonObjectValidator()),
+
+    /**
+     * Selects the policy representation returned by retrieval-style commands: {@code "original"}
+     * (default, policy as stored) or {@code "resolved"} (merged view including imports, references
+     * and namespace-root policies). Parsing/validation lives in the policies module.
+     * <p>
+     * Key: {@code "policy-view"}, Java type: {@link String}.
+     * </p>
+     *
+     * @since 3.9.0
+     */
+    POLICY_VIEW("policy-view", String.class, true, false, HeaderValueValidators.getNoOpValidator()),
+
+    /**
+     * Internal-only header threading the original {@code fields=} selector from the gateway route to
+     * {@code PolicyCommandEnforcement} so it can be re-applied to the merged JSON when
+     * {@code policy-view=resolved}.
+     * <p>
+     * Key: {@code "ditto-policy-view-fields-selector"}, Java type: {@link String}.
+     * </p>
+     *
+     * @since 3.9.0
+     */
+    POLICY_VIEW_FIELDS_SELECTOR("ditto-policy-view-fields-selector", String.class, false, false,
+            HeaderValueValidators.getNoOpValidator());
 
     /**
      * Map to speed up lookup of header definition by key.

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
@@ -241,6 +241,8 @@ public final class ImmutableDittoHeadersTest {
                 .putHeader(DittoHeaderDefinition.DIVERT_RESPONSE_TO_CONNECTION.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO)
                 .putHeader(DittoHeaderDefinition.DIVERTED_RESPONSE_FROM_CONNECTION.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM)
                 .putHeader(DittoHeaderDefinition.DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES)
+                .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved")
+                .putHeader(DittoHeaderDefinition.POLICY_VIEW_FIELDS_SELECTOR.getKey(), "policyId,entries")
                 .build();
 
         assertThat(underTest).isEqualTo(expectedHeaderMap);
@@ -597,6 +599,8 @@ public final class ImmutableDittoHeadersTest {
                 .set(DittoHeaderDefinition.DIVERT_RESPONSE_TO_CONNECTION.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO)
                 .set(DittoHeaderDefinition.DIVERTED_RESPONSE_FROM_CONNECTION.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM)
                 .set(DittoHeaderDefinition.DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES)
+                .set(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved")
+                .set(DittoHeaderDefinition.POLICY_VIEW_FIELDS_SELECTOR.getKey(), "policyId,entries")
                 .build();
 
         final Map<String, String> allKnownHeaders = createMapContainingAllKnownHeaders();
@@ -855,6 +859,8 @@ public final class ImmutableDittoHeadersTest {
         result.put(DittoHeaderDefinition.DIVERT_EXPECTED_RESPONSE_TYPES.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TYPES);
         result.put(DittoHeaderDefinition.DIVERT_RESPONSE_TO_CONNECTION.getKey(), KNOWN_DITTO_DIVERT_RESPONSE_TO);
         result.put(DittoHeaderDefinition.DIVERTED_RESPONSE_FROM_CONNECTION.getKey(), KNOWN_DITTO_DIVERTED_RESPONSE_FROM);
+        result.put(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved");
+        result.put(DittoHeaderDefinition.POLICY_VIEW_FIELDS_SELECTOR.getKey(), "policyId,entries");
         return result;
     }
 

--- a/documentation/src/main/resources/openapi/sources/api-2-index.yml
+++ b/documentation/src/main/resources/openapi/sources/api-2-index.yml
@@ -335,6 +335,8 @@ components:
       $ref: "./parameters/policyFieldsQueryParam.yml"
     PolicyIdPathParam:
       $ref: "./parameters/policyIdPathParam.yml"
+    PolicyViewParam:
+      $ref: "./parameters/policyViewParam.yml"
     PropertiesFieldsQueryParam:
       $ref: "./parameters/propertiesFieldsQueryParam.yml"
     PropertyPathPathParam:

--- a/documentation/src/main/resources/openapi/sources/parameters/policyViewParam.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/policyViewParam.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+name: policy-view
+in: query
+description: |-
+  Selects the policy representation. Accepted values: `original` (default — policy as stored)
+  and `resolved` (merged view including imports, references and namespace-root policies).
+  Imported entries appear under labels of the form `imported-<importedPolicyId>-<originalLabel>`
+  (treat the format as opaque; policy IDs may contain `-`). The `imports` block is preserved
+  unchanged.
+
+  Note on caching: the response ETag reflects only the importing policy's revision, so a `304`
+  may be returned even when imported or namespace-root policies have changed. Treat the
+  resolved view as read-through.
+
+  The resolved view exposes all `importable=implicit` entries from imported policies declared
+  by the importing policy, matching how the enforcer evaluates the policy at runtime.
+required: false
+schema:
+  type: string
+  enum: [original, resolved]
+  default: original

--- a/documentation/src/main/resources/openapi/sources/paths/policies/policy.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/policies/policy.yml
@@ -26,6 +26,7 @@ get:
   parameters:
     - $ref: '../../parameters/policyIdPathParam.yml'
     - $ref: '../../parameters/policyFieldsQueryParam.yml'
+    - $ref: '../../parameters/policyViewParam.yml'
     - $ref: '../../parameters/ifMatchHeaderParam.yml'
     - $ref: '../../parameters/ifNoneMatchHeaderParam.yml'
     - $ref: '../../parameters/timeoutParam.yml'

--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -798,6 +798,41 @@ at <code>org.eclipse.ditto:tenant-root</code> configured for pattern <code>org.e
 namespace <code>org.eclipse.ditto</code> (the pattern requires at least one sub-segment after the dot)."
 %}
 
+## Effective policy view
+
+Since Ditto *3.9.0*, `GET /api/2/policies/{policyId}` accepts an optional `policy-view` query parameter selecting
+the representation returned to the caller:
+
+* `policy-view=original` (default) — returns the policy as stored, unchanged behaviour.
+* `policy-view=resolved` — returns the **merged "effective" policy**: the importing policy's own entries plus
+  entries inherited via declared imports (with `references` resolved) plus entries from configured
+  [namespace root policies](#namespace-root-policies).
+
+The same hint may be sent as the `policy-view` Ditto header, so the resolved view is available uniformly via
+HTTP, WebSocket, server-sent events and the connectivity service.
+
+### Behaviour of the resolved view
+
+* **Imported entry labels** are rewritten as `imported-<importedPolicyId>-<originalLabel>` (declared imports only).
+  The format is informational; treat the label as opaque since policy IDs may themselves contain `-`.
+* **Authorization is preserved.** The merge runs *before* the per-subject `READ` filter, so the resolved view is
+  subject to the same authorization as the unresolved view: a caller only sees entries they have `READ` on.
+* **`fields=` is honoured.** Deep field selectors (e.g. `fields=entries/owner/subjects`) work on the resolved view.
+* **No ETag is returned.** The importing policy's revision does not track changes to imported or namespace-root
+  policies, so a `304 Not Modified` would be unsafe — the resolved view is always read-through.
+* **`If-Match` / `If-None-Match` are ignored** on `policy-view=resolved` requests for the same reason.
+* **Sub-resources** (`/entries`, `/imports`, `/entries/{label}/...`) are not affected — `policy-view` only changes
+  the top-level `GET /policies/{policyId}` representation.
+
+### Example
+
+```
+GET /api/2/policies/com.example:tenant-policy?policy-view=resolved
+```
+
+Returns the same JSON shape as `GET /api/2/policies/{policyId}`, with imported entries listed under the
+`imported-…` prefix in the `entries` map.
+
 ## Tools for editing a Policy
 
 You can edit the Policy with any text editor.

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesParameter.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesParameter.java
@@ -20,7 +20,12 @@ public enum PoliciesParameter {
     /**
      * Request parameter for including only the selected fields in the Policy JSON document(s).
      */
-    FIELDS("fields");
+    FIELDS("fields"),
+
+    /**
+     * Selects the policy representation: {@code original} (default) or {@code resolved} (merged view).
+     */
+    POLICY_VIEW("policy-view");
 
     private final String parameterValue;
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.gateway.service.endpoints.directives.auth.NamespaceAccessEnforcementDirective;
@@ -32,6 +33,7 @@ import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationR
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationResult;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.jwt.model.JsonWebToken;
@@ -41,6 +43,8 @@ import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.PolicyConstants;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyView;
+import org.eclipse.ditto.policies.model.PolicyViewInvalidException;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectAnnouncement;
 import org.eclipse.ditto.policies.model.SubjectExpiry;
@@ -171,11 +175,34 @@ public final class PoliciesRoute extends AbstractRoute {
     private Route policyId(final RequestContext ctx, final DittoHeaders dittoHeaders, final PolicyId policyId) {
         return pathEndOrSingleSlash(() ->
                 concat(
-                        // GET /policies/<policyId>?fields=<fieldsString>
-                        get(() -> parameterList(PoliciesParameter.FIELDS.toString(), fields ->
-                                handlePerRequest(ctx, RetrievePolicy.of(policyId, dittoHeaders,
-                                        calculateSelectedFields(fields).orElse(null)))
-                        )),
+                        // GET /policies/<policyId>?fields=<fieldsString>&policy-view=<view>
+                        get(() -> parameterOptional(PoliciesParameter.POLICY_VIEW.toString(), policyViewParamOpt -> {
+                            final DittoHeaders headersWithPolicyView;
+                            if (policyViewParamOpt.isPresent()) {
+                                final String raw = policyViewParamOpt.get();
+                                try {
+                                    PolicyView.fromString(raw);
+                                } catch (final PolicyViewInvalidException e) {
+                                    throw e.setDittoHeaders(dittoHeaders);
+                                }
+                                headersWithPolicyView = DittoHeaders.newBuilder(dittoHeaders)
+                                        .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), raw)
+                                        .build();
+                            } else {
+                                headersWithPolicyView = dittoHeaders;
+                            }
+                            return parameterList(PoliciesParameter.FIELDS.toString(), fields -> {
+                                final Optional<JsonFieldSelector> selectedFields = calculateSelectedFields(fields);
+                                final DittoHeaders effectiveHeaders = selectedFields
+                                        .map(sel -> DittoHeaders.newBuilder(headersWithPolicyView)
+                                                .putHeader(DittoHeaderDefinition.POLICY_VIEW_FIELDS_SELECTOR.getKey(),
+                                                        sel.toString())
+                                                .build())
+                                        .orElse(headersWithPolicyView);
+                                return handlePerRequest(ctx, RetrievePolicy.of(policyId, effectiveHeaders,
+                                        selectedFields.orElse(null)));
+                            });
+                        })),
                         put(() -> // PUT /policies/<policyId>
                                 ensureMediaTypeJsonWithFallbacksThenExtractDataBytes(ctx, dittoHeaders,
                                         payloadSource ->

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutablePolicy.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutablePolicy.java
@@ -143,6 +143,20 @@ final class ImmutablePolicy implements Policy {
      * {@link org.eclipse.ditto.base.model.entity.id.RegexPatterns#ID_REGEX}.
      */
     public static Policy fromJson(final JsonObject jsonObject) {
+        return fromJson(jsonObject, false);
+    }
+
+    /**
+     * Variant of {@link #fromJson(JsonObject)} for deserializing a resolved-view response: accepts
+     * {@code imported-*} labels. Never use this on user-submitted bodies.
+     *
+     * @since 3.9.0
+     */
+    public static Policy fromJsonAcceptingImportedLabels(final JsonObject jsonObject) {
+        return fromJson(jsonObject, true);
+    }
+
+    private static Policy fromJson(final JsonObject jsonObject, final boolean acceptImportedLabels) {
         final PolicyId policyId = jsonObject.getValue(JsonFields.ID).map(PolicyId::of).orElse(null);
 
         final PolicyLifecycle readLifecycle = jsonObject.getValue(JsonFields.LIFECYCLE)
@@ -174,7 +188,9 @@ final class ImmutablePolicy implements Policy {
                         .message(MessageFormat.format("<{0}> is not a JSON object!", jsonValue))
                         .build());
             }
-            return ImmutablePolicyEntry.fromJson(jsonField.getKey(), jsonValue.asObject());
+            return acceptImportedLabels
+                    ? ImmutablePolicyEntry.fromJsonAcceptingImportedLabels(jsonField.getKey(), jsonValue.asObject())
+                    : ImmutablePolicyEntry.fromJson(jsonField.getKey(), jsonValue.asObject());
         };
 
         final Collection<PolicyEntry> policyEntries = readEntries.stream()

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutablePolicyEntry.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutablePolicyEntry.java
@@ -198,8 +198,25 @@ final class ImmutablePolicyEntry implements PolicyEntry {
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
      */
     public static PolicyEntry fromJson(final CharSequence label, final JsonObject jsonObject) {
+        return fromJson(label, jsonObject, false);
+    }
+
+    /**
+     * Variant of {@link #fromJson(CharSequence, JsonObject)} for deserializing a resolved-view response: accepts
+     * {@code imported-*} labels. Never use this on user-submitted bodies.
+     *
+     * @since 3.9.0
+     */
+    public static PolicyEntry fromJsonAcceptingImportedLabels(final CharSequence label, final JsonObject jsonObject) {
+        return fromJson(label, jsonObject, true);
+    }
+
+    private static PolicyEntry fromJson(final CharSequence label, final JsonObject jsonObject,
+            final boolean acceptImportedLabels) {
         checkNotNull(jsonObject, "JSON object");
-        final Label lbl = Label.of(label);
+        final Label lbl = acceptImportedLabels && label.toString().startsWith(ImmutableImportedLabel.IMPORTED_PREFIX + "-")
+                ? Label.ofImported(label)
+                : Label.of(label);
 
         final Subjects subjectsFromJson = jsonObject.getValue(JsonFields.SUBJECTS)
                 .map(PoliciesModelFactory::newSubjects)

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/Label.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/Label.java
@@ -37,6 +37,16 @@ public interface Label extends CharSequence {
     }
 
     /**
+     * Returns a Label that bypasses the {@code "imported-"} reserved-prefix check. Used only to deserialize a
+     * resolved-view response on the client side; user-submitted bodies must keep using {@link #of(CharSequence)}.
+     *
+     * @since 3.9.0
+     */
+    static Label ofImported(final CharSequence labelValue) {
+        return PoliciesModelFactory.newImportedRawLabel(labelValue);
+    }
+
+    /**
      * Returns the JsonFieldDefinition for this Label.
      *
      * @return the field definition.

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PoliciesModelFactory.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PoliciesModelFactory.java
@@ -105,6 +105,17 @@ public final class PoliciesModelFactory {
     }
 
     /**
+     * Returns a {@link Label} that bypasses the reserved-prefix check (rejects neither {@code imported-} nor
+     * {@code nsimported-}). For deserializing a resolved-view response only; never use this on user-submitted
+     * policy bodies.
+     *
+     * @since 3.9.0
+     */
+    public static Label newImportedRawLabel(final CharSequence labelValue) {
+        return ImmutableLabel.of(labelValue, true);
+    }
+
+    /**
      * Returns a new {@link SubjectIssuer} with the specified {@code subjectIssuer}.
      *
      * @param subjectIssuer the SubjectIssuer char sequence.
@@ -880,6 +891,17 @@ public final class PoliciesModelFactory {
      */
     public static Policy newPolicy(final JsonObject jsonObject) {
         return ImmutablePolicy.fromJson(jsonObject);
+    }
+
+    /**
+     * Variant of {@link #newPolicy(JsonObject)} that accepts {@code imported-*} labels in the JSON.
+     * Used by {@code RetrievePolicyResponse#getPolicy()} to round-trip a {@code policy-view=resolved}
+     * response on the client side; never use it for user-submitted bodies.
+     *
+     * @since 3.9.0
+     */
+    public static Policy newPolicyAcceptingImportedLabels(final JsonObject jsonObject) {
+        return ImmutablePolicy.fromJsonAcceptingImportedLabels(jsonObject);
     }
 
     /**

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyView.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyView.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+
+/**
+ * Supported values of the {@code policy-view} request hint: {@link #ORIGINAL} returns the policy as
+ * stored, {@link #RESOLVED} returns the merged view (own entries plus declared imports plus
+ * configured namespace-root policies, with references resolved). Imported labels are rewritten as
+ * {@code imported-<importedPolicyId>-<originalLabel>} and should be treated as opaque.
+ *
+ * @since 3.9.0
+ */
+public enum PolicyView {
+
+    ORIGINAL("original"),
+    RESOLVED("resolved");
+
+    private final String value;
+
+    PolicyView(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public boolean isResolved() {
+        return this == RESOLVED;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    /**
+     * Parses a raw query/header value (case-insensitive, trimmed). Returns empty for {@code null} or blank input.
+     *
+     * @throws PolicyViewInvalidException if {@code raw} is non-blank but does not match a known value.
+     */
+    public static Optional<PolicyView> fromString(@Nullable final String raw) {
+        if (raw == null) {
+            return Optional.empty();
+        }
+        final String trimmed = raw.trim();
+        if (trimmed.isEmpty()) {
+            return Optional.empty();
+        }
+        final String lower = trimmed.toLowerCase(Locale.ROOT);
+        for (final PolicyView v : values()) {
+            if (v.value.equals(lower)) {
+                return Optional.of(v);
+            }
+        }
+        throw PolicyViewInvalidException.forValue(raw);
+    }
+
+    /**
+     * Reads {@code policy-view} from {@link DittoHeaders}. Same parsing semantics as {@link #fromString}.
+     */
+    public static Optional<PolicyView> from(final DittoHeaders headers) {
+        return fromString(headers.get(DittoHeaderDefinition.POLICY_VIEW.getKey()));
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyViewInvalidException.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/PolicyViewInvalidException.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonParsableException;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.json.JsonObject;
+
+/**
+ * Thrown when the {@code policy-view} request hint (header or query parameter) carries a value that is not one of the
+ * accepted values: {@code original} or {@code resolved}.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+@JsonParsableException(errorCode = PolicyViewInvalidException.ERROR_CODE)
+public final class PolicyViewInvalidException extends DittoRuntimeException implements PolicyException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "view.invalid";
+
+    private static final String DEFAULT_MESSAGE = "The 'policy-view' parameter has an invalid value.";
+
+    private static final String DEFAULT_DESCRIPTION =
+            "Use 'original' (or omit) for the stored policy, or 'resolved' for the merged view.";
+
+    private static final long serialVersionUID = 7283915732196485472L;
+
+    private PolicyViewInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatus.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for a {@code PolicyViewInvalidException}.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static PolicyViewInvalidException forValue(@Nullable final String raw) {
+        final String displayed = raw == null ? "null" : raw;
+        final String message = "The 'policy-view' parameter has an invalid value: '" + displayed +
+                "'. Valid values: 'original', 'resolved'.";
+        return new Builder()
+                .message(message)
+                .description(DEFAULT_DESCRIPTION)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code PolicyViewInvalidException} object with the given exception message.
+     *
+     * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyViewInvalidException.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     */
+    public static PolicyViewInvalidException fromMessage(@Nullable final String message,
+            final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromMessage(message, dittoHeaders, new Builder());
+    }
+
+    /**
+     * Constructs a new {@code PolicyViewInvalidException} object with the exception message extracted from the
+     * given JSON object.
+     *
+     * @param jsonObject the JSON to read the
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyViewInvalidException.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static PolicyViewInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+    }
+
+    @Override
+    public JsonSchemaVersion[] getSupportedSchemaVersions() {
+        return new JsonSchemaVersion[]{JsonSchemaVersion.V_2};
+    }
+
+    @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .message(getMessage())
+                .description(getDescription().orElse(null))
+                .cause(getCause())
+                .href(getHref().orElse(null))
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link PolicyViewInvalidException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyViewInvalidException> {
+
+        private Builder() {
+            message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        @Override
+        protected PolicyViewInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new PolicyViewInvalidException(dittoHeaders, message, description, cause, href);
+        }
+
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyResponse.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyResponse.java
@@ -161,7 +161,20 @@ public final class RetrievePolicyResponse extends AbstractCommandResponse<Retrie
      * @return the retrieved Policy.
      */
     public Policy getPolicy() {
-        return PoliciesModelFactory.newPolicy(policy);
+        // Only pay the lenient parser when the response actually carries import-resolved labels (i.e. came from
+        // policy-view=resolved). For the common original-view path, keep the strict factory and its validation.
+        return policy.getValue(Policy.JsonFields.ENTRIES)
+                .filter(RetrievePolicyResponse::hasImportedPrefixedLabel)
+                .map(entries -> PoliciesModelFactory.newPolicyAcceptingImportedLabels(policy))
+                .orElseGet(() -> PoliciesModelFactory.newPolicy(policy));
+    }
+
+    // Mirrors ImmutableImportedLabel.IMPORTED_PREFIX (package-private there); kept inline to avoid widening
+    // its visibility for this single read-side check.
+    private static final String IMPORTED_LABEL_PREFIX = "imported-";
+
+    private static boolean hasImportedPrefixedLabel(final JsonObject entries) {
+        return entries.getKeys().stream().anyMatch(k -> k.toString().startsWith(IMPORTED_LABEL_PREFIX));
     }
 
     @Override

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableLabelTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableLabelTest.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.policies.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.eclipse.ditto.base.model.entity.id.restriction.LengthRestrictionTestBase;
 import org.junit.Test;
 
@@ -57,5 +59,25 @@ public final class ImmutableLabelTest extends LengthRestrictionTestBase {
         // that would re-enable the namespace-policy shadow attack from issue #2431.
         final String invalidLabel = "nsimported-some-root-AUDIT";
         ImmutableLabel.of(invalidLabel);
+    }
+
+    @Test
+    public void ofImportedAcceptsImportedPrefix() {
+        final Label label = Label.ofImported("imported-tenant:base-policy-OWNER");
+        assertThat(label.toString()).isEqualTo("imported-tenant:base-policy-OWNER");
+    }
+
+    @Test
+    public void ofImportedAcceptsNsImportedPrefix() {
+        // The raw-label deserialization path must also accept nsimported- labels that arise
+        // in the resolved view post-#2431.
+        final Label label = Label.ofImported("nsimported-acme:tenant-root-AUDIT");
+        assertThat(label.toString()).isEqualTo("nsimported-acme:tenant-root-AUDIT");
+    }
+
+    @Test
+    public void ofImportedRoundTripsThroughPoliciesModelFactory() {
+        final Label label = PoliciesModelFactory.newImportedRawLabel("imported-tenant:base-OWNER");
+        assertThat(label.toString()).isEqualTo("imported-tenant:base-OWNER");
     }
 }

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutablePolicyTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutablePolicyTest.java
@@ -107,6 +107,36 @@ public final class ImmutablePolicyTest {
     }
 
     @Test
+    public void strictFromJsonRejectsImportedLabels() {
+        final JsonObject policyJsonWithImportedLabel = JsonObject.newBuilder()
+                .set("entries", JsonObject.newBuilder()
+                        .set("imported-tenant:base-OWNER", createPolicyEntry1().toJson())
+                        .build())
+                .build();
+
+        assertThatExceptionOfType(LabelInvalidException.class)
+                .isThrownBy(() -> ImmutablePolicy.fromJson(policyJsonWithImportedLabel));
+    }
+
+    @Test
+    public void fromJsonAcceptingImportedLabelsRoundTripsImportedEntries() {
+        final JsonObject ownEntryJson = createPolicyEntry1().toJson();
+        final JsonObject importedEntryJson = createPolicyEntry2().toJson();
+        final JsonObject policyJson = JsonObject.newBuilder()
+                .set("policyId", POLICY_ID.toString())
+                .set("entries", JsonObject.newBuilder()
+                        .set("EndUser", ownEntryJson)
+                        .set("imported-tenant:base-policy-OWNER", importedEntryJson)
+                        .build())
+                .build();
+
+        final Policy parsed = ImmutablePolicy.fromJsonAcceptingImportedLabels(policyJson);
+
+        DittoPolicyAssertions.assertThat(parsed).hasLabel(Label.of("EndUser"));
+        DittoPolicyAssertions.assertThat(parsed).hasLabel(Label.ofImported("imported-tenant:base-policy-OWNER"));
+    }
+
+    @Test
     public void testToAndFromJsonWithSpecialFields() {
         final PolicyEntry policyEntry1 = createPolicyEntry1();
         final PolicyEntry policyEntry2 = createPolicyEntry2();

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyViewTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyViewTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.Optional;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link PolicyView}.
+ */
+public final class PolicyViewTest {
+
+    @Test
+    public void parsesOriginal() {
+        assertThat(PolicyView.fromString("original")).contains(PolicyView.ORIGINAL);
+    }
+
+    @Test
+    public void parsesResolved() {
+        assertThat(PolicyView.fromString("resolved")).contains(PolicyView.RESOLVED);
+    }
+
+    @Test
+    public void parsesMixedCase() {
+        assertThat(PolicyView.fromString("RESOLVED")).contains(PolicyView.RESOLVED);
+        assertThat(PolicyView.fromString("Resolved")).contains(PolicyView.RESOLVED);
+    }
+
+    @Test
+    public void trimsWhitespace() {
+        assertThat(PolicyView.fromString("  resolved  ")).contains(PolicyView.RESOLVED);
+        assertThat(PolicyView.fromString("\tresolved\n")).contains(PolicyView.RESOLVED);
+    }
+
+    @Test
+    public void emptyForNull() {
+        assertThat(PolicyView.fromString(null)).isEmpty();
+    }
+
+    @Test
+    public void emptyForBlank() {
+        assertThat(PolicyView.fromString("")).isEmpty();
+        assertThat(PolicyView.fromString("   ")).isEmpty();
+    }
+
+    @Test
+    public void unknownValueThrows() {
+        assertThatExceptionOfType(PolicyViewInvalidException.class)
+                .isThrownBy(() -> PolicyView.fromString("merged"))
+                .withMessageContaining("merged")
+                .withMessageContaining("original")
+                .withMessageContaining("resolved");
+    }
+
+    @Test
+    public void effectiveIsNoLongerAccepted() {
+        assertThatExceptionOfType(PolicyViewInvalidException.class)
+                .isThrownBy(() -> PolicyView.fromString("effective"));
+    }
+
+    @Test
+    public void isResolvedTrueOnlyForResolved() {
+        assertThat(PolicyView.ORIGINAL.isResolved()).isFalse();
+        assertThat(PolicyView.RESOLVED.isResolved()).isTrue();
+    }
+
+    @Test
+    public void getValueReturnsLowercaseWireValue() {
+        assertThat(PolicyView.ORIGINAL.getValue()).isEqualTo("original");
+        assertThat(PolicyView.RESOLVED.getValue()).isEqualTo("resolved");
+        assertThat(PolicyView.RESOLVED.toString()).isEqualTo("resolved");
+    }
+
+    @Test
+    public void fromHeadersReadsCorrectKey() {
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved")
+                .build();
+        assertThat(PolicyView.from(headers)).contains(PolicyView.RESOLVED);
+    }
+
+    @Test
+    public void fromHeadersEmptyWhenAbsent() {
+        final Optional<PolicyView> v = PolicyView.from(DittoHeaders.empty());
+        assertThat(v).isEmpty();
+    }
+
+    @Test
+    public void fromHeadersThrowsOnInvalid() {
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), "bogus")
+                .build();
+        assertThatExceptionOfType(PolicyViewInvalidException.class)
+                .isThrownBy(() -> PolicyView.from(headers));
+    }
+
+}

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyResponseTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/signals/commands/query/RetrievePolicyResponseTest.java
@@ -21,6 +21,7 @@ import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.base.model.signals.commands.GlobalCommandResponseRegistry;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandResponse;
 import org.eclipse.ditto.policies.model.signals.commands.TestConstants;
@@ -93,6 +94,26 @@ public final class RetrievePolicyResponseTest {
                 GlobalCommandResponseRegistry.getInstance().parse(jsonObject, TestConstants.DITTO_HEADERS);
 
         assertThat(parsedCommandResponse).isEqualTo(commandResponse);
+    }
+
+    @Test
+    public void getPolicyRoundTripsResolvedViewWithImportedLabels() {
+        final JsonObject ownEntry = TestConstants.Policy.POLICY.getEntriesSet().iterator().next().toJson();
+        final JsonObject resolvedPolicyJson = JsonFactory.newObjectBuilder()
+                .set("policyId", TestConstants.Policy.POLICY_ID.toString())
+                .set("entries", JsonFactory.newObjectBuilder()
+                        .set("OWNER", ownEntry)
+                        .set("imported-tenant:base-policy-OWNER", ownEntry)
+                        .build())
+                .build();
+        final RetrievePolicyResponse underTest = RetrievePolicyResponse.of(TestConstants.Policy.POLICY_ID,
+                resolvedPolicyJson, EMPTY_DITTO_HEADERS);
+
+        final Policy parsed = underTest.getPolicy();
+
+        org.assertj.core.api.Assertions.assertThat(parsed.getEntryFor(Label.of("OWNER"))).isPresent();
+        org.assertj.core.api.Assertions.assertThat(parsed.getEntryFor(Label.ofImported("imported-tenant:base-policy-OWNER")))
+                .isPresent();
     }
 
 }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
@@ -13,14 +13,20 @@
 package org.eclipse.ditto.policies.service.enforcement;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.eclipse.ditto.base.model.auth.AuthorizationContext;
 import org.eclipse.ditto.base.model.entity.id.WithEntityId;
 import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.base.model.signals.commands.CommandToExceptionRegistry;
@@ -28,16 +34,21 @@ import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonParseOptions;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.enforcement.AbstractEnforcementReloaded;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyView;
+import org.eclipse.ditto.policies.model.PolicyViewInvalidException;
 import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
@@ -51,6 +62,8 @@ import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAcc
 import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.PolicyModifyCommand;
 import org.eclipse.ditto.policies.model.signals.commands.query.PolicyQueryCommandResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicy;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyResponse;
 
 /**
  * Authorizes {@link PolicyCommand}s and filters {@link PolicyCommandResponse}s.
@@ -63,6 +76,19 @@ public final class PolicyCommandEnforcement
      */
     private static final JsonFieldSelector POLICY_QUERY_COMMAND_RESPONSE_ALLOWLIST =
             JsonFactory.newFieldSelector(Policy.JsonFields.ID);
+
+    private static final JsonParseOptions JSON_PARSE_OPTIONS_FOR_FIELDS_SELECTOR =
+            JsonFactory.newParseOptionsBuilder().withoutUrlDecoding().build();
+
+    private final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
+
+    public PolicyCommandEnforcement(
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+        this.policyResolver = Objects.requireNonNull(policyResolver, "policyResolver");
+        this.namespacePoliciesConfig = Objects.requireNonNull(namespacePoliciesConfig, "namespacePoliciesConfig");
+    }
 
     @Override
     public CompletionStage<Signal<?>> authorizeSignal(final Signal<?> signal,
@@ -94,13 +120,39 @@ public final class PolicyCommandEnforcement
             if (enforcer.hasPartialPermissions(policyResourceKey,
                     authorizationContext,
                     permission)) {
-                authorizedCommand = signal;
+                authorizedCommand = stripConditionalHeadersForResolvedView(signal);
             } else {
                 throw errorForPolicyCommand(signal);
             }
         }
 
         return CompletableFuture.completedFuture(authorizedCommand);
+    }
+
+    // For policy-view=resolved, drop If-Match / If-None-Match so the conditional-header strategy can't 304 on the
+    // importing policy's revision alone (the merged content can change without that revision moving).
+    private static Signal<?> stripConditionalHeadersForResolvedView(final Signal<?> signal) {
+        if (!(signal instanceof RetrievePolicy retrievePolicy) || !isResolvedView(retrievePolicy.getDittoHeaders())) {
+            return signal;
+        }
+        final DittoHeaders headers = retrievePolicy.getDittoHeaders();
+        if (!headers.containsKey(DittoHeaderDefinition.IF_MATCH.getKey())
+                && !headers.containsKey(DittoHeaderDefinition.IF_NONE_MATCH.getKey())) {
+            return signal;
+        }
+        final DittoHeaders stripped = headers.toBuilder()
+                .removeHeader(DittoHeaderDefinition.IF_MATCH.getKey())
+                .removeHeader(DittoHeaderDefinition.IF_NONE_MATCH.getKey())
+                .build();
+        return retrievePolicy.setDittoHeaders(stripped);
+    }
+
+    private static boolean isResolvedView(final DittoHeaders headers) {
+        try {
+            return PolicyView.from(headers).map(PolicyView::isResolved).orElse(false);
+        } catch (final PolicyViewInvalidException e) {
+            throw e.setDittoHeaders(headers);
+        }
     }
 
     private PolicyCommand<?> authorizeCreatePolicy(final Enforcer enforcer,
@@ -141,19 +193,100 @@ public final class PolicyCommandEnforcement
     public CompletionStage<PolicyCommandResponse<?>> filterResponse(final PolicyCommandResponse<?> commandResponse,
             final PolicyEnforcer policyEnforcer) {
 
+        if (commandResponse instanceof RetrievePolicyResponse retrieveResp
+                && isResolvedView(retrieveResp.getDittoHeaders())) {
+            return resolveAndRebuildResponse(retrieveResp)
+                    .thenApply(rebuilt -> applyEnforcerJsonView(rebuilt, policyEnforcer));
+        }
+
         final PolicyCommandResponse<?> result;
         if (commandResponse instanceof PolicyQueryCommandResponse<?> policyQueryCommandResponse) {
-            try {
-                result = buildJsonViewForPolicyQueryCommandResponse(policyQueryCommandResponse,
-                        policyEnforcer.getEnforcer());
-            } catch (final RuntimeException e) {
-                throw reportError("Error after building JsonView", e, commandResponse.getDittoHeaders());
-            }
+            result = applyEnforcerJsonView(policyQueryCommandResponse, policyEnforcer);
         } else {
             // no filtering required for non PolicyQueryCommandResponses:
             result = commandResponse;
         }
         return CompletableFuture.completedFuture(result);
+    }
+
+    private <T extends PolicyQueryCommandResponse<T>> T applyEnforcerJsonView(
+            final PolicyQueryCommandResponse<T> response, final PolicyEnforcer policyEnforcer) {
+        try {
+            return buildJsonViewForPolicyQueryCommandResponse(response, policyEnforcer.getEnforcer());
+        } catch (final DittoRuntimeException dre) {
+            throw dre;
+        } catch (final RuntimeException e) {
+            throw reportError("Error after building JsonView", e, response.getDittoHeaders());
+        }
+    }
+
+    private CompletionStage<RetrievePolicyResponse> resolveAndRebuildResponse(final RetrievePolicyResponse response) {
+        final PolicyId policyId = response.getEntityId();
+        return policyResolver.apply(policyId)
+                .thenCompose(rawPolicyOpt -> {
+                    if (rawPolicyOpt.isEmpty()) {
+                        return CompletableFuture.completedFuture(response);
+                    }
+                    final Policy rawPolicy = rawPolicyOpt.get();
+                    return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(rawPolicy, policyResolver,
+                                    namespacePoliciesConfig)
+                            .thenApply(enforcer -> enforcer.getPolicy().orElse(rawPolicy))
+                            .thenApply(merged -> rebuildResponseWithMergedPolicy(response, merged));
+                })
+                .exceptionally(throwable -> {
+                    final DittoRuntimeException dre = DittoRuntimeException.asDittoRuntimeException(throwable, t -> {
+                        LOGGER.withCorrelationId(response.getDittoHeaders())
+                                .warn("Could not resolve effective policy view for <{}>; returning unresolved view." +
+                                        " Cause: {}", policyId, t.toString());
+                        return null;
+                    });
+                    if (dre != null) {
+                        throw dre;
+                    }
+                    return response;
+                });
+    }
+
+    private static RetrievePolicyResponse rebuildResponseWithMergedPolicy(final RetrievePolicyResponse original,
+            final Policy mergedPolicy) {
+        final JsonSchemaVersion version = original.getImplementedSchemaVersion();
+        final JsonObject mergedJson = mergedPolicy.toJson(version, FieldType.regularOrSpecial());
+        final JsonValue originalEntity = original.getEntity(version);
+        final JsonObject projected = projectMerged(mergedJson, originalEntity, original.getDittoHeaders());
+
+        final DittoHeaders headersWithoutEtag = original.getDittoHeaders().toBuilder()
+                .removeHeader(DittoHeaderDefinition.ETAG.getKey())
+                .build();
+        return RetrievePolicyResponse.of(original.getEntityId(), projected, headersWithoutEtag);
+    }
+
+    private static JsonObject projectMerged(final JsonObject mergedJson,
+            final JsonValue originalEntity,
+            final DittoHeaders headers) {
+        final String selectorString = headers.get(DittoHeaderDefinition.POLICY_VIEW_FIELDS_SELECTOR.getKey());
+        if (selectorString != null && !selectorString.isEmpty()) {
+            // The selector was just constructed by PoliciesRoute from a successful parse; if it fails to
+            // round-trip here, that's an internal bug worth surfacing rather than silently returning a wider view.
+            final JsonFieldSelector selector = JsonFactory.newFieldSelector(selectorString,
+                    JSON_PARSE_OPTIONS_FOR_FIELDS_SELECTOR);
+            return mergedJson.get(selector);
+        }
+        if (!originalEntity.isObject()) {
+            return mergedJson;
+        }
+        final List<JsonKey> originalKeys = originalEntity.asObject().getKeys();
+        if (originalKeys.isEmpty()) {
+            return mergedJson;
+        }
+        final JsonObjectBuilder builder = JsonObject.newBuilder();
+        for (final JsonKey key : originalKeys) {
+            mergedJson.getValue(key).ifPresentOrElse(
+                    value -> builder.set(key.toString(), value),
+                    () -> originalEntity.asObject().getValue(key)
+                            .ifPresent(value -> builder.set(key.toString(), value))
+            );
+        }
+        return builder.build();
     }
 
     @SuppressWarnings("unchecked")

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
@@ -279,7 +279,8 @@ public final class PolicyCommandEnforcement
 
         return mergedStage.thenCombine(allSources, (merged, ignored) -> {
             Policy result = merged;
-            // Declared imports — labels are unique per source via the imported-<sourceId>- prefix, no precedence concern.
+            // Declared imports — labels are unique per source via the imported-<sourceId>- prefix
+            // (transitive imports nest as imported-<B>-imported-<C>-<label>), so no precedence concern.
             for (final PolicyImport imp : rawPolicy.getPolicyImports()) {
                 final PolicyEnforcer src = sources.get(imp.getImportedPolicyId()).join().orElse(null);
                 if (src == null) continue;

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.policies.service.enforcement;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -41,12 +43,16 @@ import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.enforcement.AbstractEnforcementReloaded;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
 import org.eclipse.ditto.policies.model.PolicyView;
 import org.eclipse.ditto.policies.model.PolicyViewInvalidException;
 import org.eclipse.ditto.policies.model.ResourceKey;
@@ -228,10 +234,9 @@ public final class PolicyCommandEnforcement
                         return CompletableFuture.completedFuture(response);
                     }
                     final Policy rawPolicy = rawPolicyOpt.get();
-                    return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(rawPolicy, policyResolver,
-                                    namespacePoliciesConfig)
-                            .thenApply(enforcer -> enforcer.getPolicy().orElse(rawPolicy))
-                            .thenApply(merged -> rebuildResponseWithMergedPolicy(response, merged));
+                    final AuthorizationContext authCtx = response.getDittoHeaders().getAuthorizationContext();
+                    return mergeAndDropUnreadable(rawPolicy, authCtx)
+                            .thenApply(filtered -> rebuildResponseWithMergedPolicy(response, filtered));
                 })
                 .exceptionally(throwable -> {
                     final DittoRuntimeException dre = DittoRuntimeException.asDittoRuntimeException(throwable, t -> {
@@ -245,6 +250,86 @@ public final class PolicyCommandEnforcement
                     }
                     return response;
                 });
+    }
+
+    /**
+     * Builds the merged policy and drops every entry the caller has no READ on within its source. Without this
+     * source-side check, broad READ on the importing policy would expose the contents of every imported and
+     * namespace-root policy, regardless of the caller's permissions on the source.
+     */
+    private CompletionStage<Policy> mergeAndDropUnreadable(final Policy rawPolicy, final AuthorizationContext authCtx) {
+        final List<PolicyId> nsRootIds = namespacePoliciesConfig.getRootPoliciesForNamespace(
+                rawPolicy.getNamespace().orElse(""));
+
+        final Map<PolicyId, CompletableFuture<Optional<PolicyEnforcer>>> sources = new LinkedHashMap<>();
+        for (final PolicyImport imp : rawPolicy.getPolicyImports()) {
+            sources.computeIfAbsent(imp.getImportedPolicyId(), this::resolveSourceEnforcer);
+        }
+        for (final PolicyId nsRootId : nsRootIds) {
+            sources.computeIfAbsent(nsRootId, this::resolveSourceEnforcer);
+        }
+        final CompletionStage<Policy> mergedStage = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(rawPolicy, policyResolver, namespacePoliciesConfig)
+                .thenApply(enforcer -> enforcer.getPolicy().orElse(rawPolicy));
+        if (sources.isEmpty()) {
+            return mergedStage;
+        }
+        final CompletableFuture<Void> allSources = CompletableFuture.allOf(
+                sources.values().toArray(new CompletableFuture[0]));
+
+        return mergedStage.thenCombine(allSources, (merged, ignored) -> {
+            Policy result = merged;
+            // Declared imports — labels are unique per source via the imported-<sourceId>- prefix, no precedence concern.
+            for (final PolicyImport imp : rawPolicy.getPolicyImports()) {
+                final PolicyEnforcer src = sources.get(imp.getImportedPolicyId()).join().orElse(null);
+                if (src == null) continue;
+                for (final PolicyEntry e : src.getPolicy().orElseThrow()) {
+                    if (isContributedByImport(e, imp) && !hasSourceSideRead(src, e.getLabel(), authCtx)) {
+                        result = result.removeEntry(PoliciesModelFactory.newImportedLabel(
+                                imp.getImportedPolicyId(), e.getLabel()));
+                    }
+                }
+            }
+            // Ns-roots land under nsimported-<rootId>-<originalLabel>; drop must use the rewritten label
+            // or silently no-op. The rewrite also makes labels unique per source, so no precedence handling.
+            for (final PolicyId nsRootId : nsRootIds) {
+                final PolicyEnforcer src = sources.get(nsRootId).join().orElse(null);
+                if (src == null) continue;
+                for (final PolicyEntry e : src.getPolicy().orElseThrow()) {
+                    if (!ImportableType.IMPLICIT.equals(e.getImportableType())) continue;
+                    if (!hasSourceSideRead(src, e.getLabel(), authCtx)) {
+                        result = result.removeEntry(
+                                PoliciesModelFactory.newNsImportedLabel(nsRootId, e.getLabel()));
+                    }
+                }
+            }
+            return result;
+        });
+    }
+
+    private CompletableFuture<Optional<PolicyEnforcer>> resolveSourceEnforcer(final PolicyId sourceId) {
+        return policyResolver.apply(sourceId)
+                .thenCompose(opt -> opt.isPresent()
+                        ? PolicyEnforcer.withResolvedImports(opt.get(), policyResolver).thenApply(Optional::of)
+                        : CompletableFuture.completedFuture(Optional.<PolicyEnforcer>empty()))
+                .toCompletableFuture();
+    }
+
+    private static boolean hasSourceSideRead(final PolicyEnforcer src, final Label label,
+            final AuthorizationContext authCtx) {
+        return src.getEnforcer().hasPartialPermissions(
+                PoliciesResourceType.policyResource("/entries/" + label), authCtx, Permission.READ);
+    }
+
+    private static boolean isContributedByImport(final PolicyEntry sourceEntry, final PolicyImport imp) {
+        return switch (sourceEntry.getImportableType()) {
+            case IMPLICIT -> true;
+            case EXPLICIT -> imp.getEffectedImports()
+                    .map(EffectedImports::getImportedLabels)
+                    .map(labels -> labels.contains(sourceEntry.getLabel()))
+                    .orElse(false);
+            case NEVER -> false;
+        };
     }
 
     private static RetrievePolicyResponse rebuildResponseWithMergedPolicy(final RetrievePolicyResponse original,

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
@@ -14,6 +14,9 @@ package org.eclipse.ditto.policies.service.persistence.actors;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -24,12 +27,15 @@ import org.eclipse.ditto.base.model.exceptions.DittoRuntimeExceptionBuilder;
 import org.eclipse.ditto.base.model.signals.commands.streaming.SubscribeForPersistedEvents;
 import org.eclipse.ditto.base.model.signals.events.Event;
 import org.eclipse.ditto.base.service.actors.ShutdownBehaviour;
+import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.internal.utils.persistentactors.AbstractPersistenceSupervisor;
 import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
+import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
@@ -121,7 +127,13 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
 
     @Override
     protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
-        return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
+        final PolicyCacheLoader cacheLoader = PolicyCacheLoader.getSingletonInstance(getContext().getSystem());
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver =
+                policyId -> cacheLoader.asyncLoad(policyId, getContext().getSystem().dispatcher())
+                        .thenApply(Entry::get);
+        return PolicyEnforcerActor.props(entityId,
+                new PolicyCommandEnforcement(policyResolver, namespacePoliciesConfig),
+                policyEnforcerProvider,
                 policiesConfig.getPolicyConfig().getSupervisorConfig().getLocalAskTimeoutConfig(),
                 namespacePoliciesConfig
         );

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementResolvedViewTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementResolvedViewTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.service.enforcement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.api.Permission;
+import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.PolicyImports;
+import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandResponse;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyResponse;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Regression tests for the source-side READ check in {@link PolicyCommandEnforcement#filterResponse} when
+ * {@code policy-view=resolved} is requested. Locks in the protection against the disclosure leak where a caller
+ * with broad READ on the importing policy could read full contents of imported / namespace-root source policies
+ * they have no permission on. See PR review on #2429 / #2354.
+ *
+ * <p>Post-#2431 the ns-root entries appear in the merged policy under the rewritten label
+ * {@code nsimported-<rootId>-<originalLabel>}; the assertions reflect that form.</p>
+ */
+public final class PolicyCommandEnforcementResolvedViewTest {
+
+    private static final SubjectId VIEWER_ID = SubjectId.newInstance(SubjectIssuer.GOOGLE, "viewer");
+    private static final SubjectId ADMIN_ID = SubjectId.newInstance(SubjectIssuer.GOOGLE, "admin");
+    private static final Subject VIEWER = Subject.newInstance(VIEWER_ID);
+    private static final Subject ADMIN = Subject.newInstance(ADMIN_ID);
+
+    private static final ResourceKey POLICY_ROOT = PoliciesResourceType.policyResource("/");
+    private static final ResourceKey THING_ROOT = PoliciesResourceType.thingResource("/");
+
+    private static final PolicyId IMPORTING_ID = PolicyId.of("test.nsleak", "importing");
+    private static final PolicyId DECLARED_SOURCE_ID = PolicyId.of("test.nsleak", "declared-source");
+    private static final PolicyId NS_ROOT_ID = PolicyId.of("test.nsleak", "ns-root");
+    private static final String IMPORTING_NAMESPACE = "test.nsleak";
+
+    private static final DittoHeaders RESOLVED_VIEW_HEADERS = DittoHeaders.newBuilder()
+            .authorizationContext(AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
+                    AuthorizationSubject.newInstance(VIEWER_ID)))
+            .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved")
+            .correlationId("resolved-view-test")
+            .build();
+
+    /**
+     * VIEWER has READ+WRITE on policy:/ of the importing policy and zero presence in the declared-import source.
+     * Without the source-side check, the merged JSON exposes SECRET (with ADMIN's subject) in cleartext to VIEWER.
+     * With the check, SECRET must be absent.
+     */
+    @Test
+    public void resolvedViewDropsImportedEntriesWhenCallerLacksSourceSideRead() throws Exception {
+        final Policy importing = Policy.newBuilder(IMPORTING_ID)
+                .forLabel("VIEWER")
+                .setSubject(VIEWER)
+                .setGrantedPermissions(POLICY_ROOT, Permission.READ, Permission.WRITE)
+                .setImportable(ImportableType.NEVER)
+                .setPolicyImports(PolicyImports.newInstance(PoliciesModelFactory.newPolicyImport(
+                        DECLARED_SOURCE_ID, EffectedImports.newInstance(Collections.emptyList()))))
+                .build();
+        final Policy declaredSource = Policy.newBuilder(DECLARED_SOURCE_ID)
+                .forLabel("ADMIN")
+                .setSubject(ADMIN)
+                .setGrantedPermissions(POLICY_ROOT, Permission.READ, Permission.WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel("SECRET")
+                .setSubject(ADMIN)
+                .setGrantedPermissions(THING_ROOT, Permission.READ)
+                .setImportable(ImportableType.IMPLICIT)
+                .build();
+
+        final JsonObject filteredEntries = runResolvedView(importing,
+                policyResolver(importing, declaredSource), emptyNamespacePoliciesConfig());
+
+        // Declared-import label format: imported-<sourceId>-<originalLabel>.
+        final String secretLabel = "imported-" + DECLARED_SOURCE_ID + "-SECRET";
+        assertThat(filteredEntries.contains(JsonPointer.of(secretLabel)))
+                .as("imported SECRET entry must be hidden from caller without source-side READ")
+                .isFalse();
+        assertThat(filteredEntries.toString())
+                .as("ADMIN subject must not leak via imported entry")
+                .doesNotContain(ADMIN_ID.toString());
+    }
+
+    /**
+     * VIEWER has READ+WRITE on policy:/ of the importing policy and zero presence in the namespace-root source.
+     * Post-#2431 the ns-root entry would land in merged JSON under {@code nsimported-<rootId>-AUDIT}; the
+     * source-side check must drop it because VIEWER has no READ on AUDIT in the ns-root.
+     */
+    @Test
+    public void resolvedViewDropsNamespaceRootEntriesWhenCallerLacksSourceSideRead() throws Exception {
+        final Policy importing = Policy.newBuilder(IMPORTING_ID)
+                .forLabel("VIEWER")
+                .setSubject(VIEWER)
+                .setGrantedPermissions(POLICY_ROOT, Permission.READ, Permission.WRITE)
+                .setImportable(ImportableType.NEVER)
+                .build();
+        final Policy nsRoot = Policy.newBuilder(NS_ROOT_ID)
+                .forLabel("ADMIN")
+                .setSubject(ADMIN)
+                .setGrantedPermissions(POLICY_ROOT, Permission.READ, Permission.WRITE)
+                .setImportable(ImportableType.NEVER)
+                .forLabel("AUDIT")
+                .setSubject(ADMIN)
+                .setGrantedPermissions(THING_ROOT, Permission.READ)
+                .setImportable(ImportableType.IMPLICIT)
+                .build();
+
+        final JsonObject filteredEntries = runResolvedView(importing,
+                policyResolver(importing, nsRoot),
+                namespacePoliciesConfigBinding(IMPORTING_NAMESPACE, NS_ROOT_ID));
+        // Post-#2431 the ns-root entry's merged label is the rewritten nsimported-<rootId>-<originalLabel> form.
+        final String auditLabel = PoliciesModelFactory.newNsImportedLabel(NS_ROOT_ID, "AUDIT").toString();
+        assertThat(filteredEntries.contains(JsonPointer.of(auditLabel)))
+                .as("namespace-root AUDIT entry must be hidden from caller without source-side READ")
+                .isFalse();
+        assertThat(filteredEntries.toString())
+                .as("ADMIN subject must not leak via namespace-root entry")
+                .doesNotContain(ADMIN_ID.toString());
+    }
+
+    /**
+     * Drives {@link PolicyCommandEnforcement#filterResponse} end-to-end for a resolved-view request and returns the
+     * filtered {@code entries} JSON object so each test can assert on it. The importing-policy enforcer passed to
+     * {@code filterResponse} is built via {@link PolicyEnforcer#withResolvedImportsAndNamespacePolicies} with the
+     * same resolver + namespace config the production cache loader uses, mirroring runtime behaviour exactly.
+     */
+    private static JsonObject runResolvedView(final Policy importing,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> resolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) throws Exception {
+        final PolicyCommandEnforcement enforcement =
+                new PolicyCommandEnforcement(resolver, namespacePoliciesConfig);
+        final PolicyEnforcer importingEnforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(importing, resolver, namespacePoliciesConfig)
+                .toCompletableFuture().get();
+        final RetrievePolicyResponse rawResponse = RetrievePolicyResponse.of(IMPORTING_ID,
+                importing.toJson(), RESOLVED_VIEW_HEADERS);
+
+        final PolicyCommandResponse<?> filtered = enforcement.filterResponse(rawResponse, importingEnforcer)
+                .toCompletableFuture().get();
+
+        final RetrievePolicyResponse retrieveResp = (RetrievePolicyResponse) filtered;
+        return retrieveResp.getEntity().asObject().getValue("entries").orElseThrow().asObject();
+    }
+
+    private static Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver(final Policy... policies) {
+        return id -> {
+            for (final Policy policy : policies) {
+                if (policy.getEntityId().filter(pid -> pid.equals(id)).isPresent()) {
+                    return CompletableFuture.completedFuture(Optional.of(policy));
+                }
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+    }
+
+    private static NamespacePoliciesConfig emptyNamespacePoliciesConfig() {
+        final NamespacePoliciesConfig config = Mockito.mock(NamespacePoliciesConfig.class);
+        when(config.isEmpty()).thenReturn(true);
+        when(config.getNamespacePolicies()).thenReturn(Collections.emptyMap());
+        when(config.getRootPoliciesForNamespace(Mockito.anyString())).thenReturn(Collections.emptyList());
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.emptySet());
+        when(config.getNamespacesForRootPolicy(Mockito.any())).thenReturn(Collections.emptySet());
+        return config;
+    }
+
+    private static NamespacePoliciesConfig namespacePoliciesConfigBinding(final String namespace,
+            final PolicyId nsRootPolicyId) {
+        final NamespacePoliciesConfig config = Mockito.mock(NamespacePoliciesConfig.class);
+        when(config.isEmpty()).thenReturn(false);
+        when(config.getRootPoliciesForNamespace(namespace)).thenReturn(List.of(nsRootPolicyId));
+        when(config.getRootPoliciesForNamespace(Mockito.argThat(ns -> !namespace.equals(ns))))
+                .thenReturn(Collections.emptyList());
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.singleton(nsRootPolicyId));
+        return config;
+    }
+}

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
@@ -810,7 +810,11 @@ public final class PolicyCommandEnforcementTest {
 
         @Override
         protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
-            return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
+            return PolicyEnforcerActor.props(entityId,
+                    new PolicyCommandEnforcement(
+                            id -> CompletableFuture.completedFuture(Optional.empty()),
+                            emptyNamespacePoliciesConfig()),
+                    policyEnforcerProvider,
                     DefaultLocalAskTimeoutConfig.of(ConfigFactory.empty()),
                     emptyNamespacePoliciesConfig());
         }

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -25,6 +25,7 @@ import * as Piggyback from './modules/operations/piggyback.js';
 import * as Operations from './modules/operations/servicesLogging.js';
 import * as Templates from './modules/operations/templates.js';
 import * as Policies from './modules/policies/policies.js';
+import * as PoliciesEffective from './modules/policies/policiesEffective.js';
 import * as PoliciesEntries from './modules/policies/policiesEntries.js';
 import * as PoliciesImports from './modules/policies/policiesImports.js';
 import * as PoliciesJSON from './modules/policies/policiesJSON.js';
@@ -73,6 +74,7 @@ document.addEventListener('DOMContentLoaded', async function() {
   PoliciesEntries.ready();
   PoliciesSubjects.ready();
   PoliciesResources.ready();
+  PoliciesEffective.ready();
   Connections.ready();
   ConnectionsCRUD.ready();
   await ConnectionsMonitor.ready();

--- a/ui/modules/policies/policies.html
+++ b/ui/modules/policies/policies.html
@@ -39,6 +39,12 @@
                     <li class="nav-item">
                         <a class="nav-link" data-bs-toggle="tab" data-bs-target="#tabPolicyJson">JSON</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" data-bs-toggle="tab" data-bs-target="#tabPolicyEffective"
+                            title="Effective (resolved) policy: own entries plus entries inherited via imports + namespace-root policies. Read-only.">
+                            Effective
+                        </a>
+                    </li>
                 </ul>
                 <div class="tab-content" style="flex-grow: 1; overflow: hidden;">
                     <div class="tab-pane container active no-margin" id="tabPolicyEntries">
@@ -149,13 +155,29 @@
                             <div class="input-group input-group-sm mb-1">
                                 <label class="input-group-text">Template</label>
                                 <select class="form-select form-select-sm" id="selectPolicyJSONTemplate" disabled></select>
-                            </div>    
+                            </div>
                             <div class="ace_container" style="flex-grow: 1;">
                                 <div>
                                     <div class="script_editor" id="policyEditor"></div>
                                 </div>
                             </div>
                         </crud-toolbar>
+                    </div>
+                    <div class="tab-pane container no-margin" id="tabPolicyEffective">
+                        <div class="d-flex justify-content-between align-items-center mb-1">
+                            <small class="text-muted">
+                                Read-only view of the policy after import resolution and namespace-root merge.
+                                Imported entries appear with the prefix
+                                <code>imported-&lt;importedPolicyId&gt;-&lt;label&gt;</code>.
+                            </small>
+                            <button id="buttonRefreshEffectivePolicy" class="btn btn-outline-primary btn-sm"
+                                title="Re-fetch the effective view (cache invalidates lazily on import changes)">
+                                Refresh
+                            </button>
+                        </div>
+                        <div class="ace_container" style="height: calc(80vh - 50px);">
+                            <div class="script_editor" id="effectivePolicyEditor"></div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/ui/modules/policies/policiesEffective.ts
+++ b/ui/modules/policies/policiesEffective.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import * as ace from 'ace-builds/src-noconflict/ace';
+import { Ace } from 'ace-builds';
+import * as API from '../api.js';
+import * as Utils from '../utils.js';
+import * as Policies from './policies.js';
+
+type DomElements = {
+  buttonRefreshEffectivePolicy: HTMLButtonElement,
+}
+
+let dom: DomElements = {
+  buttonRefreshEffectivePolicy: null,
+};
+
+let effectivePolicyEditor: Ace.Editor;
+let lastLoadedPolicyId: string | null = null;
+
+const PLACEHOLDER_NO_POLICY = '// Load a policy to see its effective (resolved) view.';
+
+export function ready() {
+  Utils.getAllElementsById(dom);
+  Policies.observable.addChangeListener(onPolicyChanged);
+
+  effectivePolicyEditor = Utils.createAceEditor('effectivePolicyEditor', 'ace/mode/json', true);
+  effectivePolicyEditor.setReadOnly(true);
+  effectivePolicyEditor.renderer.setShowGutter(false);
+  effectivePolicyEditor.setValue(PLACEHOLDER_NO_POLICY, -1);
+
+  dom.buttonRefreshEffectivePolicy.addEventListener('click', () => {
+    if (lastLoadedPolicyId) {
+      loadEffectivePolicy(lastLoadedPolicyId);
+    }
+  });
+
+  // Re-fetch only when the user activates the tab — avoids an extra request on every policy load.
+  document.querySelector('a[data-bs-target="#tabPolicyEffective"]').addEventListener('shown.bs.tab', () => {
+    // Ace caches its measured container size from creation time. The editor is created while the
+    // tab-pane is display:none, so Ace measured 0x0 and stuck with it. Re-measure on every tab show.
+    effectivePolicyEditor.resize(true);
+    effectivePolicyEditor.renderer.updateFull(true);
+    if (Policies.thePolicy && Policies.thePolicy.policyId !== lastLoadedPolicyId) {
+      loadEffectivePolicy(Policies.thePolicy.policyId);
+    }
+  });
+}
+
+function onPolicyChanged(policy: Policies.Policy) {
+  if (!policy) {
+    lastLoadedPolicyId = null;
+    effectivePolicyEditor.setValue(PLACEHOLDER_NO_POLICY, -1);
+    return;
+  }
+  if (lastLoadedPolicyId === policy.policyId) {
+    return; // already showing the right thing
+  }
+  lastLoadedPolicyId = null;
+  // If the user is currently looking at the Effective tab, fetch immediately — switching the policy
+  // from the Recent list while on this tab does NOT fire shown.bs.tab, so we'd otherwise be stuck
+  // showing stale content. Off-tab, just invalidate; the tab activation handler will load on demand.
+  if (isEffectiveTabActive()) {
+    loadEffectivePolicy(policy.policyId);
+  } else {
+    effectivePolicyEditor.setValue('', -1);
+  }
+}
+
+function isEffectiveTabActive(): boolean {
+  const tabAnchor = document.querySelector('a[data-bs-target="#tabPolicyEffective"]');
+  return tabAnchor?.classList.contains('active') ?? false;
+}
+
+async function loadEffectivePolicy(policyId: string) {
+  effectivePolicyEditor.setValue('// loading…', -1);
+  try {
+    // policy-view=resolved is the gateway-side flag introduced by the effective-policy-view feature; on
+    // older deployments that don't recognise the parameter the gateway returns the original (stored) view,
+    // which is a graceful fallback.
+    const resolved = await API.callDittoREST('GET',
+      `/policies/${encodeURIComponent(policyId)}?policy-view=resolved`);
+    effectivePolicyEditor.setValue(JSON.stringify(resolved, null, 2), -1);
+    lastLoadedPolicyId = policyId;
+  } catch (e) {
+    effectivePolicyEditor.setValue(`// could not load effective view: ${formatError(e)}`, -1);
+    lastLoadedPolicyId = null;
+  }
+  // Force a full re-render: the editor was likely hidden when setValue was called (tab-pane hidden until
+  // shown), and Ace doesn't auto-relayout on visibility changes — without this the canvas paints nothing.
+  effectivePolicyEditor.resize(true);
+  effectivePolicyEditor.renderer.updateFull(true);
+}
+
+function formatError(e: unknown): string {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  if (typeof e === 'string') {
+    return e;
+  }
+  return JSON.stringify(e);
+}


### PR DESCRIPTION
Closes #2354. Adds a `policy-view` request hint on `GET /api/2/policies/{id}` that returns the merged "effective" policy.                                                              
   
  - `policy-view=original` (default) — policy as stored, unchanged behaviour.                                                                                                            
  - `policy-view=resolved` — own entries + declared imports + configured namespace-root policies, with `references` resolved.
                                                                                                                                                                                         
  Imported entries appear under `imported-<importedPolicyId>-<originalLabel>` (treat as opaque). The hint can also be sent as the `policy-view` Ditto header, so the resolved view is available uniformly via HTTP, WebSocket, SSE and Connectivity.