### PR TITLE
Make 4xx DittoRuntimeException subclasses stackless by default

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/exceptions/DittoRuntimeException.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/exceptions/DittoRuntimeException.java
@@ -34,6 +34,7 @@ import org.eclipse.ditto.base.model.headers.WithManifest;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.json.Jsonifiable;
+import org.eclipse.ditto.base.model.signals.FeatureToggle;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -56,6 +57,12 @@ public abstract class DittoRuntimeException extends RuntimeException
 
     /**
      * Constructs a new {@code DittoRuntimeException} object.
+     * <p>
+     * Whether the resulting exception captures a writable stack trace depends on the {@code httpStatus} and the system
+     * property {@value org.eclipse.ditto.base.model.signals.FeatureToggle#STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}:
+     * exceptions with HTTP status &ge; 500 always capture a stack trace; exceptions with HTTP status &lt; 500 omit
+     * the stack trace and suppressed-exception list when the toggle is enabled (default). Subclasses needing explicit
+     * control can use {@link #DittoRuntimeException(String, HttpStatus, DittoHeaders, String, String, Throwable, URI, boolean)}.
      *
      * @param errorCode a code which uniquely identifies the exception.
      * @param httpStatus the HTTP status.
@@ -75,12 +82,54 @@ public abstract class DittoRuntimeException extends RuntimeException
             @Nullable final Throwable cause,
             @Nullable final URI href) {
 
-        super(message, cause);
+        this(errorCode, httpStatus, dittoHeaders, message, description, cause, href,
+                computeWritableStackTrace(httpStatus));
+    }
+
+    /**
+     * Constructs a new {@code DittoRuntimeException} object with explicit control over stack-trace capture.
+     * <p>
+     * When {@code writableStackTrace} is {@code false}, both {@link Throwable#fillInStackTrace()} and the
+     * suppressed-exception machinery are disabled — eliminating the per-throw native stack walk and
+     * {@code StackTraceElement[]} allocation. Use this overload only when subclassing requires explicit override
+     * of the default policy applied by {@link #DittoRuntimeException(String, HttpStatus, DittoHeaders, String, String, Throwable, URI)}.
+     *
+     * @param errorCode a code which uniquely identifies the exception.
+     * @param httpStatus the HTTP status.
+     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+     * @param message the detail message for later retrieval with {@link #getMessage()}.
+     * @param description a description with further information about the exception.
+     * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+     * @param href a link to a resource which provides further information about the exception.
+     * @param writableStackTrace whether the resulting exception captures a writable stack trace and supports
+     * suppressed exceptions ({@code true}) or omits both for performance ({@code false}).
+     * @throws NullPointerException if {@code errorCode}, {@code httpStatus} or {@code dittoHeaders} is {@code null}.
+     * @since 3.9.0
+     */
+    protected DittoRuntimeException(final String errorCode,
+            final HttpStatus httpStatus,
+            final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href,
+            final boolean writableStackTrace) {
+
+        super(message, cause, writableStackTrace, writableStackTrace);
         this.errorCode = checkNotNull(errorCode, "error code");
         this.httpStatus = checkNotNull(httpStatus, "httpStatus");
         this.dittoHeaders = checkNotNull(dittoHeaders, "Ditto headers");
         this.description = description;
         this.href = href;
+    }
+
+    /**
+     * Decides whether an exception with the given {@code httpStatus} should capture a writable stack trace.
+     * HTTP status &ge; 500 always returns {@code true}; HTTP status &lt; 500 returns {@code true} only when the
+     * stackless feature toggle is disabled.
+     */
+    private static boolean computeWritableStackTrace(final HttpStatus httpStatus) {
+        return httpStatus.getCode() >= 500 || !FeatureToggle.isStacklessFlowControlExceptionsEnabled();
     }
 
     /**

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
@@ -84,6 +84,23 @@ public final class FeatureToggle {
             "ditto.devops.feature.wot-td-permission-filtering-enabled";
 
     /**
+     * System property name of the property defining whether {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException}
+     * subclasses representing flow-control (HTTP status &lt; 500) suppress their stack trace and suppressed-exception
+     * list. When enabled (default), such exceptions degenerate {@code Throwable.<init>} to a few field assignments —
+     * eliminating the per-throw {@code fillInStackTrace()} native call and {@code StackTraceElement[]} allocation.
+     * When disabled, every Ditto exception captures a writable stack trace as in earlier releases.
+     * <p>
+     * 5xx ({@link org.eclipse.ditto.base.model.common.HttpStatus#INTERNAL_SERVER_ERROR} and above) are unaffected and
+     * always keep their stack trace, regardless of this toggle.
+     * <p>
+     * Resolved once at JVM start (static-final). Changing the system property after class load has no effect.
+     *
+     * @since 3.9.0
+     */
+    public static final String STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED =
+            "ditto.devops.feature.stackless-flow-control-exceptions-enabled";
+
+    /**
      * Resolves the system property {@value MERGE_THINGS_ENABLED}.
      */
     private static final boolean IS_MERGE_THINGS_ENABLED = resolveProperty(MERGE_THINGS_ENABLED);
