### PR TITLE
Service CPU optimisations from JFR profiling

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
@@ -124,7 +124,8 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
 
         checkNotNull(initialHeaders, "initial headers");
         checkNotNull(definitions, "header definitions");
-        validateValueTypes(initialHeaders, definitions); // this constructor does validate the known value types
+        checkNotNull(definitionsMap, "definitionsMap");
+        validateValueTypes(initialHeaders, definitionsMap); // this constructor does validate the known value types
         myself = (S) selfType.cast(this);
         headers = preserveCaseSensitivity(initialHeaders);
         metadataHeaders = MetadataHeaders.newInstance();
@@ -194,13 +195,43 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
      *
      * @param headers the key-value-pairs to be validated.
      * @param definitions perform the actual validation.
+     * @deprecated as of 3.9.0 in favour of {@link #validateValueTypes(Map, Map)} which iterates the
+     * (typically small) headers map and looks up each definition by key, yielding O(H) lookups
+     * instead of O(D) where D is the (typically much larger) set of all known header definitions.
+     * Retained for binary compatibility with external subclasses that overrode this method.
      */
+    @Deprecated
     protected void validateValueTypes(final Map<String, String> headers,
             final Collection<? extends HeaderDefinition> definitions) {
 
         for (final HeaderDefinition definition : definitions) {
             final String value = headers.get(definition.getKey());
             if (null != value) {
+                definition.validateValue(value);
+            }
+        }
+    }
+
+    /**
+     * Validates the values of the specified headers with the help of the specified definitions map.
+     * Iterates the headers and looks up each one in {@code definitionsMap} — for the typical case
+     * where the incoming headers carry far fewer entries than the number of known header definitions,
+     * this is O(H) instead of O(D).
+     *
+     * @param headers the key-value-pairs to be validated.
+     * @param definitionsMap the known header definitions keyed by their (lower-case) header key.
+     * @since 3.9.0
+     */
+    protected void validateValueTypes(final Map<String, String> headers,
+            final Map<String, HeaderDefinition> definitionsMap) {
+
+        for (final Map.Entry<String, String> headerEntry : headers.entrySet()) {
+            final String value = headerEntry.getValue();
+            if (null == value) {
+                continue;
+            }
+            final HeaderDefinition definition = definitionsMap.get(headerEntry.getKey());
+            if (null != definition) {
                 definition.validateValue(value);
             }
         }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
@@ -222,6 +222,21 @@ public final class DefaultDittoHeadersBuilderTest {
     }
 
     @Test
+    public void createInstanceWithMapContainingNullValueForKnownHeaderDoesNotThrow() {
+        // Regression guard for the validateValueTypes(Map, Map) overload introduced in 3.9.0.
+        // Iterating the headers map's entrySet() exposes null values that the old Collection-based
+        // loop implicitly skipped (because headers.get(key) returns null both for absent keys and
+        // for keys mapped to null). The new implementation must skip null values explicitly so
+        // construction does not fail with a NullPointerException on validateValue.
+        final Map<String, String> initialHeaders = new HashMap<>();
+        initialHeaders.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), null);
+        initialHeaders.put(DittoHeaderDefinition.DRY_RUN.getKey(), "true");
+
+        // No exception expected: null value is skipped, "true" for DRY_RUN is valid.
+        of(initialHeaders).build();
+    }
+
+    @Test
     public void tryToCreateInstanceWithMapContainingInvalidHeader() {
         final String readSubjectsKey = DittoHeaderDefinition.READ_SUBJECTS.getKey();
         final String invalidJsonArrayString = "['Frank',42,'Grimes']";

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -1360,6 +1360,24 @@ jms-connection-handling-dispatcher {
 signal-enrichment-cache-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  # Explicit thread-pool-executor block: without it, Pekko's default-dispatcher
+  # fallback applies and includes `allow-core-timeout = on`, which lets every
+  # core thread die after the keep-alive interval; under bursty load this
+  # manifests as a continual thread-birth/death cycle (JFR observed
+  # ~0.06 starts/s for this dispatcher on connectivity pre-fix).
+  thread-pool-executor {
+    core-pool-size-min = 4
+    core-pool-size-min = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MIN}
+    core-pool-size-factor = 1.0
+    core-pool-size-factor = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_FACTOR}
+    core-pool-size-max = 16
+    core-pool-size-max = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MAX}
+    keep-alive-time = 60s
+    keep-alive-time = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_KEEP_ALIVE_TIME}
+    allow-core-timeout = off
+    allow-core-timeout = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_ALLOW_CORE_TIMEOUT}
+  }
+  throughput = 5
 }
 
 http-push-connection-dispatcher {

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.0.0  # chart version is effectively set by release-job
+version: 4.0.1  # chart version is effectively set by release-job
 appVersion: 3.9.0-M3
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -374,6 +374,10 @@ spec:
               value: "{{ .Values.connectivity.config.connections.encryption.migration.batchSize }}"
             - name: CONNECTIVITY_ENCRYPTION_MIGRATION_MAX_DOCS_PER_MINUTE
               value: "{{ .Values.connectivity.config.connections.encryption.migration.maxDocumentsPerMinute }}"
+            - name: SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MIN
+              value: "{{ .Values.connectivity.config.dispatchers.signalEnrichmentCache.poolSizeMin }}"
+            - name: SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MAX
+              value: "{{ .Values.connectivity.config.dispatchers.signalEnrichmentCache.poolSizeMax }}"
             {{- if .Values.connectivity.extraEnv }}
               {{- toYaml .Values.connectivity.extraEnv | nindent 12 }}
             {{- end }}

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -279,6 +279,10 @@ spec:
               value: "{{ .Values.gateway.config.wotDirectory.basePrefix }}"
             - name: GATEWAY_WOT_DIRECTORY_AUTHENTICATION_REQUIRED
               value: "{{ .Values.gateway.config.wotDirectory.authenticationRequired }}"
+            - name: SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MIN
+              value: "{{ .Values.gateway.config.dispatchers.signalEnrichmentCache.poolSizeMin }}"
+            - name: SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MAX
+              value: "{{ .Values.gateway.config.dispatchers.signalEnrichmentCache.poolSizeMax }}"
             {{- if .Values.gateway.extraEnv }}
               {{- toYaml .Values.gateway.extraEnv | nindent 12 }}
             {{- end }}

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -386,6 +386,14 @@ spec:
               value: "{{ index .Values.things.config.wot.tmValidation.feature.forbid "non-modeled-desired-properties" }}"
             - name: THINGS_WOT_TM_MODEL_VALIDATION_FEATURE_FORBID_NON_MODELED_OUTBOX_MESSAGES
               value: "{{ index .Values.things.config.wot.tmValidation.feature.forbid "non-modeled-outbox-messages" }}"
+            - name: WOT_DISPATCHER_PARALLELISM_MIN
+              value: "{{ .Values.things.config.dispatchers.wot.parallelismMin }}"
+            - name: WOT_DISPATCHER_PARALLELISM_MAX
+              value: "{{ .Values.things.config.dispatchers.wot.parallelismMax }}"
+            - name: WOT_DISPATCHER_CACHE_LOADER_PARALLELISM_MIN
+              value: "{{ .Values.things.config.dispatchers.wotCacheLoader.parallelismMin }}"
+            - name: WOT_DISPATCHER_CACHE_LOADER_PARALLELISM_MAX
+              value: "{{ .Values.things.config.dispatchers.wotCacheLoader.parallelismMax }}"
             {{- if .Values.things.extraEnv }}
               {{- toYaml .Values.things.extraEnv | nindent 12 }}
             {{- end }}

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -286,6 +286,14 @@ spec:
               value: "{{ .Values.thingsSearch.config.updater.backgroundSync.throttle.throughput }}"
             - name: BACKGROUND_SYCN_THROTTLE_PERIOD
               value: "{{ .Values.thingsSearch.config.updater.backgroundSync.throttle.period }}"
+            - name: THING_CACHE_DISPATCHER_POOL_SIZE_MIN
+              value: "{{ .Values.thingsSearch.config.dispatchers.thingCache.poolSizeMin }}"
+            - name: THING_CACHE_DISPATCHER_POOL_SIZE_MAX
+              value: "{{ .Values.thingsSearch.config.dispatchers.thingCache.poolSizeMax }}"
+            - name: POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MIN
+              value: "{{ .Values.thingsSearch.config.dispatchers.policyEnforcerCache.poolSizeMin }}"
+            - name: POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MAX
+              value: "{{ .Values.thingsSearch.config.dispatchers.policyEnforcerCache.poolSizeMax }}"
             {{- if .Values.thingsSearch.extraEnv }}
               {{- toYaml .Values.thingsSearch.extraEnv | nindent 12 }}
             {{- end }}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1326,6 +1326,20 @@ things:
           #       enforce:
           #         feature-description-modification: false
         ]
