### PR TITLE
fix activity-check reschedule interval for non-deleted persistent actors

### DIFF
--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
@@ -644,7 +644,10 @@ public abstract class AbstractPersistenceActor<
      * @param message the check-for-activity message.
      */
     protected void checkForActivity(final CheckForActivity message) {
-        scheduleCheckForActivity(getActivityCheckConfig().getDeletedInterval());
+        final Duration nextCheckInterval = isEntityActive()
+                ? getActivityCheckConfig().getInactiveInterval()
+                : getActivityCheckConfig().getDeletedInterval();
+        scheduleCheckForActivity(nextCheckInterval);
         if (entityExistsAsDeleted() && lastSnapshotRevision < getRevisionNumber()) {
             // take a snapshot after a period of inactivity if:
             // - entity is deleted,


### PR DESCRIPTION
## Summary

`AbstractPersistenceActor.checkForActivity` always rescheduled the next activity check at `deletedInterval` (default **5 min**), regardless of whether the entity was deleted. For an active (non-deleted) entity this means: after the *first* scheduled `inactiveInterval` (default **2 h**) check passes, every subsequent check fires every 5 min, and the actor is shut down as soon as no command arrives within a 5 min window — far earlier than the configured `inactive-interval` (e.g. 2 h) would suggest.

## Observed effect in production

In one deployment with `activity-check.inactive-interval = 2 h` and a workload that touches ~80 000 things from a single namespace every 30 min:

- All ~80 000 `ThingPersistenceActor`s get recovered together when the 30 min cron fires.
- The first activity check fires 2 h later and correctly prevents shutdown (counter advanced via the regular 30 min touches), but reschedules the **next** check at 5 min.
- 5 min after that — and well before the next 30 min cron touch — none of those actors saw a fresh command in the last 5 min window, so all ~80 000 get shut down within a single 5 min window.
- 25 min later (next cron cycle) all ~80 000 are recovered again from MongoDB.

The result is a tight **2 h 30 min** load → idle → bulk-recovery cycle, with a 5 min shutdown spike and a 5 min recovery spike at each end. Loki cross-check confirmed shutdowns happen exactly 2 h 05 min after each bulk-load spike.

## Fix

`checkForActivity` now picks the reschedule interval based on whether the entity exists as deleted, matching the initial scheduling done in `becomeCreatedHandler` (inactive) vs. `becomeDeletedHandler` (deleted):

```java
final Duration nextCheckInterval = entityExistsAsDeleted()
        ? getActivityCheckConfig().getDeletedInterval()
        : getActivityCheckConfig().getInactiveInterval();
scheduleCheckForActivity(nextCheckInterval);
```

## Compatibility

- No config or API change.
- Behavior for deleted entities is unchanged (5 min reschedule preserved).
- Behavior for active entities now actually honors `activity-check.inactive-interval` for subsequent checks, not just the first one.

Affects all subclasses of `AbstractPersistenceActor` (Thing, Policy, Connection). `ConnectionPersistenceActor` already short-circuits with `inactiveInterval` when `isDesiredStateOpen()`, so the visible behavior change there is limited to closed-desired-state connections.