### PR TITLE
Helm: Allow configuring `issuers` for OIDC

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.0.0  # chart version is effectively set by release-job
+version: 4.1.0  # chart version is effectively set by release-job
 appVersion: 3.9.0
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/service-config/gateway-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/gateway-extension.conf.tpl
@@ -15,6 +15,14 @@ ditto {
         {{- range $key, $value := .Values.gateway.config.authentication.oauth.openidConnectIssuers }}
           {{$key}} = {
             issuer = "{{$value.issuer}}"
+            {{- with $value.issuers }}
+            issuers = [
+              "{{$value.issuer}}"
+            {{- range $index, $issuer := . }}
+              "{{$issuer}}"
+            {{- end }}
+            ]
+            {{- end }}
             auth-subjects = [
             {{- range $index, $subject := $value.authSubjects }}
               "{{$subject}}"
@@ -78,6 +86,14 @@ ditto {
           {{- range $key, $value := .Values.gateway.config.authentication.devops.oauth.openidConnectIssuers }}
             {{$key}} = {
               issuer = "{{$value.issuer}}"
+              {{- with $value.issuers }}
+              issuers = [
+                "{{$value.issuer}}"
+              {{- range $index, $issuer := . }}
+                "{{$issuer}}"
+              {{- end }}
+              ]
+              {{- end }}
               auth-subjects = [
               {{- range $index, $subject := $value.authSubjects }}
                 "{{$subject}}"

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -2317,10 +2317,17 @@ gateway:
         # allowedClockSkew configures the amount of clock skew in seconds to tolerate when verifying the local time against the exp and nbf claims
         allowedClockSkew: 20s
         # openidConnectIssuers holds a map of issuer-prefixes as key (e.g. "example")
-        #  and OAuth "issuer" and "authSubjects" list containing which claims to extract from a JWT issued by the issuer
+        #  and OAuth "issuer" (or "issuers" list) and "authSubjects" list containing which claims to extract from a JWT
+        #  issued by the issuer
+        #
+        # When using the "issuers" option the "issuer" option is also implicitly added, so only describe additional
+        # issuers in the option
         openidConnectIssuers:
         #  example:
         #    issuer: "example.com"
+        #    issuers:
+        #    - "localhost:9000/one"
+        #    - "localhost:9000/two"
         #    authSubjects:
         #    - "{{ jwt:sub }}"
         #    - "{{ jwt:groups }}"
@@ -2366,9 +2373,15 @@ gateway:
           allowedClockSkew: 20s
           # openidConnectIssuers holds a map of issuer-prefixes as key (e.g. "example")
           #  and OAuth "issuer" and "authSubjects" list containing which claims to extract from a JWT issued by the issuer
+          #
+          # When using the "issuers" option the "issuer" option is also implicitly added, so only describe additional
+          # issuers in the option
           openidConnectIssuers:
           #  example-ops:
           #    issuer: "example.com"
+          #    issuers:
+          #    - "localhost:9000/one"
+          #    - "localhost:9000/two"
           #    authSubjects:
           #    - "{{ jwt:sub }}"
           #    - "{{ jwt:groups }}"


### PR DESCRIPTION
Adds support for configuring the `issuers`[^1] option of OpenID Connect issuers in the helm chart values directly.

[^1]: https://eclipse.dev/ditto/installation-operating.html#openid-connect