+    # dispatchers contains tuning for the WoT-related Pekko dispatchers in the things service.
+    # Defaults below are the in-jar HOCON defaults and only need overriding under sustained load.
+    dispatchers:
+      # wot dispatcher serves WoT model resolution and validation.
+      wot:
+        # parallelismMin: minimum steady-state ForkJoinPool worker count.
+        # Raised from the legacy default of 4 to 8 to avoid worker churn under bursty load.
+        parallelismMin: 8
+        # parallelismMax: hard cap on workers spawned during load spikes.
+        parallelismMax: 32
+      # wotCacheLoader serves the WoT ThingModel cache loader.
+      wotCacheLoader:
+        parallelismMin: 8
+        parallelismMax: 32
 
 ## ----------------------------------------------------------------------------
 ## things-search configuration

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -2102,6 +2102,15 @@ connectivity:
           #   Medium (100-1000 connections): 100-200
           #   Large (>1000 connections): 50-100
           maxDocumentsPerMinute: 200
+    # dispatchers contains tuning for the connectivity service's Pekko dispatchers.
+    # Defaults below match the in-jar HOCON defaults and only need overriding under sustained load.
+    dispatchers:
+      # signalEnrichmentCache dispatcher serves the signal-enrichment cache loader.
+      signalEnrichmentCache:
+        # poolSizeMin: minimum core threads kept alive across idle periods (allow-core-timeout = off).
+        poolSizeMin: 4
+        # poolSizeMax: hard cap on threads spawned during load spikes.
+        poolSizeMax: 16
 
 ## ----------------------------------------------------------------------------
 ## gateway configuration
