### PR TITLE
#2405 Add UI support for Ditto 3.9.0 policy and search features

### DIFF
--- a/ui/main.scss
+++ b/ui/main.scss
@@ -231,10 +231,13 @@ hr {
   margin: 0.25rem;
 }
 
+// Edit-mode overlay z-indices sit BELOW Bootstrap's modal layer (modal-backdrop: 1050, modal: 1055)
+// so that confirmation/info modals opened from inside an editing crud-toolbar render on top of the
+// edit overlay rather than being faded out behind it.
 .editBackground {
   display: block;
   position: fixed;
-  z-index: 1100;
+  z-index: 1040;
   left: 0;
   top: 0;
   width: 100%;
@@ -245,13 +248,13 @@ hr {
 }
 
 .editForground {
-  z-index: 1200;
+  z-index: 1045;
   position: relative;
   background-color: white;
 }
 
 .editForgroundBig {
-  z-index: 1200;
+  z-index: 1045;
   position: fixed;
   background-color: white;
   top: 0;

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -29,6 +29,8 @@ import * as PoliciesEffective from './modules/policies/policiesEffective.js';
 import * as PoliciesEntries from './modules/policies/policiesEntries.js';
 import * as PoliciesImports from './modules/policies/policiesImports.js';
 import * as PoliciesJSON from './modules/policies/policiesJSON.js';
+import * as PoliciesNamespaces from './modules/policies/policiesNamespaces.js';
+import * as PoliciesReferences from './modules/policies/policiesReferences.js';
 import * as PoliciesResources from './modules/policies/policiesResources';
 import * as PoliciesSubjects from './modules/policies/policiesSubjects';
 import * as Attributes from './modules/things/attributes.js';
@@ -74,6 +76,8 @@ document.addEventListener('DOMContentLoaded', async function() {
   PoliciesEntries.ready();
   PoliciesSubjects.ready();
   PoliciesResources.ready();
+  PoliciesNamespaces.ready();
+  PoliciesReferences.ready();
   PoliciesEffective.ready();
   Connections.ready();
   ConnectionsCRUD.ready();

--- a/ui/modules/policies/policies.html
+++ b/ui/modules/policies/policies.html
@@ -46,11 +46,11 @@
                         </a>
                     </li>
                 </ul>
-                <div class="tab-content" style="flex-grow: 1; overflow: hidden;">
+                <div class="tab-content" style="flex-grow: 1; overflow-y: auto; height: 80vh;">
                     <div class="tab-pane container active no-margin" id="tabPolicyEntries">
                         <h5>Policy Entries</h5>
                         <hr />
-                        <div class="split-h resizable_pane" style="height: 22vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-entries">
+                        <div class="split-h resizable_pane" style="height: 16vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-entries">
                             <div class="split-panel resizable_flex_column">
                                 <div class="input-group has-validation">
                                     <input class="form-control" id="tableValidationEntries" hidden="true"></input>
@@ -65,53 +65,81 @@
                             <div class="split-panel resizable_flex_column">
                                 <crud-toolbar label="Entry" id="crudEntry">
                                     <div class="input-group input-group-sm mb-1">
-                                        <label class="input-group-text">Importable</label>
+                                        <label class="input-group-text" data-bs-toggle="tooltip"
+                                            title="Whether other policies importing this one inherit this entry. 'implicit' = imported automatically when an importing policy does not specify entry labels; 'explicit' = imported only when the importing policy lists this entry's label; 'never' = cannot be imported.">
+                                            Importable
+                                        </label>
                                         <select class="form-select form-select-sm" id="selectImportable" disabled>
                                             <option selected value="implicit">implicit</option>
                                             <option value="explicit">explicit</option>
                                             <option value="never">never</option>
                                         </select>
-                                    </div>    
+                                    </div>
+                                    <div class="input-group input-group-sm mb-1">
+                                        <label class="input-group-text" data-bs-toggle="tooltip"
+                                            title="Constrains what an entry that references THIS entry may additionally contribute on top of the inherited subjects, resources and namespaces. 'Default' (field absent) = no restriction, referencing entries may add any of the three kinds. 'Deny all' ([]) = referencing entries inherit but may not add anything of their own. 'Allow only:' = whitelist; only the checked kinds may be added by a referencing entry, others are silently stripped at enforcement time.">
+                                            Allowed additions
+                                        </label>
+                                        <select class="form-select form-select-sm" id="selectAllowedAdditionsMode" style="min-width: 10.5em; flex: 1 1 10.5em;" disabled>
+                                            <option value="default">Default</option>
+                                            <option value="denyAll">Deny all</option>
+                                            <option value="allowOnly">Allow only:</option>
+                                        </select>
+                                        <span class="input-group-text gap-1 flex-wrap">
+                                            <input class="form-check-input mt-0" type="checkbox" id="checkboxAdditionSubjects"
+                                                title="subjects — when checked under 'Allow only:', a referencing entry may add subjects on top of those inherited from this entry."
+                                                disabled>
+                                            <label for="checkboxAdditionSubjects" class="me-2"
+                                                title="subjects — when checked under 'Allow only:', a referencing entry may add subjects on top of those inherited from this entry.">subj</label>
+                                            <input class="form-check-input mt-0" type="checkbox" id="checkboxAdditionResources"
+                                                title="resources — when checked under 'Allow only:', a referencing entry may add resources (grant/revoke entries) on top of those inherited."
+                                                disabled>
+                                            <label for="checkboxAdditionResources" class="me-2"
+                                                title="resources — when checked under 'Allow only:', a referencing entry may add resources (grant/revoke entries) on top of those inherited.">res</label>
+                                            <input class="form-check-input mt-0" type="checkbox" id="checkboxAdditionNamespaces"
+                                                title="namespaces — when checked under 'Allow only:', a referencing entry may add namespace patterns on top of those inherited."
+                                                disabled>
+                                            <label for="checkboxAdditionNamespaces"
+                                                title="namespaces — when checked under 'Allow only:', a referencing entry may add namespace patterns on top of those inherited.">ns</label>
+                                        </span>
+                                        <input class="form-control" id="validationAllowedAdditions" hidden="true">
+                                        <div class="invalid-feedback"></div>
+                                    </div>
                                 </crud-toolbar>
                             </div>
-                        </div>                
-                        <h6>Subjects</h6>
-                        <div class="split-h resizable_pane" style="height: 22vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-subjects">
-                            <div class="split-panel resizable_flex_column">
+                        </div>
+                        <small class="text-muted mt-2 d-block">For the entry selected above:</small>
+                        <div class="split-h resizable_pane mb-2" style="height: 32vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-subjects-resources">
+                            <div class="split-panel resizable_flex_column pe-2">
+                                <h6 class="mb-1">Subjects</h6>
                                 <div class="input-group has-validation">
                                     <input class="form-control" id="tableValidationSubjects" hidden="true"></input>
                                     <div class="invalid-feedback"></div>
                                 </div>
-                                <div class="table-wrap">
+                                <div class="table-wrap" style="max-height: 18vh;">
                                     <table class="table table-striped table-hover table-sm">
                                         <tbody id="tbodyPolicySubjects"></tbody>
                                     </table>
                                 </div>
-                            </div>
-                            <div class="split-panel resizable_flex_column">
-                                <crud-toolbar label="Subject" id="crudSubject" style="flex-grow: 1;">
+                                <crud-toolbar label="Subject" id="crudSubject"
+                                    tooltip="The 'type' field is mandatory and serves as a free-text description of the subject (its purpose, owner, source). It is mostly documentational — Ditto does not interpret it for authentication or authorization."
+                                    style="flex-grow: 1;">
                                     <div class="ace_container" style="flex-grow: 1;">
                                         <div class="script_editor" id="subjectEditor"></div>
-                                    </div>        
+                                    </div>
                                 </crud-toolbar>
                             </div>
-                            <!-- <div class="row flex_column_part">
-                            </div> -->
-                        </div>
-                        <h6>Resources</h6>
-                        <div class="split-h resizable_pane" style="height: 22vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-resources">
-                            <div class="split-panel resizable_flex_column">
+                            <div class="split-panel resizable_flex_column ps-2">
+                                <h6 class="mb-1">Resources</h6>
                                 <div class="input-group has-validation">
                                     <input class="form-control" id="tableValidationResources" hidden="true"></input>
                                     <div class="invalid-feedback"></div>
                                 </div>
-                                <div class="table-wrap">
+                                <div class="table-wrap" style="max-height: 13vh;">
                                     <table class="table table-striped table-hover table-sm">
                                         <tbody id="tbodyPolicyResources"></tbody>
                                     </table>
                                 </div>
-                            </div>
-                            <div class="split-panel resizable_flex_column">
                                 <crud-toolbar label="Resource" id="crudResource" style="flex-grow: 1;">
                                     <div class="input-group input-group-sm mb-1">
                                         <label class="input-group-text">Template</label>
@@ -119,17 +147,64 @@
                                     </div>
                                     <div class="ace_container" style="flex-grow: 1;">
                                         <div class="script_editor" id="resourceEditor"></div>
-                                    </div>        
+                                    </div>
+                                </crud-toolbar>
+                            </div>
+                        </div>
+                        <div class="split-h resizable_pane" style="height: 23vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-namespaces-references">
+                            <div class="split-panel resizable_flex_column pe-2">
+                                <h6 class="mb-1">Namespaces</h6>
+                                <div class="input-group has-validation">
+                                    <input class="form-control" id="tableValidationNamespaces" hidden="true"></input>
+                                    <div class="invalid-feedback"></div>
+                                </div>
+                                <div class="table-wrap" style="max-height: 13vh;">
+                                    <table class="table table-striped table-hover table-sm">
+                                        <tbody id="tbodyPolicyNamespaces"></tbody>
+                                    </table>
+                                </div>
+                                <crud-toolbar label="Namespace" id="crudNamespace" allowIdChange
+                                    tooltip="Restrict the entry to things in matching namespaces. Leave empty for 'applies to all namespaces'. Patterns: 'com.acme' (exact), 'com.acme.*' (descendants, not the namespace itself)."
+                                    style="flex-grow: 1;">
+                                </crud-toolbar>
+                            </div>
+                            <div class="split-panel resizable_flex_column ps-2">
+                                <h6 class="mb-1">References</h6>
+                                <div class="input-group has-validation">
+                                    <input class="form-control" id="tableValidationReferences" hidden="true"></input>
+                                    <div class="invalid-feedback"></div>
+                                </div>
+                                <div class="table-wrap" style="max-height: 13vh;">
+                                    <table class="table table-striped table-hover table-sm">
+                                        <tbody id="tbodyPolicyReferences"></tbody>
+                                    </table>
+                                </div>
+                                <crud-toolbar label="Reference" id="crudReference" style="flex-grow: 1;">
+                                    <div class="input-group input-group-sm mb-1">
+                                        <label class="input-group-text" data-bs-toggle="tooltip"
+                                            title="Where the referenced entry lives. '(local)' points at another entry in this same policy; selecting an imported policy ID points at an entry inside that imported policy. The Entry dropdown below populates from the chosen scope.">
+                                            Import
+                                        </label>
+                                        <select class="form-select form-select-sm" id="selectReferenceImport" disabled></select>
+                                    </div>
+                                    <div class="input-group input-group-sm mb-1">
+                                        <label class="input-group-text" data-bs-toggle="tooltip"
+                                            title="Label of the referenced entry. Its subjects, resources and namespaces are additively merged into the current entry at policy resolution time, subject to the referenced entry's 'allowedAdditions' restriction.">
+                                            Entry
+                                        </label>
+                                        <select class="form-select form-select-sm" id="selectReferenceEntry" disabled></select>
+                                        <input type="text" class="form-control form-control-sm" id="inputReferenceEntryFallback"
+                                            placeholder="Imported policy unreachable — type label" hidden disabled>
+                                    </div>
+                                    <small class="text-muted" id="referenceWarning"></small>
                                 </crud-toolbar>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="tab-content" style="flex-grow: 1; overflow: hidden;">
                     <div class="tab-pane container no-margin" id="tabPolicyImports">
                         <h5>Policy Imports</h5>
                         <hr />
-                        <div class="split-h resizable_pane" style="height: 75vh;" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-imports">
+                        <div class="split-h resizable_pane" style="height: calc(80vh - 50px);" data-split="horizontal" data-split-sizes="[50,50]" data-split-key="policies-imports">
                             <div class="split-panel resizable_flex_column">
                                 <div class="table-wrap">
                                     <table class="table table-striped table-hover table-sm">
@@ -139,17 +214,31 @@
                             </div>
                             <div class="split-panel resizable_flex_column">
                                 <crud-toolbar label="Imported Policy Id" id="crudImport" style="flex-grow: 1;">
-                                    <div class="table-wrap">
+                                    <div class="table-wrap" style="max-height: 35vh;">
                                         <table class="table table-striped table-hover table-sm">
                                             <tbody id="tbodyPolicyImportEntries"></tbody>
                                         </table>
+                                    </div>
+                                    <label class="form-label small mt-2 mb-1" data-bs-toggle="tooltip"
+                                        title="Whitelist of policy IDs from the imported policy's own imports to resolve transitively. By default no transitive imports are resolved.">
+                                        Transitive imports
+                                    </label>
+                                    <div class="table-wrap" id="wrapTransitiveImports" style="max-height: 25vh;">
+                                        <table class="table table-striped table-hover table-sm">
+                                            <tbody id="tbodyPolicyTransitiveImports"></tbody>
+                                        </table>
+                                    </div>
+                                    <div class="input-group input-group-sm mb-1">
+                                        <input type="text" class="form-control form-control-sm"
+                                            id="inputTransitiveImport"
+                                            placeholder="namespace:name" disabled>
+                                        <button class="btn btn-outline-primary btn-sm" type="button"
+                                            id="buttonAddTransitiveImport" disabled>Add</button>
                                     </div>
                                 </crud-toolbar>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="tab-content" style="flex-grow: 1; overflow: hidden; height: 80vh;">
                     <div class="tab-pane container no-margin" id="tabPolicyJson">
                         <crud-toolbar label="PolicyId" id="crudPolicyJson">
                             <div class="input-group input-group-sm mb-1">

--- a/ui/modules/policies/policies.ts
+++ b/ui/modules/policies/policies.ts
@@ -24,10 +24,44 @@ import { Observable } from '../utils/observable.js';
 import { TabHandler } from '../utils/tabHandler.js';
 import policyHTML from './policies.html';
 
+export type ImportableMode = 'implicit' | 'explicit' | 'never';
+export type AdditionKind = 'subjects' | 'resources' | 'namespaces';
+
+export interface Subject {
+  type?: string;
+  expiry?: string;
+  announcement?: object;
+}
+
+export interface Resource {
+  grant: string[];
+  revoke: string[];
+}
+
+export interface EntryReference {
+  entry: string;
+  import?: string;
+}
+
+export interface PolicyEntry {
+  subjects: Record<string, Subject>;
+  resources: Record<string, Resource>;
+  importable?: ImportableMode;
+  namespaces?: string[];
+  // absent ≠ []. absent = no restriction; [] = deny all additions; non-empty = whitelist of addition kinds.
+  allowedAdditions?: AdditionKind[];
+  references?: EntryReference[];
+}
+
+export interface PolicyImport {
+  entries?: string[];
+  transitiveImports?: string[];
+}
+
 export interface Policy {
   policyId: string,
-  entries: Object,
-  imports: Object,
+  entries: Record<string, PolicyEntry>,
+  imports: Record<string, PolicyImport>,
 }
 
 export let observable = Observable();

--- a/ui/modules/policies/policiesEntries.ts
+++ b/ui/modules/policies/policiesEntries.ts
@@ -163,7 +163,11 @@ function onCreateEntryClick() {
 
 function onUpdateEntryClick() {
   validateAllowedAdditionsSelection();
-  const entry = Policies.thePolicy.entries[selectedEntry];
+  // Spread-copy: never mutate Policies.thePolicy.entries[...] in place. If the PUT 4xx's, an
+  // in-place mutation would leave the cache in a state that doesn't match the server, and a
+  // subsequent Cancel would re-paint the editors from that corrupted state. Mirrors the pattern
+  // already used in policiesNamespaces.ts and policiesReferences.ts.
+  const entry = { ...Policies.thePolicy.entries[selectedEntry] };
   entry.importable = dom.selectImportable.value as Policies.ImportableMode;
   applyAllowedAdditions(entry);
   putOrDeletePolicyEntry(selectedEntry, entry, Policies.finishEditing(dom.crudEntry, CrudOperation.UPDATE));

--- a/ui/modules/policies/policiesEntries.ts
+++ b/ui/modules/policies/policiesEntries.ts
@@ -21,11 +21,18 @@ export let observable = Observable();
 
 export let selectedEntry: string;
 
+type AdditionsMode = 'default' | 'denyAll' | 'allowOnly';
+
 type DomElements = {
   tbodyPolicyEntries: HTMLTableElement,
   tableValidationEntries: HTMLInputElement,
   selectImportable: HTMLSelectElement,
   crudEntry: CrudToolbar,
+  selectAllowedAdditionsMode: HTMLSelectElement,
+  checkboxAdditionSubjects: HTMLInputElement,
+  checkboxAdditionResources: HTMLInputElement,
+  checkboxAdditionNamespaces: HTMLInputElement,
+  validationAllowedAdditions: HTMLInputElement,
 }
 
 let dom: DomElements = {
@@ -33,6 +40,11 @@ let dom: DomElements = {
   tableValidationEntries: null,
   selectImportable: null,
   crudEntry: null,
+  selectAllowedAdditionsMode: null,
+  checkboxAdditionSubjects: null,
+  checkboxAdditionResources: null,
+  checkboxAdditionNamespaces: null,
+  validationAllowedAdditions: null,
 };
 
 export function ready() {
@@ -48,14 +60,79 @@ export function ready() {
   dom.crudEntry.addEventListener('onUpdateClick', onUpdateEntryClick);
   dom.crudEntry.addEventListener('onEditToggle', onToggleEditEntry);
 
+  dom.selectAllowedAdditionsMode.addEventListener('change', onAdditionsModeChange);
+
   dom.tbodyPolicyEntries.onclick = onPolicyEntriesClick;
 }
 
 function onToggleEditEntry(event) {
-  dom.selectImportable.disabled = !event.detail.isEditing;
+  const editing: boolean = event.detail.isEditing;
+  dom.selectImportable.disabled = !editing;
+  setAllowedAdditionsControlsDisabled(!editing);
   if (event.detail.isCancel) {
     updateEditors(selectedEntry);
   }
+}
+
+function setAllowedAdditionsControlsDisabled(disabled: boolean) {
+  dom.selectAllowedAdditionsMode.disabled = disabled;
+  // The kind-checkboxes are only meaningful when "Allow only" is the active mode.
+  const allowOnlyActive = !disabled && dom.selectAllowedAdditionsMode.value === 'allowOnly';
+  dom.checkboxAdditionSubjects.disabled = !allowOnlyActive;
+  dom.checkboxAdditionResources.disabled = !allowOnlyActive;
+  dom.checkboxAdditionNamespaces.disabled = !allowOnlyActive;
+}
+
+function onAdditionsModeChange() {
+  // Re-evaluate checkbox disabled state when the user toggles between modes.
+  setAllowedAdditionsControlsDisabled(false);
+  dom.validationAllowedAdditions.classList.remove('is-invalid');
+}
+
+// Centralised absent-vs-empty discipline. Returns the value to write — `null` means "delete the field".
+// This is the single most error-prone aspect of allowedAdditions: the JSON encoding distinguishes
+// absent (no restriction) from `[]` (deny all), and the mode select is the source of truth.
+function readAllowedAdditionsFromUI(): Policies.AdditionKind[] | null {
+  const mode = dom.selectAllowedAdditionsMode.value as AdditionsMode;
+  if (mode === 'default') {
+    return null;
+  }
+  if (mode === 'denyAll') {
+    return [];
+  }
+  const kinds: Policies.AdditionKind[] = [];
+  if (dom.checkboxAdditionSubjects.checked) kinds.push('subjects');
+  if (dom.checkboxAdditionResources.checked) kinds.push('resources');
+  if (dom.checkboxAdditionNamespaces.checked) kinds.push('namespaces');
+  return kinds;
+}
+
+function applyAllowedAdditions(entry: Policies.PolicyEntry) {
+  const value = readAllowedAdditionsFromUI();
+  if (value === null) {
+    delete entry.allowedAdditions;
+  } else {
+    entry.allowedAdditions = value;
+  }
+}
+
+function loadAllowedAdditionsIntoUI(allowedAdditions: Policies.AdditionKind[] | undefined) {
+  dom.checkboxAdditionSubjects.checked = false;
+  dom.checkboxAdditionResources.checked = false;
+  dom.checkboxAdditionNamespaces.checked = false;
+  if (allowedAdditions === undefined) {
+    dom.selectAllowedAdditionsMode.value = 'default';
+  } else if (allowedAdditions.length === 0) {
+    dom.selectAllowedAdditionsMode.value = 'denyAll';
+  } else {
+    dom.selectAllowedAdditionsMode.value = 'allowOnly';
+    allowedAdditions.forEach((k) => {
+      if (k === 'subjects') dom.checkboxAdditionSubjects.checked = true;
+      else if (k === 'resources') dom.checkboxAdditionResources.checked = true;
+      else if (k === 'namespaces') dom.checkboxAdditionNamespaces.checked = true;
+    });
+  }
+  setAllowedAdditionsControlsDisabled(!dom.crudEntry.isEditing);
 }
 
 function onPolicyEntriesClick(event) {
@@ -72,17 +149,34 @@ function onCreateEntryClick() {
   Utils.assert(dom.crudEntry.idValue, 'Please enter a label for the entry', dom.crudEntry.validationElement);
   Utils.assert(!Object.keys(Policies.thePolicy.entries).includes(dom.crudEntry.idValue),
       `Entry with label ${dom.crudEntry.idValue} already exists`, dom.crudEntry.validationElement);
+  validateAllowedAdditionsSelection();
   selectedEntry = dom.crudEntry.idValue;
-  putOrDeletePolicyEntry(dom.crudEntry.idValue, {
+  const newEntry: Policies.PolicyEntry = {
     subjects: {},
     resources: {},
-    importable: dom.selectImportable.value
-  }, Policies.finishEditing(dom.crudEntry, CrudOperation.CREATE));
+    importable: dom.selectImportable.value as Policies.ImportableMode,
+  };
+  applyAllowedAdditions(newEntry);
+  putOrDeletePolicyEntry(dom.crudEntry.idValue, newEntry,
+      Policies.finishEditing(dom.crudEntry, CrudOperation.CREATE));
 }
 
 function onUpdateEntryClick() {
-  Policies.thePolicy.entries[selectedEntry].importable = dom.selectImportable.value;
-  putOrDeletePolicyEntry(selectedEntry, Policies.thePolicy.entries[selectedEntry], Policies.finishEditing(dom.crudEntry, CrudOperation.UPDATE));
+  validateAllowedAdditionsSelection();
+  const entry = Policies.thePolicy.entries[selectedEntry];
+  entry.importable = dom.selectImportable.value as Policies.ImportableMode;
+  applyAllowedAdditions(entry);
+  putOrDeletePolicyEntry(selectedEntry, entry, Policies.finishEditing(dom.crudEntry, CrudOperation.UPDATE));
+}
+
+function validateAllowedAdditionsSelection() {
+  const allowOnlyEmpty = dom.selectAllowedAdditionsMode.value === 'allowOnly' &&
+      !dom.checkboxAdditionSubjects.checked &&
+      !dom.checkboxAdditionResources.checked &&
+      !dom.checkboxAdditionNamespaces.checked;
+  Utils.assert(!allowOnlyEmpty,
+      'Pick at least one kind, or switch to "Deny all".',
+      dom.validationAllowedAdditions);
 }
 
 function onDeleteEntryClick() {
@@ -130,7 +224,9 @@ function setEntry(entryLabel: string) {
 
 function updateEditors(entryLabel: string) {
   dom.crudEntry.idValue = entryLabel;
-  dom.selectImportable.value = entryLabel && Policies.thePolicy.entries[entryLabel].importable
+  const entry = entryLabel ? Policies.thePolicy.entries[entryLabel] : null;
+  dom.selectImportable.value = (entry && entry.importable) || 'implicit';
+  loadAllowedAdditionsIntoUI(entry?.allowedAdditions);
 }
 
 

--- a/ui/modules/policies/policiesImports.ts
+++ b/ui/modules/policies/policiesImports.ts
@@ -23,12 +23,18 @@ type DomElements = {
   tbodyPolicyImports: HTMLTableElement,
   tbodyPolicyImportEntries: HTMLTableElement,
   crudImport: CrudToolbar,
+  tbodyPolicyTransitiveImports: HTMLTableElement,
+  inputTransitiveImport: HTMLInputElement,
+  buttonAddTransitiveImport: HTMLButtonElement,
 }
 
 let dom: DomElements = {
   tbodyPolicyImports: null,
   tbodyPolicyImportEntries: null,
   crudImport: null,
+  tbodyPolicyTransitiveImports: null,
+  inputTransitiveImport: null,
+  buttonAddTransitiveImport: null,
 } ;
 
 // let importEditor: ace.Editor;
@@ -49,6 +55,14 @@ export function ready() {
   dom.crudImport.addEventListener('onDeleteClick', onDeletePolicyImportClick);
   dom.crudImport.addEventListener('onEditToggle', onEditToggleImport);
   dom.crudImport.addEventListener('onIdValueChange', onIdValueChange);
+
+  dom.buttonAddTransitiveImport.addEventListener('click', onAddTransitiveImportClick);
+  dom.inputTransitiveImport.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !dom.inputTransitiveImport.disabled) {
+      e.preventDefault();
+      onAddTransitiveImportClick();
+    }
+  });
 }
 
 async function onIdValueChange() {
@@ -87,17 +101,32 @@ function onDeletePolicyImportClick() {
   });
 }
 
-function importValueFromCheckboxes() {
-  const importValue = {};
+function importValueFromCheckboxes(): Policies.PolicyImport {
+  const importValue: Policies.PolicyImport = {};
   const checkedBoxes = document.querySelectorAll('#tbodyPolicyImportEntries input:checked[data-importable="explicit"]');
   if (checkedBoxes.length > 0) {
-    importValue['entries'] = Array.from(checkedBoxes).map((checkbox) => checkbox.id);
+    importValue.entries = Array.from(checkedBoxes).map((checkbox) => checkbox.id);
+  }
+  // transitiveImports is an explicit whitelist of additional imports to resolve. Absent and `[]`
+  // are semantically equivalent (no transitives resolved either way), so we omit the field when
+  // empty rather than writing `[]`.
+  const transitive = readTransitiveImportsFromTable();
+  if (transitive.length > 0) {
+    importValue.transitiveImports = transitive;
   }
   return importValue;
 }
 
+function readTransitiveImportsFromTable(): string[] {
+  return Array.from(dom.tbodyPolicyTransitiveImports.querySelectorAll('tr'))
+      .map((row: HTMLTableRowElement) => row.id)
+      .filter((id) => id);
+}
+
 function onEditToggleImport(event: CustomEvent) {
-  setExplicitCheckboxesDisabledState(!event.detail.isEditing)
+  const editing: boolean = event.detail.isEditing;
+  setExplicitCheckboxesDisabledState(!editing);
+  setTransitiveImportsControlsDisabled(!editing);
   if (event.detail.isCancel) {
     setImport(selectedImport);
   }
@@ -106,6 +135,54 @@ function onEditToggleImport(event: CustomEvent) {
 function setExplicitCheckboxesDisabledState(disabled: boolean) {
   document.querySelectorAll('#tbodyPolicyImportEntries input[data-importable="explicit"]')
     .forEach((e: HTMLInputElement) => e.disabled = disabled);
+}
+
+function setTransitiveImportsControlsDisabled(disabled: boolean) {
+  dom.inputTransitiveImport.disabled = disabled;
+  dom.buttonAddTransitiveImport.disabled = disabled;
+  // Toggle ONLY the remove button (the .bi-x-lg icon) — navigate stays enabled regardless of
+  // edit mode so the user can inspect a linked policy without entering edit mode first.
+  dom.tbodyPolicyTransitiveImports.querySelectorAll('button:has(.bi-x-lg)')
+      .forEach((b: HTMLButtonElement) => b.disabled = disabled);
+}
+
+function onAddTransitiveImportClick() {
+  const value = dom.inputTransitiveImport.value.trim();
+  Utils.assert(value, 'Please enter a policy ID', dom.inputTransitiveImport);
+  Utils.assert(/^[^\s:]+:[^\s:]+/.test(value),
+      'Expected a policy ID in the form "namespace:name"', dom.inputTransitiveImport);
+  const existing = readTransitiveImportsFromTable();
+  Utils.assert(!existing.includes(value),
+      'Policy ID already in the list', dom.inputTransitiveImport);
+  appendTransitiveImportRow(value, false);
+  dom.inputTransitiveImport.value = '';
+  dom.inputTransitiveImport.focus();
+}
+
+function appendTransitiveImportRow(policyId: string, disabled: boolean) {
+  const row = Utils.addTableRow(dom.tbodyPolicyTransitiveImports, policyId, false);
+  Utils.addActionToRow(row, 'bi-arrow-up-right-square', getNavigatePolicyAction(policyId), 'Open policy');
+  Utils.addActionToRow(row, 'bi-x-lg', () => {
+    if (dom.inputTransitiveImport.disabled) {
+      return;
+    }
+    Utils.confirm(`Remove transitive import<br>'${policyId}'?`, 'Remove', () => {
+      row.remove();
+    });
+  }, 'Remove');
+  // Action buttons are the trailing cells; disable only the remove button when not editing — keep
+  // the navigate button available so users can inspect the linked policy without entering edit mode.
+  const buttons = row.querySelectorAll('button');
+  const removeBtn = buttons[buttons.length - 1] as HTMLButtonElement | undefined;
+  if (removeBtn) removeBtn.disabled = disabled;
+}
+
+function getNavigatePolicyAction(policyId: string) {
+  return (_evt: Event) => {
+    API.callDittoREST('GET', '/policies/' + policyId).then(async (targetPolicy: Policies.Policy) => {
+      await Policies.setThePolicy(targetPolicy);
+    });
+  };
 }
 
 async function onPolicyChanged(policy: Policies.Policy) {
@@ -130,20 +207,13 @@ async function onPolicyChanged(policy: Policies.Policy) {
   } else {
     await setImport(null);
   }
-
-  function getNavigatePolicyAction(policyId: string) {
-    return (evt: Event) => {
-      API.callDittoREST('GET', '/policies/' + policyId).then(async (targetPolicy: Policies.Policy) => {
-        await Policies.setThePolicy(targetPolicy);
-      })
-    }
-  }
 }
 
 async function setImport(importedPolicyId: string) {
 
   dom.crudImport.idValue = importedPolicyId;
   dom.tbodyPolicyImportEntries.textContent = '';
+  loadTransitiveImportsFromImport(importedPolicyId);
 
   if (importedPolicyId) {
     const importedPolicy: Policies.Policy = await API.callDittoREST('GET', '/policies/' + importedPolicyId)
@@ -162,6 +232,18 @@ async function setImport(importedPolicyId: string) {
     const isImplicit = importedPolicy.entries[entry].importable === 'implicit';
     return isImported || isImplicit;
   }
+}
+
+function loadTransitiveImportsFromImport(importedPolicyId: string) {
+  dom.tbodyPolicyTransitiveImports.textContent = '';
+  dom.inputTransitiveImport.value = '';
+  // Two cases where there's no persisted import body: no selection yet, or the user is creating a
+  // brand-new import (typing the id, not yet PUT). In the latter case we still want the controls to
+  // follow the edit-mode flag so the user can author transitive imports as part of the new entry.
+  const importBody = importedPolicyId ? Policies.thePolicy?.imports[importedPolicyId] : undefined;
+  (importBody?.transitiveImports ?? [])
+      .forEach((id) => appendTransitiveImportRow(id, !dom.crudImport.isEditing));
+  setTransitiveImportsControlsDisabled(!dom.crudImport.isEditing);
 }
 
 

--- a/ui/modules/policies/policiesNamespaces.ts
+++ b/ui/modules/policies/policiesNamespaces.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import * as API from '../api.js';
+import * as Utils from '../utils.js';
+import { CrudOperation, CrudToolbar } from '../utils/crudToolbar.js';
+import * as Policies from './policies.js';
+import * as PolicyEntries from './policiesEntries.js';
+
+let selectedNamespace: string;
+
+type DomElements = {
+  tbodyPolicyNamespaces: HTMLTableElement,
+  tableValidationNamespaces: HTMLInputElement,
+  crudNamespace: CrudToolbar,
+}
+
+let dom: DomElements = {
+  tbodyPolicyNamespaces: null,
+  tableValidationNamespaces: null,
+  crudNamespace: null,
+};
+
+export function ready() {
+  Utils.getAllElementsById(dom);
+  PolicyEntries.observable.addChangeListener(onEntryChanged);
+
+  Utils.addValidatorToTable(dom.tbodyPolicyNamespaces, dom.tableValidationNamespaces);
+
+  dom.crudNamespace.editDisabled = true;
+  dom.crudNamespace.addEventListener('onCreateClick', onCreateNamespaceClick);
+  dom.crudNamespace.addEventListener('onUpdateClick', onUpdateNamespaceClick);
+  dom.crudNamespace.addEventListener('onDeleteClick', onDeleteNamespaceClick);
+  dom.crudNamespace.addEventListener('onEditToggle', onEditToggleNamespace);
+
+  dom.tbodyPolicyNamespaces.onclick = onPolicyNamespacesClick;
+}
+
+function onPolicyNamespacesClick(event: MouseEvent): void {
+  const target = event.target as HTMLElement;
+  const id = target.parentElement?.id;
+  if (!id) {
+    return;
+  }
+  if (selectedNamespace === id) {
+    selectedNamespace = null;
+    dom.crudNamespace.idValue = null;
+  } else {
+    selectedNamespace = id;
+    dom.crudNamespace.idValue = selectedNamespace;
+  }
+}
+
+function onCreateNamespaceClick() {
+  PolicyEntries.validateSelected();
+  Utils.assert(dom.crudNamespace.idValue, 'Please enter a namespace pattern',
+      dom.crudNamespace.validationElement);
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const existing = entry.namespaces ?? [];
+  Utils.assert(!existing.includes(dom.crudNamespace.idValue),
+      'Namespace pattern already present', dom.crudNamespace.validationElement);
+  selectedNamespace = dom.crudNamespace.idValue;
+  putEntryWithNamespaces([...existing, selectedNamespace],
+      Policies.finishEditing(dom.crudNamespace, CrudOperation.CREATE));
+}
+
+function onUpdateNamespaceClick() {
+  PolicyEntries.validateSelected();
+  Utils.assert(selectedNamespace, 'Please select a namespace', dom.tableValidationNamespaces);
+  Utils.assert(dom.crudNamespace.idValue, 'Please enter a namespace pattern',
+      dom.crudNamespace.validationElement);
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const existing = entry.namespaces ?? [];
+  const next = existing.map((ns) => (ns === selectedNamespace ? dom.crudNamespace.idValue : ns));
+  selectedNamespace = dom.crudNamespace.idValue;
+  putEntryWithNamespaces(next, Policies.finishEditing(dom.crudNamespace, CrudOperation.UPDATE));
+}
+
+function onDeleteNamespaceClick() {
+  PolicyEntries.validateSelected();
+  Utils.assert(selectedNamespace, 'Please select a namespace', dom.tableValidationNamespaces);
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const existing = entry.namespaces ?? [];
+  const next = existing.filter((ns) => ns !== selectedNamespace);
+  putEntryWithNamespaces(next, Policies.finishEditing(dom.crudNamespace, CrudOperation.DELETE));
+}
+
+// Always read the latest entry body at PUT time — never cache locally — to avoid races with concurrent
+// edits in sibling sections. Empty list is normalised to "field absent" so loaded policies that never
+// opted into namespace gating round-trip unchanged.
+function putEntryWithNamespaces(namespaces: string[], onSuccess: (value: any) => any) {
+  const entry = { ...Policies.thePolicy.entries[PolicyEntries.selectedEntry] };
+  if (namespaces.length === 0) {
+    delete entry.namespaces;
+  } else {
+    entry.namespaces = namespaces;
+  }
+  API.callDittoREST('PUT',
+      `/policies/${Policies.thePolicy.policyId}/entries/${PolicyEntries.selectedEntry}`,
+      entry
+  ).then(onSuccess);
+}
+
+function onEditToggleNamespace(event: CustomEvent) {
+  if (event.detail.isCancel) {
+    dom.crudNamespace.idValue = selectedNamespace;
+  }
+}
+
+function onEntryChanged(entryLabel: string) {
+  selectedNamespace = null;
+  dom.tbodyPolicyNamespaces.textContent = '';
+  dom.crudNamespace.idValue = null;
+  dom.crudNamespace.editDisabled = (entryLabel === null);
+
+  if (Policies.thePolicy && entryLabel) {
+    const namespaces = Policies.thePolicy.entries[entryLabel].namespaces ?? [];
+    namespaces.forEach((ns) => {
+      Utils.addTableRow(dom.tbodyPolicyNamespaces, ns, false);
+    });
+  }
+}

--- a/ui/modules/policies/policiesReferences.ts
+++ b/ui/modules/policies/policiesReferences.ts
@@ -48,6 +48,12 @@ let dom: DomElements = {
 let importedPolicyCache: Map<string, Promise<Policies.Policy>> = new Map();
 let cacheOwnerPolicyId: string | null = null;
 
+// Monotonic token guarding loadEntriesForImport against out-of-order resolutions: rapid clicks
+// between import scopes can interleave such that a slower fetch resolves AFTER a faster one and
+// overwrites the dropdown the user is now looking at. Each call captures the token at entry and
+// bails out after every await if a newer call has already incremented it.
+let loadEntriesToken = 0;
+
 export function ready() {
   Utils.getAllElementsById(dom);
   Policies.observable.addChangeListener(onPolicyChanged);
@@ -131,9 +137,11 @@ async function onImportSelectChange() {
 }
 
 async function loadEntriesForImport(importValue: string, preselectEntry?: string) {
+  const myToken = ++loadEntriesToken;
   resetEntrySelect();
   dom.referenceWarning.textContent = '';
   if (importValue === LOCAL_OPTION_VALUE) {
+    // Synchronous path: no await, no need to check token (no other call could interleave).
     const labels = Policies.thePolicy ? Object.keys(Policies.thePolicy.entries) : [];
     populateEntrySelect(labels, preselectEntry);
     if (preselectEntry && !labels.includes(preselectEntry)) {
@@ -147,6 +155,11 @@ async function loadEntriesForImport(importValue: string, preselectEntry?: string
   dom.selectReferenceEntry.disabled = true;
   try {
     const importedPolicy = await getImportedPolicy(importValue);
+    if (myToken !== loadEntriesToken) {
+      // A newer call started while our fetch was in flight — drop our result so we don't paint
+      // labels for the wrong import on the dropdown the user is currently looking at.
+      return;
+    }
     const labels = Object.keys(importedPolicy.entries);
     populateEntrySelect(labels, preselectEntry);
     if (preselectEntry && !labels.includes(preselectEntry)) {
@@ -154,6 +167,9 @@ async function loadEntriesForImport(importValue: string, preselectEntry?: string
           `Entry "${preselectEntry}" not found in imported policy "${importValue}".`;
     }
   } catch (e) {
+    if (myToken !== loadEntriesToken) {
+      return;
+    }
     // Fetch failed — fall back to free-text input so the user can still author/keep the reference.
     dom.selectReferenceEntry.hidden = true;
     dom.inputReferenceEntryFallback.hidden = false;
@@ -162,7 +178,9 @@ async function loadEntriesForImport(importValue: string, preselectEntry?: string
     dom.referenceWarning.textContent =
         `Could not load imported policy "${importValue}": ${formatError(e)}`;
   } finally {
-    dom.selectReferenceEntry.disabled = !dom.crudReference.isEditing;
+    if (myToken === loadEntriesToken) {
+      dom.selectReferenceEntry.disabled = !dom.crudReference.isEditing;
+    }
   }
 }
 

--- a/ui/modules/policies/policiesReferences.ts
+++ b/ui/modules/policies/policiesReferences.ts
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import * as API from '../api.js';
+import * as Utils from '../utils.js';
+import { CrudOperation, CrudToolbar } from '../utils/crudToolbar.js';
+import * as Policies from './policies.js';
+import * as PolicyEntries from './policiesEntries.js';
+
+const LOCAL_OPTION_VALUE = '__local__';
+const LOCAL_OPTION_LABEL = '(local)';
+
+let selectedReferenceIndex: number | null = null;
+
+type DomElements = {
+  tbodyPolicyReferences: HTMLTableElement,
+  tableValidationReferences: HTMLInputElement,
+  crudReference: CrudToolbar,
+  selectReferenceImport: HTMLSelectElement,
+  selectReferenceEntry: HTMLSelectElement,
+  inputReferenceEntryFallback: HTMLInputElement,
+  referenceWarning: HTMLElement,
+}
+
+let dom: DomElements = {
+  tbodyPolicyReferences: null,
+  tableValidationReferences: null,
+  crudReference: null,
+  selectReferenceImport: null,
+  selectReferenceEntry: null,
+  inputReferenceEntryFallback: null,
+  referenceWarning: null,
+};
+
+// Cache imported policies fetched for label-lookup. Keyed by the policyId of the imported policy.
+// The cached value is the in-flight or resolved Promise; failures are NOT cached so the user can retry.
+// Cleared whenever the loaded policy changes (see onPolicyChanged).
+let importedPolicyCache: Map<string, Promise<Policies.Policy>> = new Map();
+let cacheOwnerPolicyId: string | null = null;
+
+export function ready() {
+  Utils.getAllElementsById(dom);
+  Policies.observable.addChangeListener(onPolicyChanged);
+  PolicyEntries.observable.addChangeListener(onEntryChanged);
+
+  Utils.addValidatorToTable(dom.tbodyPolicyReferences, dom.tableValidationReferences);
+
+  dom.crudReference.editDisabled = true;
+  dom.crudReference.addEventListener('onCreateClick', onCreateReferenceClick);
+  dom.crudReference.addEventListener('onUpdateClick', onUpdateReferenceClick);
+  dom.crudReference.addEventListener('onDeleteClick', onDeleteReferenceClick);
+  dom.crudReference.addEventListener('onEditToggle', onEditToggleReference);
+
+  dom.selectReferenceImport.addEventListener('change', onImportSelectChange);
+  dom.tbodyPolicyReferences.onclick = onPolicyReferencesClick;
+}
+
+function onPolicyChanged(policy: Policies.Policy) {
+  // The cache is per-loaded-policy: an imported policy fetched while editing policy A is irrelevant
+  // (and possibly stale) when the user switches to policy B. Cheaper to drop the cache than to
+  // reason about whether it's still valid.
+  if (!policy || policy.policyId !== cacheOwnerPolicyId) {
+    importedPolicyCache = new Map();
+    cacheOwnerPolicyId = policy ? policy.policyId : null;
+  }
+}
+
+function onEntryChanged(entryLabel: string) {
+  selectedReferenceIndex = null;
+  dom.tbodyPolicyReferences.textContent = '';
+  dom.referenceWarning.textContent = '';
+  dom.crudReference.idValue = null;
+  dom.crudReference.editDisabled = (entryLabel === null);
+
+  populateImportSelect();
+  resetEntrySelect();
+
+  if (Policies.thePolicy && entryLabel) {
+    // Pre-populate the Entry dropdown for the default (local) Import value so the user can pick a
+    // local entry without first interacting with the Import dropdown — selecting the default value
+    // does not fire a change event, so onImportSelectChange would never run otherwise.
+    loadEntriesForImport(LOCAL_OPTION_VALUE);
+
+    const refs = Policies.thePolicy.entries[entryLabel].references ?? [];
+    refs.forEach((ref, idx) => {
+      const importLabel = ref.import ?? LOCAL_OPTION_LABEL;
+      const row = Utils.addTableRow(dom.tbodyPolicyReferences, displayKeyForRef(idx, ref), false,
+          null, importLabel, ref.entry);
+      row.dataset.refIndex = String(idx);
+    });
+  }
+}
+
+function displayKeyForRef(index: number, ref: Policies.EntryReference): string {
+  // Synthetic key — used as the row id and the crud-toolbar idValue. Index makes it unique even when
+  // two references differ only by import.
+  const importPart = ref.import ?? LOCAL_OPTION_LABEL;
+  return `#${index} ${importPart} → ${ref.entry}`;
+}
+
+function populateImportSelect() {
+  Utils.setOptions(dom.selectReferenceImport, []);
+  const localOption = new Option(LOCAL_OPTION_LABEL, LOCAL_OPTION_VALUE);
+  dom.selectReferenceImport.add(localOption);
+  if (Policies.thePolicy) {
+    Object.keys(Policies.thePolicy.imports).forEach((id) => {
+      dom.selectReferenceImport.add(new Option(id, id));
+    });
+  }
+  dom.selectReferenceImport.value = LOCAL_OPTION_VALUE;
+}
+
+function resetEntrySelect() {
+  Utils.setOptions(dom.selectReferenceEntry, []);
+  dom.inputReferenceEntryFallback.hidden = true;
+  dom.selectReferenceEntry.hidden = false;
+}
+
+async function onImportSelectChange() {
+  await loadEntriesForImport(dom.selectReferenceImport.value);
+}
+
+async function loadEntriesForImport(importValue: string, preselectEntry?: string) {
+  resetEntrySelect();
+  dom.referenceWarning.textContent = '';
+  if (importValue === LOCAL_OPTION_VALUE) {
+    const labels = Policies.thePolicy ? Object.keys(Policies.thePolicy.entries) : [];
+    populateEntrySelect(labels, preselectEntry);
+    if (preselectEntry && !labels.includes(preselectEntry)) {
+      dom.referenceWarning.textContent = `Local entry "${preselectEntry}" not found in this policy.`;
+    }
+    return;
+  }
+  // Imported policy lookup — show "Loading…" while we fetch (or hit the cache).
+  populateEntrySelect([], undefined);
+  dom.selectReferenceEntry.add(new Option('Loading…', '', true, true));
+  dom.selectReferenceEntry.disabled = true;
+  try {
+    const importedPolicy = await getImportedPolicy(importValue);
+    const labels = Object.keys(importedPolicy.entries);
+    populateEntrySelect(labels, preselectEntry);
+    if (preselectEntry && !labels.includes(preselectEntry)) {
+      dom.referenceWarning.textContent =
+          `Entry "${preselectEntry}" not found in imported policy "${importValue}".`;
+    }
+  } catch (e) {
+    // Fetch failed — fall back to free-text input so the user can still author/keep the reference.
+    dom.selectReferenceEntry.hidden = true;
+    dom.inputReferenceEntryFallback.hidden = false;
+    dom.inputReferenceEntryFallback.disabled = !dom.crudReference.isEditing;
+    dom.inputReferenceEntryFallback.value = preselectEntry ?? '';
+    dom.referenceWarning.textContent =
+        `Could not load imported policy "${importValue}": ${formatError(e)}`;
+  } finally {
+    dom.selectReferenceEntry.disabled = !dom.crudReference.isEditing;
+  }
+}
+
+function populateEntrySelect(labels: string[], preselectEntry: string | undefined) {
+  Utils.setOptions(dom.selectReferenceEntry, labels);
+  dom.selectReferenceEntry.hidden = false;
+  dom.inputReferenceEntryFallback.hidden = true;
+  if (preselectEntry !== undefined) {
+    if (labels.includes(preselectEntry)) {
+      dom.selectReferenceEntry.value = preselectEntry;
+    } else {
+      // Add a placeholder option so the user sees the dangling label rather than silently losing it.
+      const opt = new Option(preselectEntry + ' (missing)', preselectEntry, true, true);
+      dom.selectReferenceEntry.add(opt);
+    }
+  }
+}
+
+function getImportedPolicy(policyId: string): Promise<Policies.Policy> {
+  if (importedPolicyCache.has(policyId)) {
+    return importedPolicyCache.get(policyId);
+  }
+  const promise = API.callDittoREST('GET', '/policies/' + policyId) as Promise<Policies.Policy>;
+  importedPolicyCache.set(policyId, promise);
+  // Don't cache failures — let the user retry on the next dropdown change.
+  promise.catch(() => importedPolicyCache.delete(policyId));
+  return promise;
+}
+
+function formatError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  return JSON.stringify(e);
+}
+
+function onPolicyReferencesClick(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+  const row = target.closest('tr');
+  if (!row || !row.dataset.refIndex) {
+    return;
+  }
+  const idx = Number(row.dataset.refIndex);
+  if (selectedReferenceIndex === idx) {
+    selectedReferenceIndex = null;
+    dom.crudReference.idValue = null;
+    resetEntrySelect();
+    populateImportSelect();
+    return;
+  }
+  selectedReferenceIndex = idx;
+  const ref = Policies.thePolicy.entries[PolicyEntries.selectedEntry].references[idx];
+  dom.crudReference.idValue = displayKeyForRef(idx, ref);
+  populateImportSelect();
+  dom.selectReferenceImport.value = ref.import ?? LOCAL_OPTION_VALUE;
+  loadEntriesForImport(dom.selectReferenceImport.value, ref.entry);
+}
+
+function buildReferenceFromUI(): Policies.EntryReference {
+  const importValue = dom.selectReferenceImport.value;
+  const entryLabel = dom.inputReferenceEntryFallback.hidden
+      ? dom.selectReferenceEntry.value
+      : dom.inputReferenceEntryFallback.value.trim();
+  Utils.assert(entryLabel, 'Please pick or type an entry label', dom.crudReference.validationElement);
+  const ref: Policies.EntryReference = { entry: entryLabel };
+  if (importValue !== LOCAL_OPTION_VALUE) {
+    ref.import = importValue;
+  }
+  return ref;
+}
+
+function onCreateReferenceClick() {
+  PolicyEntries.validateSelected();
+  const ref = buildReferenceFromUI();
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const next = [...(entry.references ?? []), ref];
+  putEntryWithReferences(next, Policies.finishEditing(dom.crudReference, CrudOperation.CREATE));
+}
+
+function onUpdateReferenceClick() {
+  PolicyEntries.validateSelected();
+  Utils.assert(selectedReferenceIndex !== null, 'Please select a reference',
+      dom.tableValidationReferences);
+  const ref = buildReferenceFromUI();
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const next = [...(entry.references ?? [])];
+  next[selectedReferenceIndex] = ref;
+  putEntryWithReferences(next, Policies.finishEditing(dom.crudReference, CrudOperation.UPDATE));
+}
+
+function onDeleteReferenceClick() {
+  PolicyEntries.validateSelected();
+  Utils.assert(selectedReferenceIndex !== null, 'Please select a reference',
+      dom.tableValidationReferences);
+  const entry = Policies.thePolicy.entries[PolicyEntries.selectedEntry];
+  const next = (entry.references ?? []).filter((_, i) => i !== selectedReferenceIndex);
+  putEntryWithReferences(next, Policies.finishEditing(dom.crudReference, CrudOperation.DELETE));
+}
+
+// Always read the latest entry body at PUT time. Empty list collapses to "field absent" so
+// previously-untouched entries stay untouched.
+function putEntryWithReferences(refs: Policies.EntryReference[], onSuccess: (value: any) => any) {
+  const entry = { ...Policies.thePolicy.entries[PolicyEntries.selectedEntry] };
+  if (refs.length === 0) {
+    delete entry.references;
+  } else {
+    entry.references = refs;
+  }
+  API.callDittoREST('PUT',
+      `/policies/${Policies.thePolicy.policyId}/entries/${PolicyEntries.selectedEntry}`,
+      entry
+  ).then(onSuccess);
+}
+
+function onEditToggleReference(event: CustomEvent) {
+  const editing: boolean = event.detail.isEditing;
+  dom.selectReferenceImport.disabled = !editing;
+  dom.selectReferenceEntry.disabled = !editing;
+  dom.inputReferenceEntryFallback.disabled = !editing;
+  // The crud-toolbar's idValue input is a read-only display for references — the actual data comes
+  // from the two selects below. CrudToolbar would normally enable it during create (empty value);
+  // override that to avoid suggesting the synthetic display key is an authored field.
+  dom.crudReference.validationElement.disabled = true;
+  if (event.detail.isCancel) {
+    onEntryChanged(PolicyEntries.selectedEntry);
+  }
+}

--- a/ui/modules/policies/policiesResources.ts
+++ b/ui/modules/policies/policiesResources.ts
@@ -38,6 +38,33 @@ let dom : DomElements = {
 
 let resourceEditor: Ace.Editor;
 
+// Pretty-prints a resource body (e.g. {grant:[...], revoke:[...]}) without breaking arrays of
+// primitives across multiple lines — keeps the editor compact since horizontal space is plentiful
+// but vertical space is not. Falls back to standard multiline formatting for arrays containing
+// objects/arrays.
+function stringifyResource(value: any, indent = 2): string {
+  const pad = ' '.repeat(indent);
+  const isPrimitive = (v: any) =>
+      v === null || ['string', 'number', 'boolean'].includes(typeof v);
+  function format(v: any, currentIndent: string): string {
+    if (Array.isArray(v)) {
+      if (v.length === 0) return '[]';
+      if (v.every(isPrimitive)) return '[' + v.map((x) => JSON.stringify(x)).join(', ') + ']';
+      const inner = currentIndent + pad;
+      return '[\n' + v.map((x) => inner + format(x, inner)).join(',\n') + '\n' + currentIndent + ']';
+    }
+    if (v !== null && typeof v === 'object') {
+      const keys = Object.keys(v);
+      if (keys.length === 0) return '{}';
+      const inner = currentIndent + pad;
+      return '{\n' + keys.map((k) =>
+          inner + JSON.stringify(k) + ': ' + format(v[k], inner)).join(',\n') + '\n' + currentIndent + '}';
+    }
+    return JSON.stringify(v);
+  }
+  return format(value, '');
+}
+
 export function ready() {
   Utils.getAllElementsById(dom);
   PolicyEntries.observable.addChangeListener(onEntryChanged);
@@ -61,7 +88,7 @@ export function ready() {
 
 function onSelectResourceTemplateChange(event) {
   dom.crudResource.idValue = event.target.value;
-  resourceEditor.setValue(JSON.stringify(resourceTemplates.resources[event.target.value], null, 2), -1);
+  resourceEditor.setValue(stringifyResource(resourceTemplates.resources[event.target.value]), -1);
 }
 
 function onPolicyResourcesClick(event): any {
@@ -73,7 +100,7 @@ function onPolicyResourcesClick(event): any {
     selectedResource = event.target.parentNode.id;
     dom.crudResource.idValue = selectedResource;
     resourceEditor.setValue(
-      JSON.stringify(Policies.thePolicy.entries[PolicyEntries.selectedEntry].resources[selectedResource], null, 2), -1);
+      stringifyResource(Policies.thePolicy.entries[PolicyEntries.selectedEntry].resources[selectedResource]), -1);
   }
   dom.crudResource.idValue = selectedResource;
 }
@@ -127,7 +154,7 @@ function onEditToggleResource(event: CustomEvent) {
   if (event.detail.isCancel) {
     dom.crudResource.idValue = selectedResource;
     if (Policies.thePolicy && PolicyEntries.selectedEntry && selectedResource) {
-      resourceEditor.setValue(JSON.stringify(Policies.thePolicy.entries[PolicyEntries.selectedEntry].resources[selectedResource], null, 2), -1);
+      resourceEditor.setValue(stringifyResource(Policies.thePolicy.entries[PolicyEntries.selectedEntry].resources[selectedResource]), -1);
     } else {
       resourceEditor.setValue('');
     }
@@ -151,7 +178,7 @@ function onEntryChanged(entryLabel: string) {
       );
       if (key === selectedResource) {
         dom.crudResource.idValue = key;
-        resourceEditor.setValue(JSON.stringify(Policies.thePolicy.entries[entryLabel].resources[key], null, 2), -1);
+        resourceEditor.setValue(stringifyResource(Policies.thePolicy.entries[entryLabel].resources[key]), -1);
       }
     });
   }

--- a/ui/modules/policies/policiesSubjects.ts
+++ b/ui/modules/policies/policiesSubjects.ts
@@ -116,6 +116,14 @@ function onEditToggleSubject(event: CustomEvent) {
     } else {
       subjectEditor.setValue('');
     }
+  } else if (event.detail.isEditing && !selectedSubject && subjectEditor.getValue() === '') {
+    // Entering edit mode with no row selected = creating a new subject. Seed the editor with the
+    // minimal valid skeleton so the user lands inside the empty "type" string and can start typing
+    // a description without first having to author the JSON shape.
+    subjectEditor.setValue('{\n  "type": ""\n}', -1);
+    // Position the cursor inside the empty "type" value so typing fills the description directly.
+    subjectEditor.gotoLine(2, '  "type": "'.length, false);
+    subjectEditor.focus();
   }
 }
 

--- a/ui/modules/policies/policyTemplates.json
+++ b/ui/modules/policies/policyTemplates.json
@@ -130,5 +130,72 @@
         "importable": "never"
       }
     }
+  },
+  "3.9 Features Showcase": {
+    "entries": {
+      "DEFAULT": {
+        "subjects": {
+          "{{ request:subjectId }}": {
+            "type": "the creator"
+          }
+        },
+        "resources": {
+          "policy:/": {
+            "grant": [
+              "READ",
+              "WRITE"
+            ],
+            "revoke": []
+          }
+        }
+      },
+      "BASE": {
+        "subjects": {
+          "nginx:ditto": {
+            "type": "service account"
+          }
+        },
+        "resources": {
+          "thing:/": {
+            "grant": [
+              "READ"
+            ],
+            "revoke": []
+          }
+        },
+        "importable": "explicit",
+        "allowedAdditions": ["subjects"]
+      },
+      "ACME_OPERATORS": {
+        "subjects": {
+          "google:operator-acme": {
+            "type": "operator"
+          }
+        },
+        "resources": {},
+        "namespaces": ["com.acme", "com.acme.*"],
+        "references": [
+          { "entry": "BASE" }
+        ]
+      },
+      "STRICT_AUDITORS": {
+        "subjects": {
+          "google:auditor": {
+            "type": "auditor"
+          }
+        },
+        "resources": {},
+        "allowedAdditions": [],
+        "references": [
+          { "entry": "EXPLICIT", "import": "ditto:imported-policy" }
+        ]
+      }
+    },
+    "imports": {
+      "ditto:imported-policy": {
+        "entries": ["EXPLICIT"],
+        "transitiveImports": ["ditto:root-template"]
+      }
+    }
   }
 }

--- a/ui/modules/things/searchFilter.ts
+++ b/ui/modules/things/searchFilter.ts
@@ -22,6 +22,7 @@ const filterExamples = [
   'ge(thingId,"myThing1")',
   'gt(_created,"2020-08-05T12:17")',
   'exists(features/featureId)',
+  'empty(features/temperature/properties/list)',
   'and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))',
   'or(eq(attributes/location,"kitchen"),eq(attributes/location,"living-room"))',
   'like(attributes/key1,"known-chars-at-start*")',

--- a/ui/modules/things/thingUpdates.html
+++ b/ui/modules/things/thingUpdates.html
@@ -95,7 +95,7 @@
                 </div>
                 <div class="input-group input-group-sm mb-1">
                     <label class="input-group-text" data-bs-toggle="tooltip"
-                        title="RQL filter applied server-side to historical events, e.g. exists(features/temperature) or gt(features/temperature/properties/value,50)">
+                        title="RQL filter applied server-side to historical events, e.g. exists(features/temperature), empty(attributes/notes) or gt(features/temperature/properties/value,50)">
                         RQL Filter</label>
                     <input type="text" class="form-control form-control-sm" id="inputHistoricalRqlFilter"
                         placeholder="e.g. gt(features/temperature/properties/value,50)">

--- a/ui/modules/things/thingsSearch.ts
+++ b/ui/modules/things/thingsSearch.ts
@@ -83,7 +83,7 @@ function onThingsTableClicked(event) {
  */
 export function searchTriggered(filter: string, rqlFilterCallback: () => void) {
   ThingsSearchGlobalVars.lastSearch = filter;
-  const regex = /^(eq\(|ne\(|gt\(|ge\(|lt\(|le\(|in\(|like\(|ilike\(|exists\(|and\(|or\(|not\().*/;
+  const regex = /^(eq\(|ne\(|gt\(|ge\(|lt\(|le\(|in\(|like\(|ilike\(|exists\(|empty\(|and\(|or\(|not\().*/;
   if (filter === '' || regex.test(filter)) {
     searchThings(filter);
     rqlFilterCallback();

--- a/ui/modules/utils.ts
+++ b/ui/modules/utils.ts
@@ -357,7 +357,9 @@ let modalConfirm;
  */
 export function confirm(message: string, action: string, callback) {
   modalConfirm = modalConfirm ?? new Modal('#modalConfirm');
-  dom.modalBodyConfirm.textContent = message;
+  // Callers conventionally embed <br> for line breaks (e.g. "Delete entry<br>'<id>'?"). textContent
+  // would render the markup literally, so sanitise and assign as HTML instead.
+  dom.modalBodyConfirm.innerHTML = sanitizeHTML(message);
   dom.buttonConfirmed.innerText = action;
   dom.buttonConfirmed.onclick = callback;
   modalConfirm.show();

--- a/ui/modules/utils/crudToolbar.ts
+++ b/ui/modules/utils/crudToolbar.ts
@@ -127,6 +127,11 @@ export class CrudToolbar extends HTMLElement {
       this.dom.buttonEdit.onclick = () => this.toggleEdit(false);
       this.dom.buttonCancel.onclick = () => this.toggleEdit(true);
       this.dom.label.innerText = this.getAttribute('label') || 'Label';
+      const tooltip = this.getAttribute('tooltip');
+      if (tooltip) {
+        this.dom.label.setAttribute('title', tooltip);
+        this.dom.label.setAttribute('data-bs-toggle', 'tooltip');
+      }
       this.dom.buttonCreate.onclick = this.eventDispatcher('onCreateClick');
       this.dom.buttonUpdate.onclick = this.eventDispatcher('onUpdateClick');
       this.dom.buttonDelete.onclick = this.eventDispatcher('onDeleteClick');


### PR DESCRIPTION
Resolves: #2405

Policies tab:
- Imports: edit `transitiveImports` whitelist per import (Add input, ↗ navigate, × remove with confirm). Field omitted from PUT body when list is empty (absent ≡ []).
- Entries: new `namespaces` editor (side-by-side with `references`), new `references` editor with two-dropdown picker (local entries vs imported-policy entries, lazy-fetched and cached, free-text fallback when imported policy unreachable), inline `allowedAdditions` tri-state control (Default / Deny all / Allow only:) preserving the absent-vs-`[]` distinction.
- Layout restructure: Subjects + Resources side-by-side; Namespaces + References side-by-side underneath; "For the entry selected above:" hint to signal hierarchy.
- Resource JSON editor: arrays of primitives no longer wrap across lines (compact `["READ","WRITE"]`); editor capped to remaining column space.
- Subject crud-toolbar: tooltip on the label and `{"type":""}` JSON skeleton seeded with cursor inside the empty value when creating.
- New 3.9 features showcase template covering namespaces / allowedAdditions / references / transitiveImports.
- `<crud-toolbar>` gains optional `tooltip` attribute applied to its internal label.

Search:
- `empty()` RQL predicate: added to autocomplete examples, RQL filter tooltip, and the predicate-detection regex in `searchTriggered` (the latter previously routed `empty(...)` queries to a thingId lookup).

Misc:
- Edit-overlay z-indices (`editBackground` / `editForground`) lowered below Bootstrap modal layer so confirmation dialogs opened during editing render on top of the overlay.
- `Utils.confirm` renders messages via DOMPurify-sanitised innerHTML so the established `<br>` line-break convention works (was rendering literal `<br>`).