### PR TITLE
add policy-lockout-prevention feature toggle for PoliciesValidator

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
@@ -101,6 +101,24 @@ public final class FeatureToggle {
             "ditto.devops.feature.stackless-flow-control-exceptions-enabled";
 
     /**
+     * System property name of the property defining whether the policy lockout prevention check performed by
+     * {@code PoliciesValidator} is enabled. The check rejects any create or modify operation whose resulting policy
+     * lacks at least one permanent subject with {@code WRITE} permission on resource {@code policy:/}.
+     * <p>
+     * With namespace-scoped root policies (since 3.9.0), the implicitly imported global policy may already supply
+     * the required permission, in which case the persistence-side check is overly strict (it does not see the
+     * namespace root). Setting this toggle to {@code false} disables the validator's lockout-prevention
+     * short-circuit so the policy is accepted regardless of its own subjects' permissions on {@code policy:/}.
+     * <p>
+     * The enforcement-side check in {@code PolicyCommandEnforcement.authorizeCreatePolicy} is unaffected by this
+     * toggle — it operates on an enforcer that already includes namespace-scoped root policies.
+     *
+     * @since 3.9.1
+     */
+    public static final String POLICY_LOCKOUT_PREVENTION_ENABLED =
+            "ditto.devops.feature.policy-lockout-prevention-enabled";
+
+    /**
      * Resolves the system property {@value MERGE_THINGS_ENABLED}.
      */
     private static final boolean IS_MERGE_THINGS_ENABLED = resolveProperty(MERGE_THINGS_ENABLED);
@@ -147,6 +165,12 @@ public final class FeatureToggle {
      */
     private static final boolean IS_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED =
             resolveProperty(STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED);
+
+    /**
+     * Resolves the system property {@value POLICY_LOCKOUT_PREVENTION_ENABLED}.
+     */
+    private static final boolean IS_POLICY_LOCKOUT_PREVENTION_ENABLED =
+            resolveProperty(POLICY_LOCKOUT_PREVENTION_ENABLED);
 
     private static boolean resolveProperty(final String propertyName) {
         final String propertyValue = System.getProperty(propertyName, Boolean.TRUE.toString());
@@ -302,5 +326,17 @@ public final class FeatureToggle {
      */
     public static boolean isStacklessFlowControlExceptionsEnabled() {
         return IS_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED;
+    }
+
+    /**
+     * Returns whether the policy lockout prevention check in {@code PoliciesValidator} is enabled, based on the system
+     * property {@value POLICY_LOCKOUT_PREVENTION_ENABLED}. When {@code false}, the validator's "at least one permanent
+     * subject must have WRITE on policy:/" check is bypassed.
+     *
+     * @return whether policy lockout prevention is enabled.
+     * @since 3.9.1
+     */
+    public static boolean isPolicyLockoutPreventionEnabled() {
+        return IS_POLICY_LOCKOUT_PREVENTION_ENABLED;
     }
 }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/signals/FeatureToggleTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/signals/FeatureToggleTest.java
@@ -35,4 +35,15 @@ public final class FeatureToggleTest {
                 .isEqualTo("ditto.devops.feature.stackless-flow-control-exceptions-enabled");
     }
 
+    @Test
+    public void policyLockoutPreventionToggleDefaultsToTrue() {
+        assertThat(FeatureToggle.isPolicyLockoutPreventionEnabled()).isTrue();
+    }
+
+    @Test
+    public void policyLockoutPreventionPropertyNameIsStable() {
+        assertThat(FeatureToggle.POLICY_LOCKOUT_PREVENTION_ENABLED)
+                .isEqualTo("ditto.devops.feature.policy-lockout-prevention-enabled");
+    }
+
 }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/DittoService.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/DittoService.java
@@ -429,6 +429,8 @@ public abstract class DittoService<C extends ServiceSpecificConfig> {
         System.setProperty(FeatureToggle.STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED,
                 Boolean.toString(
                         rawConfig.getBoolean(FeatureToggle.STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED)));
+        System.setProperty(FeatureToggle.POLICY_LOCKOUT_PREVENTION_ENABLED,
+                Boolean.toString(rawConfig.getBoolean(FeatureToggle.POLICY_LOCKOUT_PREVENTION_ENABLED)));
         System.setProperty(DittoSystemProperties.DITTO_LIMITS_POLICY_IMPORTS_LIMIT,
                 Integer.toString(limitsConfig.getPolicyImportsLimit()));
         final MetricsConfig metricsConfig = serviceSpecificConfig.getMetricsConfig();

--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -19,6 +19,10 @@ release. Each entry uses one of the Artifact Hub change kinds: `added`, `changed
 ### Added
 - Allow configuring `issuers` for OpenID Connect in Helm values
   ([#2442](https://github.com/eclipse-ditto/ditto/pull/2442))
+- New `global.featureFlags.policyLockoutPreventionEnabled` to disable the policy:/-WRITE
+  lockout-prevention check in `PoliciesValidator` (useful when namespace-scoped root
+  policies supply the required permission)
+  ([#2456](https://github.com/eclipse-ditto/ditto/pull/2456))
 
 ## [4.0.0]
 

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.1.0  # chart version is effectively set by release-job
+version: 4.1.2  # chart version is effectively set by release-job
 appVersion: 3.9.0
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -222,6 +222,8 @@ spec:
               value: "{{ .Values.global.featureFlags.policyEnforcementUseThroughputOptimizedEvaluatorEnabled }}"
             - name: DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED
               value: "{{ .Values.global.featureFlags.stacklessFlowControlExceptionsEnabled }}"
+            - name: DITTO_DEVOPS_FEATURE_POLICY_LOCKOUT_PREVENTION_ENABLED
+              value: "{{ .Values.global.featureFlags.policyLockoutPreventionEnabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_ENABLED
               value: "{{ .Values.global.metrics.liveEntities.enabled }}"
             - name: DITTO_METRICS_LIVE_ENTITIES_METRICS_REFRESH_INTERVAL

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -203,6 +203,13 @@ global:
     #  Exceptions with HTTP status >= 500 always keep their stack trace, regardless of this toggle. Set this to
     #  false to restore the legacy behaviour where every Ditto exception captures a writable stack trace.
     stacklessFlowControlExceptionsEnabled: true
+    # policyLockoutPreventionEnabled controls whether the PoliciesValidator rejects create/modify operations
+    #  whose resulting policy lacks at least one permanent subject with WRITE permission on resource policy:/.
+    #  When enabled (default), the legacy lockout-prevention check is active. When disabled, the check is bypassed -
+    #  useful in deployments using namespace-scoped root policies (since 3.9.0) where the implicitly imported global
+    #  policy can supply the required permission. The enforcement-side authorize-create-policy check already
+    #  considers namespace-scoped root policies and is unaffected by this toggle.
+    policyLockoutPreventionEnabled: true
   # logging the logging configuration for Ditto
   logging:
     # sysout holds the logging to SYSOUT config

--- a/internal/utils/config/src/main/resources/ditto-devops.conf
+++ b/internal/utils/config/src/main/resources/ditto-devops.conf
@@ -58,5 +58,14 @@ ditto.devops {
     //  -Dditto.devops.feature.stackless-flow-control-exceptions-enabled, NOT from HOCON.
     stackless-flow-control-exceptions-enabled = true
     stackless-flow-control-exceptions-enabled = ${?DITTO_DEVOPS_FEATURE_STACKLESS_FLOW_CONTROL_EXCEPTIONS_ENABLED}
+
+    // enables/disables the policy lockout prevention check in PoliciesValidator.
+    //  When enabled (default), creating or modifying a policy is rejected unless at least one permanent subject in
+    //  the resulting policy has WRITE permission on resource policy:/. When disabled, this check is bypassed —
+    //  useful in deployments using namespace-scoped root policies (since 3.9.0) where the implicitly imported
+    //  global policy can supply the required permission. The enforcement-side check in PolicyCommandEnforcement
+    //  already considers namespace-scoped root policies and is unaffected by this toggle.
+    policy-lockout-prevention-enabled = true
+    policy-lockout-prevention-enabled = ${?DITTO_DEVOPS_FEATURE_POLICY_LOCKOUT_PREVENTION_ENABLED}
   }
 }

--- a/policies/api/src/main/java/org/eclipse/ditto/policies/api/PoliciesValidator.java
+++ b/policies/api/src/main/java/org/eclipse/ditto/policies/api/PoliciesValidator.java
@@ -23,6 +23,7 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.common.Validator;
+import org.eclipse.ditto.base.model.signals.FeatureToggle;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyEntry;
@@ -100,6 +101,13 @@ public final class PoliciesValidator implements Validator {
 
     @Override
     public boolean isValid() {
+        // Operator-level opt-out: with namespace-scoped root policies (since 3.9.0), the implicitly imported global
+        // policy may supply the required WRITE on policy:/ that this validator would otherwise demand from the
+        // policy's own entries. The validator has no access to the namespace-policies config, so we short-circuit
+        // when the operator has disabled lockout prevention globally.
+        if (!FeatureToggle.isPolicyLockoutPreventionEnabled()) {
+            return true;
+        }
         if (containsPolicyImport) {
             return true;
         } else {


### PR DESCRIPTION
## Summary

`PoliciesValidator` unconditionally rejects any create/modify operation whose resulting policy lacks a permanent subject with `WRITE` on `policy:/`. With namespace-scoped root policies (since 3.9.0), the implicitly imported global policy may already supply that permission — but the validator lives in `policies/api` with no access to `NamespacePoliciesConfig`, so it cannot see those merged-in subjects and legitimate modifications get rejected.

This PR introduces the `ditto.devops.feature.policy-lockout-prevention-enabled` feature toggle (default `true`, preserving current behaviour) so operators of namespace-scoped-root deployments can disable the validator's check.

## Details

- New `POLICY_LOCKOUT_PREVENTION_ENABLED` constant + `isPolicyLockoutPreventionEnabled()` accessor in `FeatureToggle` (`@since 3.9.1`).
- `PoliciesValidator.isValid()` short-circuits to `true` when the toggle is off, ahead of the existing `containsPolicyImport` short-circuit.
- HOCON entry in `ditto-devops.conf`, JVM-property bridge in `DittoService`, Helm values + policies-deployment env-var wiring.
- The enforcement-side `PolicyCommandEnforcement.authorizeCreatePolicy` is **untouched**: its enforcer is built via `PolicyEnforcer.withResolvedImportsAndNamespacePolicies`, which already merges namespace roots into the enforcer view — so `hasUnrestrictedWritePermission` correctly counts WRITE-on-`policy:/` that originates from the namespace root, and no toggle is needed there.