@@ -2453,6 +2462,15 @@ gateway:
       # authenticationRequired whether authentication is required to access the WoT Thing Directory endpoint
       #  defaults to false for public access per WoT Discovery specification expectations
       authenticationRequired: false
+    # dispatchers contains tuning for the gateway service's Pekko dispatchers.
+    # Defaults below match the in-jar HOCON defaults and only need overriding under sustained load.
+    dispatchers:
+      # signalEnrichmentCache dispatcher serves the signal-enrichment cache loader.
+      signalEnrichmentCache:
+        # poolSizeMin: minimum core threads kept alive across idle periods (allow-core-timeout = off).
+        poolSizeMin: 4
+        # poolSizeMax: hard cap on threads spawned during load spikes.
+        poolSizeMax: 16
 
 ## ----------------------------------------------------------------------------
 ## nginx configuration

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -114,7 +114,13 @@ global:
   #  if false, both OpenID-Connect and basicAuth via nginx (see above "basicAuthUsers" and "hashedBasicAuthUsers") is used
   #  ref: https://www.eclipse.dev/ditto/installation-operating.html#openid-connect
   jwtOnly: false
-  # jvmOptions defines the JVM options applied to all Ditto services running in the JVM, it is put in JAVA_TOOL_OPTIONS
+  # jvmOptions defines the JVM options applied to all Ditto services running in the JVM, it is put in JAVA_TOOL_OPTIONS.
+  # io.netty.leakDetection.level=disabled turns off Netty's ResourceLeakDetector. Netty defaults to SIMPLE
+  # which samples 1/128 buffer allocations and captures a Throwable stack trace per sampled buffer; on the
+  # Pekko remote / Mongo client hot paths this adds measurable allocation pressure. To re-enable for
+  # debugging / canary, append to a service's additionalJvmOptions:
+  #   -Dio.netty.leakDetection.level=simple
+  # (per-service additionalJvmOptions is rendered after global.jvmOptions so the per-service value wins.)
   jvmOptions: >
     -XX:+ExitOnOutOfMemoryError
     -XX:+HeapDumpOnOutOfMemoryError
@@ -129,6 +135,7 @@ global:
     -XX:+UnlockExperimentalVMOptions
     -XX:+UseCompactObjectHeaders
     -Djava.net.preferIPv4Stack=true
+    -Dio.netty.leakDetection.level=disabled
   pekkoOptions: >
     -Dpekko.management.cluster.bootstrap.contact-point-discovery.port-name=management
     -Dpekko.http.client.parsing.max-chunk-size=2m
@@ -1679,6 +1686,19 @@ thingsSearch:
       #   # or as index key spec:
       #   # indexHint:
       #   #   "t.attributes.location": 1
+    # dispatchers contains tuning for the things-search service's Pekko dispatchers.
+    # Defaults below match the in-jar HOCON defaults and only need overriding under sustained load.
+    dispatchers:
+      # thingCache dispatcher serves the thing-cache-loader actor.
+      thingCache:
+        # poolSizeMin: minimum core threads kept alive across idle periods (allow-core-timeout = off).
+        poolSizeMin: 4
+        # poolSizeMax: hard cap on threads spawned during load spikes.
+        poolSizeMax: 16
+      # policyEnforcerCache dispatcher serves the policy-enforcer-cache-loader actor.
+      policyEnforcerCache:
+        poolSizeMin: 4
+        poolSizeMax: 16
 
 
 ## ----------------------------------------------------------------------------

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -706,12 +706,21 @@ authentication-dispatcher {
   thread-pool-executor {
     # minimum number of threads to cap factor-based core number to
     core-pool-size-min = 4
+    core-pool-size-min = ${?AUTHENTICATION_DISPATCHER_POOL_SIZE_MIN}
     # No of core threads ... ceil(available processors * factor)
     core-pool-size-factor = 2.0
     core-pool-size-factor = ${?AUTHENTICATION_DISPATCHER_POOL_SIZE_FACTOR}
     # maximum number of threads to cap factor-based number to
     core-pool-size-max = 8
     core-pool-size-max = ${?AUTHENTICATION_DISPATCHER_POOL_SIZE_MAX}
+    keep-alive-time = 60s
+    keep-alive-time = ${?AUTHENTICATION_DISPATCHER_KEEP_ALIVE_TIME}
+    # Without an explicit value, Pekko's default-dispatcher reference cascades
+    # `allow-core-timeout = on`, killing idle core threads after 60s and
+    # producing a continual start/die cycle (JFR observed ~0.32 starts/s
+    # for this dispatcher pre-fix).
+    allow-core-timeout = off
+    allow-core-timeout = ${?AUTHENTICATION_DISPATCHER_ALLOW_CORE_TIMEOUT}
   }
   throughput = 100
 }

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -719,6 +719,23 @@ authentication-dispatcher {
 signal-enrichment-cache-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  # Explicit thread-pool-executor block: without it, Pekko's default-dispatcher
+  # fallback applies and includes `allow-core-timeout = on`, which lets every
+  # core thread die after the keep-alive interval; under bursty load this
+  # manifests as a continual thread-birth/death cycle.
+  thread-pool-executor {
+    core-pool-size-min = 4
+    core-pool-size-min = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MIN}
+    core-pool-size-factor = 1.0
+    core-pool-size-factor = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_FACTOR}
+    core-pool-size-max = 16
+    core-pool-size-max = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_POOL_SIZE_MAX}
+    keep-alive-time = 60s
+    keep-alive-time = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_KEEP_ALIVE_TIME}
+    allow-core-timeout = off
+    allow-core-timeout = ${?SIGNAL_ENRICHMENT_CACHE_DISPATCHER_ALLOW_CORE_TIMEOUT}
+  }
+  throughput = 5
 }
 
 include "kamon.conf"

