### PR TITLE
Convert enforcement AskTimeoutException to 503 instead of 500

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/exceptions/EnforcementTimeoutException.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/exceptions/EnforcementTimeoutException.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.model.exceptions;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonParsableException;
+import org.eclipse.ditto.json.JsonObject;
+
+/**
+ * This exception indicates that the enforcement of a signal timed out. Unlike {@link DittoInternalErrorException},
+ * this maps to HTTP 503 (Service Unavailable) to signal that the client should retry.
+ */
+@Immutable
+@JsonParsableException(errorCode = EnforcementTimeoutException.ERROR_CODE)
+public final class EnforcementTimeoutException extends DittoRuntimeException implements GeneralException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "enforcement.timeout";
+
+    private static final String DEFAULT_MESSAGE =
+            "The enforcement of the signal timed out, please retry later.";
+    private static final String DEFAULT_DESCRIPTION =
+            "The signal could not be enforced within the configured timeout. " +
+                    "Please retry the performed action in order to improve resiliency.";
+
+    private static final long serialVersionUID = 7284610854427332607L;
+
+    private EnforcementTimeoutException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatus.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for a {@code EnforcementTimeoutException}.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a new {@code EnforcementTimeoutException} object with given message.
+     *
+     * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new EnforcementTimeoutException.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     */
+    public static EnforcementTimeoutException fromMessage(@Nullable final String message,
+            final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromMessage(message, dittoHeaders, new Builder());
+    }
+
+    /**
+     * Constructs a new {@code EnforcementTimeoutException} object with the exception message extracted from the
+     * given JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new EnforcementTimeoutException.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static EnforcementTimeoutException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+    }
+
+    @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .message(getMessage())
+                .description(getDescription().orElse(null))
+                .cause(getCause())
+                .href(getHref().orElse(null))
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link EnforcementTimeoutException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<EnforcementTimeoutException> {
+
+        private Builder() {
+            message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        @Override
+        protected EnforcementTimeoutException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new EnforcementTimeoutException(dittoHeaders, message, description, cause, href);
+        }
+    }
+}

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/exceptions/EnforcementTimeoutExceptionTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/exceptions/EnforcementTimeoutExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.model.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.junit.Test;
+
+/**
+ * Tests {@link EnforcementTimeoutException}.
+ */
+public final class EnforcementTimeoutExceptionTest {
+
+    private static final EnforcementTimeoutException UNDER_TEST =
+            EnforcementTimeoutException.newBuilder().build();
+
+    private static final JsonObject KNOWN_JSON = JsonFactory.newObject("{\n" +
+            "  \"status\": 503,\n" +
+            "  \"error\": \"enforcement.timeout\",\n" +
+            "  \"message\": \"The enforcement of the signal timed out, please retry later.\",\n" +
+            "  \"description\": \"The signal could not be enforced within the configured timeout. " +
+            "Please retry the performed action in order to improve resiliency.\"\n" +
+            "}");
+
+    @Test
+    public void toJsonReturnsExpected() {
+        final JsonObject jsonObject = UNDER_TEST.toJson();
+        assertThat(jsonObject).isEqualTo(KNOWN_JSON);
+    }
+
+    @Test
+    public void createInstanceFromValidJson() {
+        final EnforcementTimeoutException deserialized =
+                EnforcementTimeoutException.fromJson(KNOWN_JSON, DittoHeaders.empty());
+        assertThat(deserialized).isEqualTo(UNDER_TEST);
+    }
+
+    @Test
+    public void httpStatusIsServiceUnavailable() {
+        assertThat(UNDER_TEST.getHttpStatus()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void errorCodeIsCorrect() {
+        assertThat(UNDER_TEST.getErrorCode()).isEqualTo("enforcement.timeout");
+    }
+
+    @Test
+    public void setDittoHeadersReturnsSameExceptionType() {
+        final DittoHeaders newHeaders = DittoHeaders.newBuilder().correlationId("test-123").build();
+        final DittoRuntimeException result = UNDER_TEST.setDittoHeaders(newHeaders);
+        assertThat(result).isInstanceOf(EnforcementTimeoutException.class);
+        assertThat(result.getDittoHeaders()).isEqualTo(newHeaders);
+    }
+}

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
@@ -53,6 +54,7 @@ import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.base.model.exceptions.EnforcementTimeoutException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
@@ -914,9 +916,18 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
     private DittoRuntimeException getEnforcementExceptionAsRuntimeException(final Throwable throwable,
             final WithDittoHeaders signal) {
 
+        final Throwable rootCause = unwrapCompletionException(throwable);
         final DittoRuntimeException dre;
-        if (throwable instanceof DittoRuntimeException dittoRuntimeException) {
+        if (rootCause instanceof DittoRuntimeException dittoRuntimeException) {
             dre = dittoRuntimeException;
+        } else if (rootCause instanceof AskTimeoutException) {
+            log.withCorrelationId(signal)
+                    .warning("Enforcement of signal for entity <{}> timed out: {}",
+                            entityId, rootCause.getMessage());
+            dre = EnforcementTimeoutException.newBuilder()
+                    .dittoHeaders(signal.getDittoHeaders())
+                    .cause(rootCause)
+                    .build();
         } else {
             dre = DittoRuntimeException.asDittoRuntimeException(throwable, t -> {
                 log.withCorrelationId(signal)
@@ -929,6 +940,13 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
             });
         }
         return dre;
+    }
+
+    static Throwable unwrapCompletionException(final Throwable throwable) {
+        if (throwable instanceof CompletionException && throwable.getCause() != null) {
+            return unwrapCompletionException(throwable.getCause());
+        }
+        return throwable;
     }
 
     /**

--- a/internal/utils/persistent-actors/src/test/java/org/eclipse/ditto/internal/utils/persistentactors/EnforcementExceptionConversionTest.java
+++ b/internal/utils/persistent-actors/src/test/java/org/eclipse/ditto/internal/utils/persistentactors/EnforcementExceptionConversionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistentactors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletionException;
+
+import org.apache.pekko.pattern.AskTimeoutException;
+import org.eclipse.ditto.base.model.exceptions.DittoInternalErrorException;
+import org.eclipse.ditto.base.model.exceptions.EnforcementTimeoutException;
+import org.junit.Test;
+
+/**
+ * Tests the enforcement exception conversion logic in {@link AbstractPersistenceSupervisor}, specifically the
+ * conversion of {@link AskTimeoutException} to {@link EnforcementTimeoutException} (503 instead of 500).
+ */
+public final class EnforcementExceptionConversionTest {
+
+    @Test
+    public void unwrapDirectAskTimeoutException() {
+        final Throwable original = new AskTimeoutException("enforcer timed out");
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(original);
+        assertThat(unwrapped).isSameAs(original);
+        assertThat(unwrapped).isInstanceOf(AskTimeoutException.class);
+    }
+
+    @Test
+    public void unwrapSingleCompletionException() {
+        final AskTimeoutException cause = new AskTimeoutException("enforcer timed out");
+        final CompletionException wrapped = new CompletionException(cause);
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(wrapped);
+        assertThat(unwrapped).isSameAs(cause);
+        assertThat(unwrapped).isInstanceOf(AskTimeoutException.class);
+    }
+
+    @Test
+    public void unwrapDoubleCompletionException() {
+        final AskTimeoutException cause = new AskTimeoutException("enforcer timed out");
+        final CompletionException inner = new CompletionException(cause);
+        final CompletionException outer = new CompletionException(inner);
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(outer);
+        assertThat(unwrapped).isSameAs(cause);
+        assertThat(unwrapped).isInstanceOf(AskTimeoutException.class);
+    }
+
+    @Test
+    public void unwrapCompletionExceptionWithNullCauseReturnsItself() {
+        final CompletionException noCause = new CompletionException(null);
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(noCause);
+        assertThat(unwrapped).isSameAs(noCause);
+    }
+
+    @Test
+    public void unwrapNonCompletionExceptionReturnsSame() {
+        final RuntimeException other = new RuntimeException("other");
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(other);
+        assertThat(unwrapped).isSameAs(other);
+    }
+
+    @Test
+    public void unwrappedAskTimeoutIsNotDittoRuntimeException() {
+        final AskTimeoutException cause = new AskTimeoutException("enforcer timed out");
+        final CompletionException wrapped = new CompletionException(cause);
+        final Throwable unwrapped = AbstractPersistenceSupervisor.unwrapCompletionException(wrapped);
+
+        // AskTimeoutException is NOT a DittoRuntimeException — this is the key distinction
+        // that makes it fall through to the EnforcementTimeoutException branch
+        assertThat(unwrapped).isNotInstanceOf(
+                org.eclipse.ditto.base.model.exceptions.DittoRuntimeException.class);
+        assertThat(unwrapped).isInstanceOf(AskTimeoutException.class);
+    }
+
+    @Test
+    public void enforcementTimeoutExceptionHasCorrectProperties() {
+        final EnforcementTimeoutException exception = EnforcementTimeoutException.newBuilder().build();
+        assertThat(exception.getHttpStatus().getCode()).isEqualTo(503);
+        assertThat(exception.getErrorCode()).isEqualTo("enforcement.timeout");
+        assertThat(exception).isNotInstanceOf(DittoInternalErrorException.class);
+    }
+}


### PR DESCRIPTION
During rolling restarts, AskTimeoutException from the enforcer child was wrapped as DittoInternalErrorException (HTTP 500). This is misleading — the timeout is transient and clients should retry.

Introduce EnforcementTimeoutException (HTTP 503) and convert AskTimeoutException to it in getEnforcementExceptionAsRuntimeException. Also unwrap CompletionException wrappers from async chains before checking the exception type.

Fixes #2439