@@ -124,6 +141,12 @@ public final class FeatureToggle {
      */
     private static final boolean IS_WOT_TD_PERMISSION_FILTERING_ENABLED =
             resolveProperty(WOT_TD_PERMISSION_FILTERING_ENABLED);
+
+    /**
+     * Resolves the system property {@value STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}.
+     */
+    private static final boolean IS_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED =
+            resolveProperty(STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED);
 
     private static boolean resolveProperty(final String propertyName) {
         final String propertyValue = System.getProperty(propertyName, Boolean.TRUE.toString());
@@ -267,5 +290,17 @@ public final class FeatureToggle {
      */
     public static boolean isWotTdPermissionFilteringEnabled() {
         return IS_WOT_TD_PERMISSION_FILTERING_ENABLED;
+    }
+
+    /**
+     * Returns whether stack-trace suppression for flow-control (HTTP status &lt; 500)
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} subclasses is enabled, based on the system
+     * property {@value STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}.
+     *
+     * @return whether stackless flow-control exceptions are enabled.
+     * @since 3.9.0
+     */
+    public static boolean isStacklessFlowControlExceptionsEnabled() {
+        return IS_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED;
     }
 }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/exceptions/DittoRuntimeExceptionTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/exceptions/DittoRuntimeExceptionTest.java
@@ -12,6 +12,10 @@
  */
 package org.eclipse.ditto.base.model.exceptions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -29,7 +33,93 @@ public final class DittoRuntimeExceptionTest {
                 .withRedefinedSuperclass()
                 .usingGetClass()
                 .suppress(Warning.NONFINAL_FIELDS)
-                .verify();  
+                .verify();
+    }
+
+    @Test
+    public void defaultBuildOf4xxExceptionHasEmptyStackTrace() {
+        final DittoRuntimeException underTest = new TestDittoRuntimeException(HttpStatus.NOT_FOUND);
+
+        assertThat(underTest.getStackTrace()).isEmpty();
+        assertThat(underTest.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void defaultBuildOf5xxExceptionHasNonEmptyStackTrace() {
+        final DittoRuntimeException underTest = new TestDittoRuntimeException(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        assertThat(underTest.getStackTrace()).isNotEmpty();
+    }
+
+    @Test
+    public void defaultBuildOf3xxExceptionHasEmptyStackTrace() {
+        // Locks down the rule: any HTTP status < 500 → stackless.
+        final DittoRuntimeException underTest = new TestDittoRuntimeException(HttpStatus.NOT_MODIFIED);
+
+        assertThat(underTest.getStackTrace()).isEmpty();
+    }
+
+    @Test
+    public void explicit8ArgCtorWithWritableStackTraceTrueCapturesStackEvenFor4xx() {
+        final DittoRuntimeException underTest =
+                new TestDittoRuntimeException(HttpStatus.NOT_FOUND, true);
+
+        assertThat(underTest.getStackTrace()).isNotEmpty();
+    }
+
+    @Test
+    public void explicit8ArgCtorWithWritableStackTraceFalseSuppressesStackEvenFor5xx() {
+        final DittoRuntimeException underTest =
+                new TestDittoRuntimeException(HttpStatus.INTERNAL_SERVER_ERROR, false);
+
+        assertThat(underTest.getStackTrace()).isEmpty();
+    }
+
+    @Test
+    public void addSuppressedIsNoOpForStacklessException() {
+        final DittoRuntimeException underTest = new TestDittoRuntimeException(HttpStatus.BAD_REQUEST);
+        underTest.addSuppressed(new RuntimeException("suppressed"));
+
+        assertThat(underTest.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void jsonRoundTripUnaffectedByStacklessness() {
+        final DittoRuntimeException original = new TestDittoRuntimeException(HttpStatus.NOT_FOUND);
+
+        // toJson uses the wire fields only - status / errorCode / message / description / href.
+        // The wire format must be identical regardless of whether the source exception is stackless.
+        final org.eclipse.ditto.json.JsonObject json = original.toJson();
+
+        assertThat(json.getValue(DittoRuntimeException.JsonFields.STATUS).orElseThrow().intValue())
+                .isEqualTo(HttpStatus.NOT_FOUND.getCode());
+        assertThat(json.getValue(DittoRuntimeException.JsonFields.ERROR_CODE).orElseThrow())
+                .isEqualTo(TestDittoRuntimeException.ERROR_CODE);
+        // No stack-trace-related field in the JSON.
+        assertThat(json.contains(org.eclipse.ditto.json.JsonKey.of("stackTrace"))).isFalse();
+    }
+
+    /**
+     * Concrete subclass used purely for testing the {@link DittoRuntimeException} construction policy.
+     */
+    private static final class TestDittoRuntimeException extends DittoRuntimeException {
+
+        private static final String ERROR_CODE = "test.dittoRuntimeException";
+        private static final long serialVersionUID = 1L;
+
+        private TestDittoRuntimeException(final HttpStatus httpStatus) {
+            super(ERROR_CODE, httpStatus, DittoHeaders.empty(), "test-message", null, null, null);
+        }
+
+        private TestDittoRuntimeException(final HttpStatus httpStatus, final boolean writableStackTrace) {
+            super(ERROR_CODE, httpStatus, DittoHeaders.empty(), "test-message", null, null, null,
+                    writableStackTrace);
+        }
+
+        @Override
+        public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+            return this;
+        }
     }
 
 }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/signals/FeatureToggleTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/signals/FeatureToggleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.model.signals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link FeatureToggle}.
+ */
+public final class FeatureToggleTest {
+
+    @Test
+    public void stacklessFlowControlExceptionsToggleDefaultsToTrue() {
+        // Toggles are resolved once at class load via System.getProperty(name, "true"). Without an explicit
+        // -D override the default is true.
+        assertThat(FeatureToggle.isStacklessFlowControlExceptionsEnabled()).isTrue();
+    }
+
+    @Test
+    public void stacklessFlowControlExceptionsPropertyNameIsStable() {
+        // Regression guard so that renames cannot silently break operator-facing JVM properties.
+        assertThat(FeatureToggle.STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED)
+                .isEqualTo("ditto.devops.feature.stackless-flow-control-exceptions-enabled");
+    }
+
+}

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/DittoService.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/DittoService.java
@@ -426,6 +426,9 @@ public abstract class DittoService<C extends ServiceSpecificConfig> {
         System.setProperty(FeatureToggle.POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED,
                 Boolean.toString(
                         rawConfig.getBoolean(FeatureToggle.POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED)));
+        System.setProperty(FeatureToggle.STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED,
+                Boolean.toString(
+                        rawConfig.getBoolean(FeatureToggle.STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED)));
         System.setProperty(DittoSystemProperties.DITTO_LIMITS_POLICY_IMPORTS_LIMIT,
                 Integer.toString(limitsConfig.getPolicyImportsLimit()));
         final MetricsConfig metricsConfig = serviceSpecificConfig.getMetricsConfig();

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.0.0  # chart version is effectively set by release-job
+version: 4.0.1  # chart version is effectively set by release-job
 appVersion: 3.9.0-M3
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -226,6 +226,8 @@ spec:
               value: "{{ .Values.global.featureFlags.tracingSpanMetricsEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
+              value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
             - name: PEKKO_COORDINATED_SHUTDOWN_PHASES_CLUSTER_SHARDING_SHUTDOWN_REGION
               value: "{{ .Values.connectivity.config.cluster.coordinatedShutdown.phases.clusterShardingShutdownRegion.timeout }}"
             - name: PEKKO_COORDINATED_SHUTDOWN_PHASES_CLUSTER_EXITING_TIMEOUT

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -211,6 +211,8 @@ spec:
               value: "{{ .Values.global.featureFlags.tracingSpanMetricsEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
+              value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
             - name: PEKKO_COORDINATED_SHUTDOWN_PHASES_CLUSTER_SHARDING_SHUTDOWN_REGION
               value: "{{ .Values.gateway.config.cluster.coordinatedShutdown.phases.clusterShardingShutdownRegion.timeout }}"
             - name: PEKKO_COORDINATED_SHUTDOWN_PHASES_CLUSTER_EXITING_TIMEOUT

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -220,6 +220,8 @@ spec:
               value: "{{ .Values.global.featureFlags.tracingSpanMetricsEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
+              value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_ENABLED
               value: "{{ .Values.global.metrics.liveEntities.enabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_REFRESH_INTERVAL

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -224,6 +224,8 @@ spec:
               value: "{{ .Values.global.featureFlags.tracingSpanMetricsEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
+              value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_ENABLED
               value: "{{ .Values.global.metrics.liveEntities.enabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_REFRESH_INTERVAL

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -220,6 +220,8 @@ spec:
               value: "{{ .Values.global.featureFlags.tracingSpanMetricsEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
+              value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_ENABLED
               value: "{{ .Values.global.metrics.liveEntities.enabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_REFRESH_INTERVAL

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -189,6 +189,13 @@ global:
     #  for policy enforcement. This evaluator trades off higher memory use for higher throughput and lower CPU usage.
     #  The alternative, if configured to false, is a memory-optimized evaluator which uses less memory but more CPU.
     policyEnforcementUseThroughputOptimizedEvaluatorEnabled: true
+    # stacklessFlowControlExceptionsEnabled controls whether DittoRuntimeException subclasses representing flow-control
+    #  (HTTP status < 500, e.g. 404 Not Found, 403 Forbidden, 400 Bad Request) omit their stack trace and
+    #  suppressed-exception list. When enabled (default), these exceptions degenerate Throwable.<init> to a few
+    #  field assignments - eliminating the per-throw fillInStackTrace native call and StackTraceElement[] allocation.
+    #  Exceptions with HTTP status >= 500 always keep their stack trace, regardless of this toggle. Set this to
+    #  false to restore the legacy behaviour where every Ditto exception captures a writable stack trace.
+    stacklessFlowControlExceptionsEnabled: true
   # logging the logging configuration for Ditto
   logging:
     # sysout holds the logging to SYSOUT config

--- a/internal/utils/config/src/main/resources/ditto-devops.conf
+++ b/internal/utils/config/src/main/resources/ditto-devops.conf
@@ -49,5 +49,14 @@ ditto.devops {
     //  When disabled, TDs are returned unfiltered to any authenticated user (legacy behavior).
     wot-td-permission-filtering-enabled = true
     wot-td-permission-filtering-enabled = ${?DITTO_DEVOPS_FEATURE_WOT_TD_PERMISSION_FILTERING_ENABLED}
+
+    // enables/disables stack-trace suppression for flow-control DittoRuntimeException subclasses.
+    //  When enabled (default), exceptions whose HTTP status is < 500 omit their stack trace and suppressed-exception
+    //  list, eliminating the per-throw fillInStackTrace native call and StackTraceElement[] allocation.
+    //  Exceptions with HTTP status >= 500 always keep their stack trace, regardless of this toggle.
+    //  Note: this entry is for discoverability only - the feature is read via the system property
+    //  -Dditto.devops.feature.stackless-flow-control-exceptions-enabled, NOT from HOCON.
+    stackless-flow-control-exceptions-enabled = true
+    stackless-flow-control-exceptions-enabled = ${?DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}
   }
 }


### PR DESCRIPTION
## Summary

`DittoRuntimeException` subclasses representing flow-control — HTTP status `< 500`, e.g. `ThingNotAccessibleException`, `PolicyNotAccessibleException`, `WotThingModelPayloadValidationException`, `MessageSendNotAllowedException` — now omit their stack trace and suppressed-exception list. This eliminates the per-throw `fillInStackTrace()` native call and `StackTraceElement[]` allocation, which JFR profiling on a gateway pod showed to be the dominant cost in the exception path (376 `ThingNotAccessibleException` / 309 s ≈ 1.22/s, ~30 frames captured each — roughly 720 kB/s of `StackTraceElement[]` garbage on the gateway alone).

Exceptions with HTTP status `>= 500` (`INTERNAL_SERVER_ERROR`, `BAD_GATEWAY`, `SERVICE_UNAVAILABLE`, `GATEWAY_TIMEOUT`, …) **always keep their stack trace** because they signal real bugs / infrastructure problems where the stack is diagnostic.

### Implementation

Centralised inside `DittoRuntimeException` itself — **one new private static helper** `computeWritableStackTrace(HttpStatus)` decides per construction based on `httpStatus.getCode() < 500 && FeatureToggle.isStacklessFlowControlExceptionsEnabled()`. All 232 subclasses inherit the new behaviour automatically without per-subclass code changes. A new `protected` 8-arg constructor takes an explicit `writableStackTrace` flag as an escape hatch for subclasses that need to override the default policy.

**Wire format unchanged** — `DittoRuntimeException.toJson` emits only `status` / `errorCode` / `message` / `description` / `href`; stack frames were never serialised to clients.

### Feature toggle

`ditto.devops.feature.stackless-flow-control-exceptions-enabled` (default `true`) restores the legacy behaviour — every Ditto exception captures a writable stack trace — when set to `false`. Plumbed end-to-end following the same pattern as every other toggle in `FeatureToggle.java`:

1. HOCON entry in `ditto-devops.conf` with `${?DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}` env-var interpolation
2. HOCON→`System.setProperty` bridge in `DittoService.injectSystemPropertiesLimits`
3. Helm `global.featureFlags.stacklessFlowControlExceptionsEnabled` value + per-service deployment-template env-var binding (all 5 services)

### Side effects to be aware of

- SLF4J `log.X("...", e)` with a 4xx DRE as `Throwable` arg prints just `"ClassName: message"` instead of a full stack. Most Ditto logging uses the `"... <{}>", e` form which calls `toString()` and is unaffected.
- `Throwable.addSuppressed()` on a 4xx DRE becomes a no-op. The codebase has 3 production call sites (`JsonFieldsEncryptor`, `DocumentProcessor`, `ThingSupervisorActor`); all three use suppressed exceptions as diagnostic aids, not data.
- Operators who today rely on a 4xx DRE's stack trace for triage can flip the toggle off via `-Dditto.devops.feature.stackless-flow-control-exceptions-enabled=false` or the new Helm value.