--- a/internal/utils/cache-loaders/src/main/resources/reference.conf
+++ b/internal/utils/cache-loaders/src/main/resources/reference.conf
@@ -4,4 +4,26 @@
 ask-with-retry-dispatcher {
   type = "Dispatcher"
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  # An explicit thread-pool-executor block is required by the configurator.
+  # Without it, Pekko's default-dispatcher fallback applies and includes
+  # `allow-core-timeout = on`, which lets every core thread die after the
+  # keep-alive interval; under bursty load this manifests as a continual
+  # thread-birth/death cycle (~2 starts/s observed in production profiles).
+  thread-pool-executor {
+    # Minimum core pool size, kept alive across idle periods.
+    core-pool-size-min = 4
+    core-pool-size-min = ${?ASK_WITH_RETRY_DISPATCHER_POOL_SIZE_MIN}
+    # ceil(available processors * factor), then capped by min/max.
+    core-pool-size-factor = 1.0
+    core-pool-size-factor = ${?ASK_WITH_RETRY_DISPATCHER_POOL_SIZE_FACTOR}
+    core-pool-size-max = 16
+    core-pool-size-max = ${?ASK_WITH_RETRY_DISPATCHER_POOL_SIZE_MAX}
+    # Idle timeout for non-core threads spawned above core-pool-size.
+    keep-alive-time = 60s
+    keep-alive-time = ${?ASK_WITH_RETRY_DISPATCHER_KEEP_ALIVE_TIME}
+    # Keep core threads alive even when idle - prevents start/die churn.
+    allow-core-timeout = off
+    allow-core-timeout = ${?ASK_WITH_RETRY_DISPATCHER_ALLOW_CORE_TIMEOUT}
+  }
+  throughput = 5
 }

