### PR TITLE
Make SSE publisher backpressure buffer size configurable

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.0.1  # chart version is effectively set by release-job
+version: 4.0.2  # chart version is effectively set by release-job
 appVersion: 3.9.0-M3
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -261,6 +261,8 @@ spec:
               value: "{{ .Values.gateway.config.websocket.throttling.interval }}"
             - name: GATEWAY_WEBSOCKET_THROTTLING_LIMIT
               value: "{{ .Values.gateway.config.websocket.throttling.limit }}"
+            - name: GATEWAY_SSE_PUBLISHER_BACKPRESSURE
+              value: "{{ .Values.gateway.config.sse.publisher.backpressureBufferSize }}"
             - name: GATEWAY_SSE_THROTTLING_ENABLED
               value: "{{ .Values.gateway.config.sse.throttling.enabled }}"
             - name: GATEWAY_SSE_THROTTLING_INTERVAL

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -2422,6 +2422,11 @@ gateway:
         limit: 100
     # websocket contains the gateway SSE (server sent events) configuration
     sse:
+      # publisher contains the configuration for sending/publishing data via SSE
+      publisher:
+        # backpressureBufferSize is the max buffer size of how many outstanding events a single SSE client can have -
+        #  when the buffer is full, the upstream is backpressured (no events are dropped)
+        backpressureBufferSize: 100
       # throttling contains the throttling configuration of a single SSE session (only applies for search via SSE)
       throttling:
         # enabled whether throttling message publishing via a single websocket session is enabled

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -439,7 +439,8 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
                         }
 
                         final Source<SessionedJsonifiable, SupervisedStream.WithQueue> publisherSource =
