### PR TITLE
Implement X509 authentication for MongoDB connection

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/internal/utils/config/src/main/resources/ditto-mongo.conf
+++ b/internal/utils/config/src/main/resources/ditto-mongo.conf
@@ -35,6 +35,9 @@ ditto.mongodb {
     ssl = false
     ssl = ${?MONGO_DB_SSL_ENABLED}
 
+    sslCAFile = ""
+    sslCAFile = ${?MONGO_DB_CA_FILE}
+
     # read preference is one of: primary, primaryPreferred, secondary, secondaryPreferred, nearest
     readPreference = primary
     readPreference = ${?MONGO_DB_READ_PREFERENCE}
@@ -69,6 +72,19 @@ ditto.mongodb {
     # The default session name is "dittoSession".
     awsSessionName = "dittoSession"
     awsSessionName = ${?MONGO_DB_AWS_SESSION_NAME}
+
+    useX509Authentication = false
+    useX509Authentication = ${?MONGO_DB_X509_AUTH_ENABLED}
+
+    # The PKCS12 file to use for X509 certificate authentication
+    sslClientCertFile = ""
+    sslClientCertFile = ${?MONGO_DB_SSL_CLIENT_CERT_FILE}
+
+    sslClientKeyFile = ""
+    sslClientKeyFile = ${?MONGO_DB_SSL_CLIENT_KEY_FILE}
+
+    sslClientKeyPassword = ""
+    sslClientKeyPassword = ${?MONGO_DB_SSL_CLIENT_KEY_PASSWORD}
 
     // all options in the "extra-options" are simply added to the MongoDB URI
     // that way any available URI option may be added, even if not explicitly specified in Ditto's mongo config

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClientBuilder.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClientBuilder.java
@@ -91,6 +91,14 @@ public interface DittoMongoClientBuilder {
         GeneralPropertiesStep enableSsl(boolean enabled);
 
         /**
+         * Sets the CA root certificate file to use for SSL.
+         *
+         * @param sslCaFile the CA root certificate file path.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep sslCaFile(String sslCaFile);
+
+        /**
          * Sets the maximum duration of a query.
          * Default is defined at {@link org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig.MongoDbConfigValue#MAX_QUERY_TIME}.
          *
@@ -202,6 +210,38 @@ public interface DittoMongoClientBuilder {
          * @return this builder instance with the updated retryWrites.
          */
         GeneralPropertiesStep setRetryWrites(boolean retryWrites);
+
+        /**
+         * Determines whether to use X509 certificates for authentication.
+         *
+         * @param useX509Authentication {@code true} if X509 Authentication should be used, {@code false} otherwise.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep useX509Authentication(boolean useX509Authentication);
+
+        /**
+         * Sets the client certificate file for use in X509 authentication.
+         *
+         * @param sslClientCertFile the client certificate file path.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep sslClientCertFile(String sslClientCertFile);
+
+        /**
+         * Sets the client key file for use in X509 authentication.
+         *
+         * @param sslClientKeyFile the client key file path.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep sslClientKeyFile(String sslClientKeyFile);
+
+        /**
+         * Sets the client key file's encryption password.
+         *
+         * @param sslClientKeyPassword the client key file's password.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep sslClientKeyPassword(String sslClientKeyPassword);
 
         /**
          * Creates a new instance of {@code DittoMongoClient} with the properties of this builder.

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
@@ -14,8 +14,7 @@ package org.eclipse.ditto.internal.utils.persistence.mongo;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
+import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +22,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
-import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+
+import com.mongodb.MongoCredential;
+
+import io.netty.handler.ssl.SslContext;
+
+import io.netty.handler.ssl.SslContextBuilder;
 
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -349,10 +354,15 @@ public final class MongoClientWrapper implements DittoMongoClient {
         @Nullable private ConnectionString connectionString;
         private String defaultDatabaseName;
         private boolean sslEnabled;
+        private String sslCa;
         private boolean isUseAwsIamRole;
         private String awsRegion;
         private String awsRoleArn;
         private String awsSessionName;
+        private boolean isUseX509Authentication;
+        private String sslClientCert;
+        private String sslClientKey;
+        private String sslClientKeyPassword;
         @Nullable private EventLoopGroup eventLoopGroup;
 
         private MongoClientWrapperBuilder() {
@@ -401,6 +411,7 @@ public final class MongoClientWrapper implements DittoMongoClient {
 
             final MongoDbConfig.OptionsConfig optionsConfig = mongoDbConfig.getOptionsConfig();
             builder.enableSsl(optionsConfig.isSslEnabled());
+            builder.sslCaFile(optionsConfig.sslCaFile());
             builder.useAwsIamRole(optionsConfig.isUseAwsIamRole());
             builder.awsRegion(optionsConfig.awsRegion());
             builder.awsRoleArn(optionsConfig.awsRoleArn());
@@ -409,6 +420,10 @@ public final class MongoClientWrapper implements DittoMongoClient {
             builder.setReadConcern(optionsConfig.readConcern().getMongoReadConcern());
             builder.setWriteConcern(optionsConfig.writeConcern());
             builder.setRetryWrites(optionsConfig.isRetryWrites());
+            builder.useX509Authentication(optionsConfig.isUseX509Authentication());
+            builder.sslClientCertFile(optionsConfig.sslClientCertFile());
+            builder.sslClientKeyFile(optionsConfig.sslClientKeyFile());
+            builder.sslClientKeyPassword(optionsConfig.sslClientKeyPassword());
 
             return builder;
         }
@@ -446,6 +461,12 @@ public final class MongoClientWrapper implements DittoMongoClient {
         @Override
         public MongoClientWrapperBuilder enableSsl(final boolean enabled) {
             sslEnabled = enabled;
+            return this;
+        }
+
+        @Override
+        public MongoClientWrapperBuilder sslCaFile(final String sslCaFile) {
+            this.sslCa = sslCaFile;
             return this;
         }
 
@@ -555,6 +576,30 @@ public final class MongoClientWrapper implements DittoMongoClient {
         }
 
         @Override
+        public MongoClientWrapperBuilder useX509Authentication(final boolean useX509Authentication) {
+            this.isUseX509Authentication = useX509Authentication;
+            return this;
+        }
+
+        @Override
+        public MongoClientWrapperBuilder sslClientCertFile(final String sslClientCertFile) {
+            this.sslClientCert = sslClientCertFile;
+            return this;
+        }
+
+        @Override
+        public MongoClientWrapperBuilder sslClientKeyFile(final String sslClientKeyFile) {
+            this.sslClientKey = sslClientKeyFile;
+            return this;
+        }
+
+        @Override
+        public MongoClientWrapperBuilder sslClientKeyPassword(final String sslClientKeyPassword) {
+            this.sslClientKeyPassword = sslClientKeyPassword;
+            return this;
+        }
+
+        @Override
         public MongoClientWrapper build() {
             buildAndApplySslSettings();
 
@@ -563,40 +608,50 @@ public final class MongoClientWrapper implements DittoMongoClient {
                         AwsAuthenticationHelper.provideAwsIamBasedMongoCredential(awsRegion, awsRoleArn, awsSessionName)
                 );
             }
+
+            if (isUseX509Authentication) {
+                mongoClientSettingsBuilder.credential(MongoCredential.createMongoX509Credential());
+            }
+
             return new MongoClientWrapper(mongoClientSettingsBuilder.build(), defaultDatabaseName,
                     dittoMongoClientSettingsBuilder.build(), eventLoopGroup);
         }
 
         private void buildAndApplySslSettings() {
-            if (sslEnabled) {
-                eventLoopGroup = new NioEventLoopGroup();
-                mongoClientSettingsBuilder
-                        .transportSettings(TransportSettings.nettyBuilder().eventLoopGroup(eventLoopGroup).build())
-                        .applyToSslSettings(builder -> builder
-                                .context(tryToCreateAndInitSslContext())
-                                .enabled(sslEnabled));
-            } else if (null != connectionString) {
-                eventLoopGroup = null;
-                mongoClientSettingsBuilder
-                        .applyToSslSettings(builder -> builder
-                                .enabled(sslEnabled));
-            }
+            eventLoopGroup = new NioEventLoopGroup();
+            mongoClientSettingsBuilder
+                    .transportSettings(TransportSettings.nettyBuilder()
+                            .eventLoopGroup(eventLoopGroup)
+                            .sslContext(tryToCreateAndInitSslContext(sslCa, sslClientCert, sslClientKey, sslClientKeyPassword))
+                            .build())
+                    .applyToSslSettings(builder -> builder.enabled(sslEnabled));
         }
 
-        private static SSLContext tryToCreateAndInitSslContext() {
+        private static SslContext tryToCreateAndInitSslContext(String sslCa, String sslClientCert, String sslClientKey, String sslClientKeyPassword) {
             try {
-                return createAndInitSslContext();
-            } catch (final NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException("No such Algorithm is supported!", e);
-            } catch (final KeyManagementException e) {
-                throw new IllegalStateException("KeyManagementException!", e);
+                return createAndInitSslContext(sslCa, sslClientCert, sslClientKey, sslClientKeyPassword);
+            } catch (final SSLException e) {
+                throw new IllegalArgumentException("SSLException!", e);
             }
         }
 
-        private static SSLContext createAndInitSslContext() throws NoSuchAlgorithmException, KeyManagementException {
-            final SSLContext result = SSLContext.getInstance("TLSv1.2");
-            result.init(null, null, null);
-            return result;
+        private static SslContext createAndInitSslContext(String sslCa, String sslClientCert, String sslClientKey, String sslClientKeyPassword)
+                throws SSLException {
+            final var builder = SslContextBuilder.forClient();
+
+            if (sslCa != null && !sslCa.isEmpty()) {
+                final var sslCaFile = new File(sslCa);
+                builder.trustManager(sslCaFile);
+            }
+
+            if (sslClientCert != null && !sslClientCert.isEmpty()) {
+                final var sslClientCertFile = new File(sslClientCert);
+                final var sslClientKeyFile = new File(sslClientKey);
+                builder.keyManager(sslClientCertFile, sslClientKeyFile,
+                        sslClientKeyPassword.isEmpty() ? null : sslClientKeyPassword);
+            }
+
+            return builder.build();
         }
     }
 }

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -44,10 +44,15 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     private final String awsArnRole;
     private final String awsSessionName;
     private final boolean sslEnabled;
+    private final String sslCaFile;
     private final ReadPreference readPreference;
     private final ReadConcern readConcern;
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
+    private final boolean useX509Authentication;
+    private final String sslClientCertFile;
+    private final String sslClientKeyFile;
+    private final String sslClientKeyPassword;
     private final Map<String, Object> extraUriOptions;
 
     private DefaultOptionsConfig(final ScopedConfig config) {
@@ -55,6 +60,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
         awsRegion = config.getString(OptionsConfigValue.AWS_REGION.getConfigPath());
         awsArnRole = config.getString(OptionsConfigValue.AWS_ROLE_ARN.getConfigPath());
         sslEnabled = config.getBoolean(OptionsConfigValue.SSL_ENABLED.getConfigPath());
+        sslCaFile = config.getString(OptionsConfigValue.SSL_CA_FILE.getConfigPath());
         this.awsSessionName = config.getString(OptionsConfigValue.AWS_SESSION_NAME.getConfigPath());
         final var readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
         readPreference = ReadPreference.ofReadPreference(readPreferenceString)
@@ -80,6 +86,10 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
             return new DittoConfigError(msg);
         });
         retryWrites = config.getBoolean(OptionsConfigValue.RETRY_WRITES.getConfigPath());
+        useX509Authentication = config.getBoolean(OptionsConfigValue.USE_X509_AUTHENTICATION.getConfigPath());
+        sslClientCertFile = config.getString(OptionsConfigValue.SSL_CLIENT_CERT_FILE.getConfigPath());
+        sslClientKeyFile = config.getString(OptionsConfigValue.SSL_CLIENT_KEY_FILE.getConfigPath());
+        sslClientKeyPassword = config.getString(OptionsConfigValue.SSL_CLIENT_KEY_PASSWORD.getConfigPath());
         extraUriOptions = Collections.unmodifiableMap(new HashMap<>(
                 configToMap(config.getConfig(OptionsConfigValue.EXTRA_URI_OPTIONS.getConfigPath()))
         ));
@@ -104,6 +114,11 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     @Override
     public boolean isSslEnabled() {
         return sslEnabled;
+    }
+
+    @Override
+    public String sslCaFile() {
+        return sslCaFile;
     }
 
     @Override
@@ -145,6 +160,18 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
     public String awsSessionName() {return awsSessionName;}
 
     @Override
+    public boolean isUseX509Authentication() {return useX509Authentication;}
+
+    @Override
+    public String sslClientCertFile() {return sslClientCertFile;}
+
+    @Override
+    public String sslClientKeyFile() {return sslClientKeyFile;}
+
+    @Override
+    public String sslClientKeyPassword() {return sslClientKeyPassword;}
+
+    @Override
     public Map<String, Object> extraUriOptions() {
         return extraUriOptions;
     }
@@ -163,17 +190,23 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
                 && Objects.equals(awsArnRole, that.awsArnRole)
                 && Objects.equals(awsSessionName, that.awsSessionName)
                 && sslEnabled == that.sslEnabled
+                && Objects.equals(sslCaFile, that.sslCaFile)
                 && retryWrites == that.retryWrites &&
                 readPreference == that.readPreference &&
                 readConcern == that.readConcern &&
                 Objects.equals(writeConcern, that.writeConcern) &&
-                Objects.equals(extraUriOptions, that.extraUriOptions);
+                Objects.equals(extraUriOptions, that.extraUriOptions)
+                && useX509Authentication == that.useX509Authentication
+                && Objects.equals(sslClientCertFile, that.sslClientCertFile)
+                && Objects.equals(sslClientKeyFile, that.sslClientKeyFile)
+                && Objects.equals(sslClientKeyPassword, that.sslClientKeyPassword);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(useAwsIamRole, awsRegion, awsArnRole, awsArnRole, awsSessionName, sslEnabled,
-                readPreference, readConcern, writeConcern, retryWrites, extraUriOptions);
+        return Objects.hash(useAwsIamRole, awsRegion, awsArnRole, awsArnRole, awsSessionName, sslEnabled, sslCaFile,
+                readPreference, readConcern, writeConcern, retryWrites, extraUriOptions, useX509Authentication,
+                sslClientCertFile, sslClientKeyFile, sslClientKeyPassword);
     }
 
     @Override

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
@@ -138,6 +138,13 @@ public interface MongoDbConfig {
         boolean isSslEnabled();
 
         /**
+         * Gets the Ceritificate Authority root certificate file for use in SSL.
+         *
+         * @return the CA root certificate file path.
+         */
+        String sslCaFile();
+
+        /**
          * Gets the desired read preference that should be used for accessing MongoDB.
          *
          * @return the desired read preference.
@@ -196,6 +203,34 @@ public interface MongoDbConfig {
         String awsSessionName();
 
         /**
+         * Indicates whether to use X509 certificates for authentication.
+         *
+         * @return {@code true} if X509 Authentication should be used, {@code false} otherwise.
+         */
+        boolean isUseX509Authentication();
+
+        /**
+         * Gets the client certificate file for use in X509 authentication.
+         *
+         * @return The client certificate file path.
+         */
+        String sslClientCertFile();
+
+        /**
+         * Gets the client key file for use in X509 authentication.
+         *
+         * @return The client key file path.
+         */
+        String sslClientKeyFile();
+
+        /**
+         * Gets the client key file's encryption password.
+         *
+         * @return The client key file's encryption password.
+         */
+        String sslClientKeyPassword();
+
+        /**
          * Gets the extra options to add to the configured MongoDB {@code uri}.
          *
          * @return the extra options.
@@ -211,6 +246,11 @@ public interface MongoDbConfig {
              * Determines whether SSL should be enabled for the configured MongoDB source.
              */
             SSL_ENABLED("ssl", false),
+
+            /**
+             * Specifies the CA root certificate file to use for SSL.
+             */
+            SSL_CA_FILE("sslCAFile", ""),
 
             /**
              * Determines the read preference used for MongoDB connections. See {@link ReadPreference} for available options.
@@ -252,6 +292,26 @@ public interface MongoDbConfig {
              * Specifies the AWS session name to be used when assuming the IAM role.
              */
             AWS_SESSION_NAME("awsSessionName", "dittoSession"),
+
+            /**
+             * Determines whether X509 certificates should be used for authentication.
+             */
+            USE_X509_AUTHENTICATION("useX509Authentication", false),
+
+            /**
+             * Specifies the client certificate file for use in X509 authentication.
+             */
+            SSL_CLIENT_CERT_FILE("sslClientCertFile", ""),
+
+            /**
+             * Specifies the client key file for use in X509 authentication.
+             */
+            SSL_CLIENT_KEY_FILE("sslClientKeyFile", ""),
+
+            /**
+             * Specifies the client key file's encryption password.
+             */
+            SSL_CLIENT_KEY_PASSWORD("sslClientKeyPassword", ""),
 
             /**
              * The extra options to add to the configured MongoDB {@code uri}.

--- a/internal/utils/persistence/src/main/scala/org/eclipse/ditto/internal/utils/persistence/pekko/CustomizableScalaDriverPersistenceExtension.scala
+++ b/internal/utils/persistence/src/main/scala/org/eclipse/ditto/internal/utils/persistence/pekko/CustomizableScalaDriverPersistenceExtension.scala
@@ -13,13 +13,18 @@
 package org.eclipse.ditto.internal.utils.persistence.pekko
 
 import com.mongodb.MongoCredential
+import com.mongodb.connection.TransportSettings
 import com.typesafe.config.Config
+import io.netty.handler.ssl.SslContextBuilder
 import org.apache.pekko.actor.ActorSystem
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig
 import org.eclipse.ditto.internal.utils.persistence.mongo.auth.AwsAuthenticationHelper
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.DefaultMongoDbConfig
 import pekko.contrib.persistence.mongodb.driver.{ScalaDriverPersistenceJournaller, ScalaDriverPersistenceReadJournaller, ScalaDriverPersistenceSnapshotter, ScalaMongoDriver}
 import pekko.contrib.persistence.mongodb.{ConfiguredExtension, MongoPersistenceExtension, MongoPersistenceJournalMetrics, MongoPersistenceJournallingApi}
+
+import java.io.File
+import javax.net.ssl.SSLException
 
 /**
  * An adjustment of the original pekko-persistence
@@ -41,16 +46,31 @@ class CustomizableScalaDriverPersistenceExtension(val actorSystem: ActorSystem)
       val mongoDbConfig = DefaultMongoDbConfig.of(DefaultScopedConfig.dittoScoped(actorSystem.settings.config))
       val optionsConfig = mongoDbConfig.getOptionsConfig
 
-      if (optionsConfig.isUseAwsIamRole) {
-        val mongoCredential = AwsAuthenticationHelper.provideAwsIamBasedMongoCredential(
+      val mongoCredential = if (optionsConfig.isUseAwsIamRole) {
+        AwsAuthenticationHelper.provideAwsIamBasedMongoCredential(
           optionsConfig.awsRegion(),
           optionsConfig.awsRoleArn(),
           optionsConfig.awsSessionName()
         )
-        new CustomizableScalaMongoDriver(actorSystem, config, builder => builder.credential(mongoCredential))
+      } else if (optionsConfig.isUseX509Authentication) {
+        MongoCredential.createMongoX509Credential()
       } else {
-        new ScalaMongoDriver(actorSystem, config)
+        null
       }
+
+      new CustomizableScalaMongoDriver(actorSystem, config, builder => {
+        if (mongoCredential != null) {
+          builder.credential(mongoCredential)
+        }
+
+        builder.applyToSslSettings(sslBuilder => sslBuilder.enabled(optionsConfig.isSslEnabled))
+          .transportSettings(TransportSettings.nettyBuilder()
+            .sslContext(tryToCreateAndInitSslContext(optionsConfig.sslCaFile(), optionsConfig.sslClientCertFile(),
+                optionsConfig.sslClientKeyFile(), optionsConfig.sslClientKeyPassword()))
+            .build())
+
+        builder
+      })
     }
 
     override lazy val journaler: MongoPersistenceJournallingApi = new ScalaDriverPersistenceJournaller(driver)
@@ -60,6 +80,31 @@ class CustomizableScalaDriverPersistenceExtension(val actorSystem: ActorSystem)
     override lazy val snapshotter = new ScalaDriverPersistenceSnapshotter(driver)
 
     override lazy val readJournal = new ScalaDriverPersistenceReadJournaller(driver)
+
+    private def tryToCreateAndInitSslContext(sslCa: String, sslClientCert: String, sslClientKey: String, sslClientKeyPassword: String)
+    = try createAndInitSslContext(sslCa, sslClientCert, sslClientKey, sslClientKeyPassword)
+    catch {
+      case e: SSLException =>
+        throw new IllegalArgumentException("SSLException!", e)
+    }
+
+    @throws[SSLException]
+    private def createAndInitSslContext(sslCa: String, sslClientCert: String, sslClientKey: String, sslClientKeyPassword: String) = {
+      val builder = SslContextBuilder.forClient
+      if (sslCa != null && sslCa.nonEmpty) {
+        val sslCaFile = new File(sslCa)
+        builder.trustManager(sslCaFile)
+      }
+
+      if (sslClientCert != null && sslClientCert.nonEmpty) {
+        val sslClientCertFile = new File(sslClientCert)
+        val sslClientKeyFile = new File(sslClientKey)
+        builder.keyManager(sslClientCertFile, sslClientKeyFile,
+          if (sslClientKeyPassword.isEmpty) null else sslClientKeyPassword)
+      }
+
+      builder.build
+    }
   }
 
 }


### PR DESCRIPTION
Adds support for using X509 authentication when connecting to MongoDB.

Also allows configuring the CA root certificate used in the TLS connection to MongoDB.