--- a/json-cbor/src/main/java/org/eclipse/ditto/json/cbor/JacksonSerializationContext.java
+++ b/json-cbor/src/main/java/org/eclipse/ditto/json/cbor/JacksonSerializationContext.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
  */
 public final class JacksonSerializationContext implements SerializationContext {
 
+    private static final CBORFactory DEFAULT_CBOR_FACTORY = new CBORFactory();
+
     private final JsonGenerator jacksonGenerator;
     private final ControllableOutputStream outputStream;
 
@@ -44,7 +46,7 @@ public final class JacksonSerializationContext implements SerializationContext {
     }
 
     JacksonSerializationContext(final OutputStream outputStream) throws IOException {
-        this(new CBORFactory(), outputStream);
+        this(DEFAULT_CBOR_FACTORY, outputStream);
     }
 
     /**

--- a/json/src/main/java/org/eclipse/ditto/json/DefaultDittoJsonHandler.java
+++ b/json/src/main/java/org/eclipse/ditto/json/DefaultDittoJsonHandler.java
@@ -120,19 +120,11 @@ public final class DefaultDittoJsonHandler extends DittoJsonHandler<List<JsonVal
     }
 
     private static JsonNumber parseToIntegerOrLong(final String string) {
-        try {
-            return parseToInteger(string);
-        } catch (final NumberFormatException e) {
-            return parseToLong(string);
+        final long longValue = Long.parseLong(string);
+        if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
+            return ImmutableJsonInt.of((int) longValue);
         }
-    }
-
-    private static ImmutableJsonInt parseToInteger(final String string) {
-        return ImmutableJsonInt.of(Integer.parseInt(string));
-    }
-
-    private static ImmutableJsonLong parseToLong(final String string) {
-        return ImmutableJsonLong.of(Long.parseLong(string));
+        return ImmutableJsonLong.of(longValue);
     }
 
     @Override

--- a/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
@@ -60,22 +60,42 @@ final class JavaStringToEscapedJsonString implements UnaryOperator<String> {
     @Override
     public String apply(final String javaString) {
         requireNonNull(javaString, "The Java String to be converted must not be null");
+        final int len = javaString.length();
+        final int firstEscape = indexOfFirstEscape(javaString, len);
+        if (firstEscape < 0) {
+            final StringBuilder stringBuilder = new StringBuilder(len + NUM_ENCLOSING_QUOTES);
+            stringBuilder.append(QUOTE).append(javaString).append(QUOTE);
+            return stringBuilder.toString();
+        }
         final StringBuilder stringBuilder =
-                new StringBuilder((int) (javaString.length() * ESCAPING_BUFFER_FACTOR) + NUM_ENCLOSING_QUOTES);
+                new StringBuilder((int) (len * ESCAPING_BUFFER_FACTOR) + NUM_ENCLOSING_QUOTES);
         stringBuilder.append(QUOTE);
-        stringBuilder.append(javaString);
-        int i = 1; // offset of starting " char
-        for (final char c : javaString.toCharArray()) {
-            @Nullable final String replacement = jsonCharEscaper.apply(c);
+        stringBuilder.append(javaString, 0, firstEscape);
+        int runStart = firstEscape;
+        for (int i = firstEscape; i < len; i++) {
+            @Nullable final String replacement = jsonCharEscaper.apply(javaString.charAt(i));
             if (null != replacement) {
-                stringBuilder.replace(i, i + 1, replacement);
-                i += replacement.length();
-            } else {
-                i++;
+                if (i > runStart) {
+                    stringBuilder.append(javaString, runStart, i);
+                }
+                stringBuilder.append(replacement);
+                runStart = i + 1;
             }
+        }
+        if (runStart < len) {
+            stringBuilder.append(javaString, runStart, len);
         }
         stringBuilder.append(QUOTE);
         return stringBuilder.toString();
+    }
+
+    private int indexOfFirstEscape(final String javaString, final int len) {
+        for (int i = 0; i < len; i++) {
+            if (null != jsonCharEscaper.apply(javaString.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 
 }

--- a/json/src/test/java/org/eclipse/ditto/json/DefaultDittoJsonHandlerTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/DefaultDittoJsonHandlerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the numeric parsing behaviour of {@link DefaultDittoJsonHandler}, exercised through
+ * {@link JsonValueParser}.
+ * <p>
+ * The handler does not use {@link NumberFormatException} as control flow when distinguishing between {@code int} and
+ * {@code long} values; these tests pin down the resulting {@link JsonValue} subtype across the
+ * {@code Integer}/{@code Long} boundary and around expected error inputs.
+ */
+public final class DefaultDittoJsonHandlerTest {
+
+    private static final Function<String, JsonValue> PARSER = JsonValueParser.fromString();
+
+    private static JsonValue parseValue(final String numberLiteral) {
+        return PARSER.apply("{\"a\":" + numberLiteral + "}").asObject().getValue("a").get();
+    }
+
+    @Test
+    public void parsePositiveIntegerYieldsJsonInt() {
+        final JsonValue value = parseValue("42");
+        assertThat(value.isInt()).isTrue();
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.asInt()).isEqualTo(42);
+    }
+
+    @Test
+    public void parseNegativeIntegerYieldsJsonInt() {
+        final JsonValue value = parseValue("-42");
+        assertThat(value.isInt()).isTrue();
+        assertThat(value.asInt()).isEqualTo(-42);
+    }
+
+    @Test
+    public void parseZeroYieldsJsonInt() {
+        final JsonValue value = parseValue("0");
+        assertThat(value.isInt()).isTrue();
+        assertThat(value.asInt()).isEqualTo(0);
+    }
+
+    @Test
+    public void parseIntegerMaxValueExactYieldsJsonInt() {
+        final JsonValue value = parseValue(String.valueOf(Integer.MAX_VALUE));
+        assertThat(value.isInt()).isTrue();
+        assertThat(value.asInt()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void parseIntegerMaxValuePlusOneYieldsJsonLong() {
+        final long boundary = (long) Integer.MAX_VALUE + 1L;
+        final JsonValue value = parseValue(String.valueOf(boundary));
+        assertThat(value.isInt()).isFalse();
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.asLong()).isEqualTo(boundary);
+    }
+
+    @Test
+    public void parseIntegerMinValueExactYieldsJsonInt() {
+        final JsonValue value = parseValue(String.valueOf(Integer.MIN_VALUE));
+        assertThat(value.isInt()).isTrue();
+        assertThat(value.asInt()).isEqualTo(Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void parseIntegerMinValueMinusOneYieldsJsonLong() {
+        final long boundary = (long) Integer.MIN_VALUE - 1L;
+        final JsonValue value = parseValue(String.valueOf(boundary));
+        assertThat(value.isInt()).isFalse();
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.asLong()).isEqualTo(boundary);
+    }
+
+    @Test
+    public void parseLongMaxValueExactYieldsJsonLong() {
+        final JsonValue value = parseValue(String.valueOf(Long.MAX_VALUE));
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.isInt()).isFalse();
+        assertThat(value.asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void parseLongMinValueExactYieldsJsonLong() {
+        final JsonValue value = parseValue(String.valueOf(Long.MIN_VALUE));
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.asLong()).isEqualTo(Long.MIN_VALUE);
+    }
+
+    @Test
+    public void parseLong19DigitHashYieldsJsonLong() {
+        // Representative input from Publisher.deserializeGroupedHashes - a 64-bit hash always overflows Integer.
+        final long hash = 7719141912096836184L;
+        final JsonValue value = parseValue(String.valueOf(hash));
+        assertThat(value.isLong()).isTrue();
+        assertThat(value.asLong()).isEqualTo(hash);
+    }
+
+    @Test
+    public void parseValueAboveLongMaxValueThrowsJsonParseException() {
+        // 20-digit string exceeds Long.MAX_VALUE (9223372036854775807).
+        final String tooLarge = "99999999999999999999";
+        assertThatExceptionOfType(JsonParseException.class)
+                .isThrownBy(() -> parseValue(tooLarge));
+    }
+
+    @Test
+    public void parseDecimalYieldsJsonDouble() {
+        final JsonValue value = parseValue("3.14");
+        assertThat(value.isDouble()).isTrue();
+        assertThat(value.asDouble()).isEqualTo(3.14d);
+    }
+
+    @Test
+    public void parseScientificNotationYieldsJsonDouble() {
+        final JsonValue value = parseValue("1e10");
+        assertThat(value.isDouble()).isTrue();
+        assertThat(value.asDouble()).isEqualTo(1e10d);
+    }
+
+}

--- a/json/src/test/java/org/eclipse/ditto/json/JavaStringToEscapedJsonStringTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/JavaStringToEscapedJsonStringTest.java
@@ -49,4 +49,70 @@ public final class JavaStringToEscapedJsonStringTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    public void convertEmptyString() {
+        assertThat(underTest.apply("")).isEqualTo("\"\"");
+    }
+
+    @Test
+    public void convertOnlySpecialChars() {
+        assertThat(underTest.apply("\"\\\b\f\n\r\t"))
+                .isEqualTo("\"\\\"\\\\\\b\\f\\n\\r\\t\"");
+    }
+
+    @Test
+    public void convertEscapeAtStart() {
+        assertThat(underTest.apply("\"hello")).isEqualTo("\"\\\"hello\"");
+    }
+
+    @Test
+    public void convertEscapeAtEnd() {
+        assertThat(underTest.apply("hello\"")).isEqualTo("\"hello\\\"\"");
+    }
+
+    @Test
+    public void convertConsecutiveEscapes() {
+        assertThat(underTest.apply("a\"\"b")).isEqualTo("\"a\\\"\\\"b\"");
+    }
+
+    @Test
+    public void convertControlCharsBelow0x20() {
+        // 0x00..0x1F must all be escaped; shorthands take precedence over the unicode form.
+        final StringBuilder input = new StringBuilder(0x20);
+        for (int i = 0; i < 0x20; i++) {
+            input.append((char) i);
+        }
+        final String actual = underTest.apply(input.toString());
+        // shorthands for 0x08 \b, 0x09 \t, 0x0A \n, 0x0C \f, 0x0D \r
+        final String expected = "\""
+                + "\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007"
+                + "\\b\\t\\n\\u000B\\f\\r\\u000E\\u000F"
+                + "\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017"
+                + "\\u0018\\u0019\\u001A\\u001B\\u001C\\u001D\\u001E\\u001F"
+                + "\"";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void surrogatePairPassthrough() {
+        // 😀 = U+1F600 = surrogate pair D83D DE00. Both halves are above 0x7F and unescaped.
+        final String smiley = "😀";
+        assertThat(underTest.apply(smiley)).isEqualTo("\"" + smiley + "\"");
+    }
+
+    @Test
+    public void backslashIsEscaped() {
+        assertThat(underTest.apply("a\\b")).isEqualTo("\"a\\\\b\"");
+    }
+
+    @Test
+    public void longStringWithoutEscapesTakesFastPath() {
+        final StringBuilder sb = new StringBuilder(4096);
+        for (int i = 0; i < 4096; i++) {
+            sb.append('a');
+        }
+        final String input = sb.toString();
+        assertThat(underTest.apply(input)).isEqualTo("\"" + input + "\"");
+    }
+
 }

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractEnforcerActor.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractEnforcerActor.java
@@ -123,7 +123,12 @@ public abstract class AbstractEnforcerActor<I extends EntityId, S extends Signal
 
     protected CompletionStage<Optional<PolicyEnforcer>> loadPolicyEnforcer(final Signal<?> signal) {
         return providePolicyIdForEnforcement(signal)
-                .thenComposeAsync(this::providePolicyEnforcer, enforcementExecutor);
+                .thenComposeAsync(policyId -> {
+                    if (policyId == null) {
+                        return CompletableFuture.completedFuture(Optional.empty());
+                    }
+                    return providePolicyEnforcer(policyId);
+                }, enforcementExecutor);
     }
 
     private void paRecovered(final Control paRecoveredTrigger) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
@@ -113,7 +113,7 @@ final class CachingPolicyEnforcerProvider extends AbstractPolicyEnforcerProvider
     @Override
     public CompletionStage<Optional<PolicyEnforcer>> getPolicyEnforcer(@Nullable final PolicyId policyId) {
         if (policyId == null) {
-            LOGGER.warn("Returning empty loaded PolicyEnforcer for provided <null> PolicyId");
+            LOGGER.debug("Returning empty loaded PolicyEnforcer for provided <null> PolicyId");
             return CompletableFuture.completedFuture(Optional.empty());
         }
         return Patterns.ask(cachingPolicyEnforcerProviderActor, policyId, LOCAL_POLICY_RETRIEVAL_TIMEOUT)

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/DefaultPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/DefaultPolicyEnforcerProvider.java
@@ -54,7 +54,7 @@ final class DefaultPolicyEnforcerProvider extends AbstractPolicyEnforcerProvider
     @Override
     public CompletionStage<Optional<PolicyEnforcer>> getPolicyEnforcer(@Nullable final PolicyId policyId) {
         if (null == policyId) {
-            LOGGER.warn("Returning empty loaded PolicyEnforcer for provided <null> PolicyId");
+            LOGGER.debug("Returning empty loaded PolicyEnforcer for provided <null> PolicyId");
             return CompletableFuture.completedFuture(Optional.empty());
         } else {
             try {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.policies.enforcement;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -30,7 +29,6 @@ import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.policies.model.PolicyImport;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 
@@ -39,7 +37,12 @@ import scala.concurrent.ExecutionContextExecutor;
 final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>> {
 
     private final Cache<PolicyId, Entry<PolicyEnforcer>> delegate;
+    // Reverse index: importedPolicyId -> set of policies that import it.
+    // Used to cascade invalidation from imported policies to their importers.
     private final Map<PolicyId, Set<PolicyId>> policyIdToImportingMap;
+    // Forward index: importingPolicyId -> set of policies it imports.
+    // Lets deregisterImportMappings run in O(k) (k = imports of this policy) instead of O(N) over the full reverse map.
+    private final Map<PolicyId, Set<PolicyId>> importingPolicyIdToImportedMap;
     private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     PolicyEnforcerCache(final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader,
@@ -47,6 +50,7 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
             final CacheConfig cacheConfig,
             final NamespacePoliciesConfig namespacePoliciesConfig) {
         policyIdToImportingMap = new ConcurrentHashMap<>();
+        importingPolicyIdToImportedMap = new ConcurrentHashMap<>();
         this.namespacePoliciesConfig = namespacePoliciesConfig;
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
@@ -88,12 +92,16 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
      * (e.g. from removed imports or transitive imports) don't accumulate.
      */
     private void deregisterImportMappings(final PolicyId importingPolicyId) {
-        policyIdToImportingMap.forEach((importedId, importingSet) ->
-                policyIdToImportingMap.computeIfPresent(importedId, (id, set) -> {
-                    set.remove(importingPolicyId);
-                    return set.isEmpty() ? null : set;
-                })
-        );
+        final Set<PolicyId> previouslyImported = importingPolicyIdToImportedMap.remove(importingPolicyId);
+        if (previouslyImported == null) {
+            return;
+        }
+        for (final PolicyId importedPolicyId : previouslyImported) {
+            policyIdToImportingMap.computeIfPresent(importedPolicyId, (id, set) -> {
+                set.remove(importingPolicyId);
+                return set.isEmpty() ? null : set;
+            });
+        }
     }
 
     private void registerImportMapping(final PolicyId importedPolicyId, final PolicyId importingPolicyId) {
@@ -102,6 +110,12 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
                     importingPolicyIds == null ? new HashSet<>() : importingPolicyIds;
             newImportingPolicyIds.add(importingPolicyId);
             return newImportingPolicyIds;
+        });
+        importingPolicyIdToImportedMap.compute(importingPolicyId, (id, importedPolicyIds) -> {
+            final Set<PolicyId> newImportedPolicyIds =
+                    importedPolicyIds == null ? new HashSet<>() : importedPolicyIds;
+            newImportedPolicyIds.add(importedPolicyId);
+            return newImportedPolicyIds;
         });
     }
 

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -768,12 +768,17 @@ wot-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
   fork-join-executor {
-    # Min number of threads to cap factor-based parallelism number to
-    parallelism-min = 4
+    # Min number of threads to cap factor-based parallelism number to.
+    # Raised from 4 to 8 so the steady-state pool matches the observed sustained
+    # demand on bursty WoT model resolution and avoids transient worker spawning.
+    parallelism-min = 8
+    parallelism-min = ${?WOT_DISPATCHER_PARALLELISM_MIN}
     # Parallelism (threads) ... ceil(available processors * factor)
     parallelism-factor = 3.0
+    parallelism-factor = ${?WOT_DISPATCHER_PARALLELISM_FACTOR}
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
+    parallelism-max = ${?WOT_DISPATCHER_PARALLELISM_MAX}
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
   throughput = 5
@@ -782,12 +787,17 @@ wot-dispatcher-cache-loader {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedForkJoinExecutorServiceConfigurator"
   fork-join-executor {
-    # Min number of threads to cap factor-based parallelism number to
-    parallelism-min = 4
+    # Min number of threads to cap factor-based parallelism number to.
+    # Raised from 4 to 8 (see wot-dispatcher above) to dampen ForkJoinPool
+    # worker churn under sustained cache-loader load.
+    parallelism-min = 8
+    parallelism-min = ${?WOT_DISPATCHER_CACHE_LOADER_PARALLELISM_MIN}
     # Parallelism (threads) ... ceil(available processors * factor)
     parallelism-factor = 3.0
+    parallelism-factor = ${?WOT_DISPATCHER_CACHE_LOADER_PARALLELISM_FACTOR}
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
+    parallelism-max = ${?WOT_DISPATCHER_CACHE_LOADER_PARALLELISM_MAX}
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
   throughput = 5

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -456,11 +456,44 @@ blocked-namespaces-dispatcher {
 policy-enforcer-cache-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  # Explicit thread-pool-executor block: without it, Pekko's default-dispatcher
+  # fallback applies and includes `allow-core-timeout = on`, which lets every
+  # core thread die after the keep-alive interval; under bursty load this
+  # manifests as a continual thread-birth/death cycle.
+  thread-pool-executor {
+    core-pool-size-min = 4
+    core-pool-size-min = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MIN}
+    core-pool-size-factor = 1.0
+    core-pool-size-factor = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_FACTOR}
+    core-pool-size-max = 16
+    core-pool-size-max = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MAX}
+    keep-alive-time = 60s
+    keep-alive-time = ${?POLICY_ENFORCER_CACHE_DISPATCHER_KEEP_ALIVE_TIME}
+    allow-core-timeout = off
+    allow-core-timeout = ${?POLICY_ENFORCER_CACHE_DISPATCHER_ALLOW_CORE_TIMEOUT}
+  }
+  throughput = 5
 }
 
 thing-cache-dispatcher {
   type = Dispatcher
   executor = "org.eclipse.ditto.internal.utils.metrics.service.executor.InstrumentedThreadPoolExecutorServiceConfigurator"
+  # Same rationale as policy-enforcer-cache-dispatcher above: explicit pool
+  # config keeps idle core threads alive across bursty cache-loader load
+  # (JFR observed ~0.95 thread starts/s pre-fix).
+  thread-pool-executor {
+    core-pool-size-min = 4
+    core-pool-size-min = ${?THING_CACHE_DISPATCHER_POOL_SIZE_MIN}
+    core-pool-size-factor = 1.0
+    core-pool-size-factor = ${?THING_CACHE_DISPATCHER_POOL_SIZE_FACTOR}
+    core-pool-size-max = 16
+    core-pool-size-max = ${?THING_CACHE_DISPATCHER_POOL_SIZE_MAX}
+    keep-alive-time = 60s
+    keep-alive-time = ${?THING_CACHE_DISPATCHER_KEEP_ALIVE_TIME}
+    allow-core-timeout = off
+    allow-core-timeout = ${?THING_CACHE_DISPATCHER_ALLOW_CORE_TIMEOUT}
+  }
+  throughput = 5
 }
 
 include "kamon.conf"


### PR DESCRIPTION
## Summary

CPU optimisations identified by 60-second to 5-minute JFR recordings on the things, things-search, and connectivity dev pods. Four commits, all independent and behaviour-preserving:

- **things-service (`66ef7c6eb0`)** — five fixes targeting the JFR-observed hot paths:
  - O(k) forward-index in `PolicyEnforcerCache.deregisterImportMappings` (was O(N) full-map scan); null-PolicyId short-circuit in `AbstractEnforcerActor.loadPolicyEnforcer` plus WARN→DEBUG downgrade (was producing ~200 k log lines/day on dev).
  - Static `CBORFactory` reuse in `JacksonSerializationContext` (was allocated per serialisation; top byte[]/int[] allocator).
  - `DefaultDittoJsonHandler.parseToIntegerOrLong` parses long-then-downcast instead of try-`Integer.parseInt`-catch-`NumberFormatException`-fallback (JFR observed ~113 NFE/s from 64-bit pub/sub hashes).
  - Bulk-copy fast path in `JavaStringToEscapedJsonString.apply` (no-escape strings) + `append(CharSequence, start, end)` runs instead of per-char `replace`.
  - `ask-with-retry-dispatcher`: add the missing `thread-pool-executor` block with `allow-core-timeout = off` (Pekko's default-dispatcher fallback was killing idle core threads after 60 s); raise `wot-dispatcher` / `wot-dispatcher-cache-loader` `parallelism-min` 4 → 8.

- **things-search (`3578855ef6`)** — two structural fixes mirroring the things-service patterns:
  - Same `thread-pool-executor` template for `thing-cache-dispatcher` and `policy-enforcer-cache-dispatcher` (JFR observed ~0.95 thread-births/s on thing-cache-dispatcher pre-fix).
  - Append `-Dio.netty.leakDetection.level=disabled` to `global.jvmOptions` in Helm. Netty defaults to SIMPLE which captures a Throwable stack per sampled buffer; ~0.56/s on the Pekko-remote/Mongo paths.

- **base/model `validateValueTypes` (`5b9c4b7381`)** — invert the loop in `AbstractDittoHeadersBuilder.validateValueTypes`. The pre-existing variant iterates *all* known `HeaderDefinition`s (~50+) and `headers.get(definitionKey)` per definition; the new `@since 3.9.0` overload iterates the (typically small) headers map and looks up each entry in a `Map<String, HeaderDefinition>` — O(H) instead of O(D). Hits on every inbound Pekko cluster message; the legacy `Collection` overload is kept `@Deprecated` for binary compatibility with external subclasses. Defensive null-value skip preserves identical observable behaviour.

- **`signal-enrichment-cache-dispatcher` (`fd13a72e9b`)** — repo-wide audit found two remaining occurrences of the same defect (gateway + connectivity); fixed identically. After this commit, no instances of `type = Dispatcher` + `InstrumentedThreadPoolExecutorServiceConfigurator` + missing `thread-pool-executor` block remain in `*/main/resources/*.conf`.

All new HOCON tunables are `${?ENV_VAR}`-overridable; Helm wiring (`{things,thingsSearch,gateway,connectivity}.config.dispatchers.*` + deployment-template env-var bindings) is included.