-                                SupervisedStream.sourceQueue(10);
+                                SupervisedStream.sourceQueue(
+                                        streamingConfig.getSseConfig().getPublisherBackpressureBufferSize());
 
                         return publisherSource.viaMat(KillSwitches.single(), Keep.both())
                                 .mapMaterializedValue(pair -> {
@@ -509,7 +510,8 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
                         sseAuthorizationEnforcer.checkAuthorization(ctx, dittoHeaders).thenApply(unused -> {
 
                             final Source<SessionedJsonifiable, SupervisedStream.WithQueue> publisherSource =
-                                    SupervisedStream.sourceQueue(10);
+                                    SupervisedStream.sourceQueue(
+                                            streamingConfig.getSseConfig().getPublisherBackpressureBufferSize());
 
                             return publisherSource.viaMat(KillSwitches.single(), Keep.both())
                                     .mapMaterializedValue(pair -> {

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultSseConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultSseConfig.java
@@ -29,9 +29,12 @@ import com.typesafe.config.Config;
 final class DefaultSseConfig implements SseConfig {
 
     private final ThrottlingConfig throttlingConfig;
+    private final int publisherBackpressureBufferSize;
 
     private DefaultSseConfig(final ScopedConfig scopedConfig) {
         throttlingConfig = ThrottlingConfig.of(scopedConfig);
+        publisherBackpressureBufferSize =
+                scopedConfig.getPositiveIntOrThrow(SseConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE);
     }
 
     /**
@@ -52,22 +55,29 @@ final class DefaultSseConfig implements SseConfig {
     }
 
     @Override
+    public int getPublisherBackpressureBufferSize() {
+        return publisherBackpressureBufferSize;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final DefaultSseConfig that = (DefaultSseConfig) o;
-        return Objects.equals(throttlingConfig, that.throttlingConfig);
+        return publisherBackpressureBufferSize == that.publisherBackpressureBufferSize &&
+                Objects.equals(throttlingConfig, that.throttlingConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(throttlingConfig);
+        return Objects.hash(throttlingConfig, publisherBackpressureBufferSize);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "throttlingConfig=" + throttlingConfig +
+                ", publisherBackpressureBufferSize=" + publisherBackpressureBufferSize +
                 "]";
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/SseConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/SseConfig.java
@@ -32,8 +32,21 @@ public interface SseConfig {
      */
     ThrottlingConfig getThrottlingConfig();
 
+    /**
+     * Returns the max buffer size of how many outstanding events a single SSE client can have.
+     * When the buffer is full, the upstream is backpressured.
+     *
+     * @return the buffer size.
+     */
+    int getPublisherBackpressureBufferSize();
+
     enum SseConfigValue implements KnownConfigValue {
-        ;
+
+        /**
+         * The max buffer size of how many outstanding events a single SSE client can have.
+         */
+        PUBLISHER_BACKPRESSURE_BUFFER_SIZE("publisher.backpressure-buffer-size", 100);
+
         private final String path;
         private final Object defaultValue;
 

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -191,6 +191,12 @@ ditto {
       }
 
       sse {
+        # the max buffer size of how many outstanding events a single SSE client can have
+        publisher {
+          backpressure-buffer-size = 100
+          backpressure-buffer-size = ${?GATEWAY_SSE_PUBLISHER_BACKPRESSURE}
+        }
+
         throttling {
           enabled = false
           enabled = ${?GATEWAY_SSE_THROTTLING_ENABLED}

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultSseConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultSseConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.util.config.streaming;
+
+import java.time.Duration;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit test for {@link DefaultSseConfig}.
+ */
+public final class DefaultSseConfigTest {
+
+    private static Config sseTestConfig;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @BeforeClass
+    public static void initTestFixture() {
+        sseTestConfig = ConfigFactory.load("sse-test");
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultSseConfig.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final SseConfig underTest = DefaultSseConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.getPublisherBackpressureBufferSize())
+                .as(SseConfig.SseConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE.getConfigPath())
+                .isEqualTo(SseConfig.SseConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE.getDefaultValue());
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final SseConfig underTest = DefaultSseConfig.of(sseTestConfig);
+
+        softly.assertThat(underTest.getPublisherBackpressureBufferSize())
+                .as(SseConfig.SseConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE.getConfigPath())
+                .isEqualTo(77);
+        softly.assertThat(underTest.getThrottlingConfig().getInterval())
+                .as("throttling.interval")
+                .isEqualTo(Duration.ofSeconds(8L));
+        softly.assertThat(underTest.getThrottlingConfig().getLimit())
+                .as("throttling.limit")
+                .isEqualTo(9);
+    }
+
+}

--- a/gateway/service/src/test/resources/sse-test.conf
+++ b/gateway/service/src/test/resources/sse-test.conf
@@ -1,0 +1,8 @@
+sse {
+  publisher.backpressure-buffer-size = 77
+  throttling {
+    enabled = true
+    interval = 8s
+    limit = 9
+  }
+}


### PR DESCRIPTION
## Summary

- The buffer size of the SSE publisher source queue in `ThingsSseRouteBuilder` was hardcoded to `10`. Once a client consumes server-sent events slower than the upstream produces them, the buffer fills up and Pekko emits frequent `Backpressuring because buffer is full and overflowStrategy is: [Backpressure] in stream [queueSource]` WARN logs from `org.apache.pekko.stream.impl.QueueSource`. No data is lost (the upstream is backpressured), but the log noise is non-trivial and the threshold of 10 is much tighter than what's used for the WebSocket publisher (default 200).
- Make the SSE publisher buffer size configurable via:
  - HOCON: `ditto.gateway.streaming.sse.publisher.backpressure-buffer-size`
  - Env var: `GATEWAY_SSE_PUBLISHER_BACKPRESSURE`
  - Helm value: `gateway.config.sse.publisher.backpressureBufferSize`
- Raise the default from `10` → `100` (still well below the WebSocket default of 200; SSE messages are bigger and one event per `keepAlive` heartbeat already pushes through).

## Changes

| File                                                                          | Change                                                                                   |
| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| `gateway/.../streaming/SseConfig.java`                                        | Add `getPublisherBackpressureBufferSize()` + `PUBLISHER_BACKPRESSURE_BUFFER_SIZE` enum   |
| `gateway/.../streaming/DefaultSseConfig.java`                                 | Wire field + equals/hashCode/toString                                                    |
| `gateway/service/src/main/resources/gateway.conf`                             | New HOCON setting with env-var override                                                  |
| `gateway/.../sse/ThingsSseRouteBuilder.java`                                  | Both hardcoded `SupervisedStream.sourceQueue(10)` calls now use the config value         |
| `gateway/.../DefaultSseConfigTest.java` + `sse-test.conf`                     | New unit test (defaults, file values, equals/hashCode)                                   |
| `deployment/helm/ditto/values.yaml` + `gateway-deployment.yaml`               | Expose the new value via helm                                                            |
