### PR TITLE
Fix `ssl-config` not being picked up

### DIFF
--- a/internal/utils/http/src/main/java/org/eclipse/ditto/internal/utils/http/DefaultHttpClientFacade.java
+++ b/internal/utils/http/src/main/java/org/eclipse/ditto/internal/utils/http/DefaultHttpClientFacade.java
@@ -72,8 +72,9 @@ public final class DefaultHttpClientFacade implements HttpClientFacade {
 
     @Override
     public CompletionStage<HttpResponse> createSingleHttpRequest(final HttpRequest request) {
+        // https://github.com/apache/pekko-http/commit/53365087aa1fe029fb4522c9d40045673cb23b6e
         return Http.get(actorSystem)
-                .singleRequest(request, Http.get(actorSystem).defaultClientHttpsContext(),
+                .singleRequest(request, Http.get(actorSystem).createDefaultClientHttpsContext(),
                         connectionPoolSettings,
                         actorSystem.log()
                 );


### PR DESCRIPTION
Fixes #2443

This fixes the problem but uses a deprecated method (`createDefaultClientHttpsContext()`)