### PR TITLE
Fix resolved policy view dropping imports when source-side READ comes via namespace-root

### DIFF
--- a/documentation/src/main/resources/pages/ditto/release_notes_391.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_391.md
@@ -49,6 +49,18 @@ fired every 5 minutes and the actor was shut down as soon as no command arrived 
 than the configured `inactive-interval` would suggest. The fix affects all subclasses of `AbstractPersistenceActor`
 (Thing, Policy, Connection); behavior for deleted entities is unchanged.
 
+#### Fix resolved policy view dropping imports when source-side READ comes via namespace-root
+
+PR [#2458](https://github.com/eclipse-ditto/ditto/pull/2458) fixes a regression in the `?policy-view=resolved`
+response where every entry contributed by a declared import was silently stripped when the caller's READ on the
+imported policy came solely from an operator-configured namespace-root policy. `PolicyCommandEnforcement` built each
+source enforcer with `withResolvedImports` — without merging namespace-root entries — so the source-side READ filter
+evaluated `policy:/entries/<label>` against the source policy's own subjects only. A caller whose access to the
+source came only via the namespace-root (e.g. a global devops admin) lost every `imported-<srcId>-…` entry from the
+resolved view, while imports that happened to contain a directly-authenticating subject still worked. Source
+enforcers now use `withResolvedImportsAndNamespacePolicies`, mirroring the importing-policy evaluation; the existing
+security tests still pass — a caller with no legitimate path to the source still loses the entries.
+
 ### Helm Chart
 
 The following changes were included via the `helm-chart-4.1.0` milestone (see the complete list of

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
@@ -22,28 +22,41 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.AllowedAddition;
+import org.eclipse.ditto.policies.model.EffectedImports;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.PolicyRevision;
 import org.eclipse.ditto.policies.model.Resource;
+import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.Resources;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectId;
@@ -274,6 +287,189 @@ public final class PolicyEnforcerCacheTest {
             // Leaf is still cached — template change no longer cascades to it
             verifyLoadedFromCache(leafPolicyWithoutTransitive, underTest, cacheLoader);
         }};
+    }
+
+    /**
+     * Integration-style cache test for the customer-shaped 3-policy graph (template / main-with-references /
+     * leaf-with-transitiveImports). Unlike the other tests in this file, this one wires a real
+     * {@link com.github.benmanes.caffeine.cache.AsyncCacheLoader} that actually runs
+     * {@link PolicyEnforcer#withResolvedImportsAndNamespacePolicies} against an in-memory map of raw policies,
+     * so the test exercises both:
+     * <ol>
+     *   <li>that the model layer's reference resolution materializes main's {@code importable=implicit}
+     *       entries with subjects merged in from a locally-referenced {@code importable=explicit} entry
+     *       (the symptom that motivated this test — entries were observed missing in the resolved leaf view), and</li>
+     *   <li>that {@code invalidate(mainId)} cascades to the leaf and the subsequent cache load actually re-resolves
+     *       leaf against the updated main, so a change to main's MANAGER subject is observable in leaf's
+     *       resolved view without restart.</li>
+     * </ol>
+     */
+    @Test
+    public void transitiveImportWithLocalReferenceIsResolvedAndCacheReloadsOnMainChange() throws Exception {
+        // ===== Build the 3-policy customer-shaped graph =====
+        final PolicyId templateId = PolicyId.of("test.cache", "template");
+        final PolicyId mainId = PolicyId.of("test.cache", "main");
+        final PolicyId leafId = PolicyId.of("test.cache", "leaf");
+
+        final Label roomAccessLabel = Label.of("ROOM_ACCESS");
+        final Label managerLabel = Label.of("MANAGER");
+        final ResourceKey roomThing = ResourceKey.newInstance("thing", JsonPointer.of("features/room"));
+
+        // template: IMPLICIT ROOM_ACCESS with READ on thing:/features/room, no subjects,
+        // allowedAdditions=[SUBJECTS] so consumers may attach subjects but not extra resources.
+        final PolicyEntry templateRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(Resource.newInstance(roomThing,
+                        EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+        final Policy template = PoliciesModelFactory.newPolicyBuilder(templateId)
+                .setRevision(1L)
+                .set(templateRoom)
+                .build();
+
+        // main: imports template; carries the manager subject in an EXPLICIT entry (not pulled into the leaf
+        // because leaf imports main with entries:[]); plus a per-resource IMPLICIT ROOM_ACCESS entry that only
+        // declares references — one local to MANAGER (for subjects), one import-ref to template's ROOM_ACCESS
+        // (for resources). This is the entry the customer observed missing in the resolved leaf view.
+        final SubjectId aliceId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "alice");
+        final PolicyEntry mainManager = PoliciesModelFactory.newPolicyEntry(managerLabel,
+                Subjects.newInstance(Subject.newInstance(aliceId)),
+                PoliciesModelFactory.emptyResources(),
+                ImportableType.EXPLICIT);
+        final PolicyEntry mainRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null,
+                Arrays.asList(
+                        PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                        PoliciesModelFactory.newEntryReference(templateId, roomAccessLabel)));
+        final Policy main = PoliciesModelFactory.newPolicyBuilder(mainId)
+                .setRevision(1L)
+                .set(mainManager)
+                .set(mainRoom)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(templateId, (EffectedImports) null))
+                .build();
+
+        // leaf: imports main with empty entries list + transitiveImports=[template], no own entries.
+        final EffectedImports leafImportOfMain = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), Collections.singletonList(templateId));
+        final Policy leaf = PoliciesModelFactory.newPolicyBuilder(leafId)
+                .setRevision(1L)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(mainId, leafImportOfMain))
+                .build();
+
+        // ===== Wire the cache with a map-backed loader that runs real reference resolution =====
+        final ConcurrentMap<PolicyId, Policy> policies = new ConcurrentHashMap<>();
+        policies.put(templateId, template);
+        policies.put(mainId, main);
+        policies.put(leafId, leaf);
+
+        final NamespacePoliciesConfig nsConfig =
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config());
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> loader =
+                new MapBackedPolicyEnforcerCacheLoader(policies, nsConfig);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final PolicyEnforcerCache cache = new PolicyEnforcerCache(
+                loader, executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                nsConfig);
+
+        new TestKit(actorSystem) {{
+            // ===== Phase 1: First read of leaf — verify entries with merged references are present =====
+            final Optional<Entry<PolicyEnforcer>> leafEntry1 = cache.get(leafId).toCompletableFuture().join();
+            final Policy leafResolved1 = leafEntry1
+                    .flatMap(Entry::get)
+                    .flatMap(PolicyEnforcer::getPolicy)
+                    .orElseThrow(() -> new AssertionError("leaf failed to load"));
+
+            final Label mainPrefixedRoom = PoliciesModelFactory.newImportedLabel(mainId, roomAccessLabel);
+            final PolicyEntry roomEntry1 = leafResolved1.getEntryFor(mainPrefixedRoom)
+                    .orElseThrow(() -> new AssertionError(
+                            "imported-<mainId>-ROOM_ACCESS missing from leaf's resolved view — " +
+                                    "the IMPLICIT entry with a local reference to an EXPLICIT MANAGER " +
+                                    "entry must survive the import + reference resolution"));
+
+            assertThat(subjectIdsOf(roomEntry1))
+                    .as("local reference to EXPLICIT MANAGER must merge alice into ROOM_ACCESS")
+                    .contains(aliceId.toString());
+            assertThat(roomEntry1.getResources().getResource(roomThing))
+                    .as("import reference to template:ROOM_ACCESS must merge template's resource")
+                    .isPresent();
+
+            // ===== Phase 2: Update main — replace MANAGER's alice subject with bob =====
+            final SubjectId bobId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "bob");
+            final PolicyEntry mainManagerUpdated = PoliciesModelFactory.newPolicyEntry(managerLabel,
+                    Subjects.newInstance(Subject.newInstance(bobId)),
+                    PoliciesModelFactory.emptyResources(),
+                    ImportableType.EXPLICIT);
+            final Policy mainUpdated = PoliciesModelFactory.newPolicyBuilder(mainId)
+                    .setRevision(2L)
+                    .set(mainManagerUpdated)
+                    .set(mainRoom)
+                    .setPolicyImport(PoliciesModelFactory.newPolicyImport(templateId, (EffectedImports) null))
+                    .build();
+            policies.put(mainId, mainUpdated);
+
+            // ===== Phase 3: Invalidate main — must cascade to leaf via the main → leaf edge =====
+            cache.invalidate(mainId);
+
+            // ===== Phase 4: Re-read leaf — must reflect updated MANAGER subject =====
+            final Optional<Entry<PolicyEnforcer>> leafEntry2 = cache.get(leafId).toCompletableFuture().join();
+            final Policy leafResolved2 = leafEntry2
+                    .flatMap(Entry::get)
+                    .flatMap(PolicyEnforcer::getPolicy)
+                    .orElseThrow(() -> new AssertionError("leaf failed to reload"));
+
+            final PolicyEntry roomEntry2 = leafResolved2.getEntryFor(mainPrefixedRoom)
+                    .orElseThrow(() -> new AssertionError(
+                            "imported-<mainId>-ROOM_ACCESS missing from leaf after main invalidation"));
+            assertThat(subjectIdsOf(roomEntry2))
+                    .as("after invalidate(mainId), reloaded leaf must reflect MANAGER's new subject")
+                    .contains(bobId.toString())
+                    .doesNotContain(aliceId.toString());
+        }};
+    }
+
+    private static Set<String> subjectIdsOf(final PolicyEntry entry) {
+        return StreamSupport.stream(entry.getSubjects().spliterator(), false)
+                .map(s -> s.getId().toString())
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Map-backed {@link AsyncCacheLoader} that mirrors the production {@link PolicyEnforcerCacheLoader}:
+     * fetches the raw policy from an in-memory map, then resolves imports + references via the same map.
+     * The resolver is rebuilt on every load and reads the current map state, so updates published into the
+     * map are picked up by the next cache miss.
+     */
+    private static final class MapBackedPolicyEnforcerCacheLoader
+            implements AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> {
+
+        private final ConcurrentMap<PolicyId, Policy> policies;
+        private final NamespacePoliciesConfig namespacePoliciesConfig;
+
+        MapBackedPolicyEnforcerCacheLoader(final ConcurrentMap<PolicyId, Policy> policies,
+                final NamespacePoliciesConfig namespacePoliciesConfig) {
+            this.policies = policies;
+            this.namespacePoliciesConfig = namespacePoliciesConfig;
+        }
+
+        @Override
+        public CompletableFuture<Entry<PolicyEnforcer>> asyncLoad(final PolicyId policyId,
+                final Executor executor) {
+            final Policy policy = policies.get(policyId);
+            if (policy == null) {
+                return CompletableFuture.completedFuture(Entry.nonexistent());
+            }
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> resolver =
+                    id -> CompletableFuture.completedFuture(Optional.ofNullable(policies.get(id)));
+            final long revision = policy.getRevision().map(PolicyRevision::toLong).orElse(1L);
+            return PolicyEnforcer
+                    .withResolvedImportsAndNamespacePolicies(policy, resolver, namespacePoliciesConfig)
+                    .thenApply(enforcer -> Entry.of(revision, enforcer))
+                    .toCompletableFuture();
+        }
     }
 
     @Test

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/PolicyImporterTest.java
@@ -26,7 +26,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
 import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers;
 import org.junit.Test;
 
 /**
@@ -1276,6 +1281,179 @@ public final class PolicyImporterTest {
                 .map(s -> s.getId().toString())
                 .collect(java.util.stream.Collectors.toSet());
         assertThat(subjectIds).contains("google:alice", "google:bob", "google:charlie");
+    }
+
+    /**
+     * Customer-shaped 3-level scenario combining transitiveImports, import references and local
+     * references in a single policy graph:
+     * <ul>
+     *   <li><b>template</b> — defines per-resource access entries (READ on a thing path + WRITE on a
+     *       message path), each {@code importable=implicit} with {@code allowedAdditions=[SUBJECTS]}
+     *       so consumers may attach subjects but not extra resources.</li>
+     *   <li><b>main</b> — imports template (full). Holds a single subject-bearing entry
+     *       ({@code importable=explicit}, so it is not pulled along by implicit imports), plus one
+     *       implicit per-resource entry per template entry. Each implicit entry has no own subjects
+     *       or resources; it only declares two references: one local to the subject-bearing entry,
+     *       and one import-reference to the matching template entry.</li>
+     *   <li><b>leaf</b> — imports main with {@code entries: []} and
+     *       {@code transitiveImports: [template]}, no entries of its own. Models a downstream
+     *       policy that only wants main's resolved access entries.</li>
+     * </ul>
+     *
+     * Verifies that leaf's effective policy contains the per-resource entries from main with
+     * template's resources merged in AND main's subject attached via the local reference, and that
+     * the resulting policy actually grants those permissions to the configured subject while
+     * denying everyone else.
+     */
+    @Test
+    public void testTransitiveImportWithLocalAndImportReferencesAppliesPermissions() {
+        final PolicyId templateId = PolicyId.of("com.example", "template");
+        final PolicyId mainId = PolicyId.of("com.example", "main");
+        final PolicyId leafId = PolicyId.of("com.example", "leaf");
+
+        final Label roomAccessLabel = Label.of("ROOM_ACCESS");
+        final Label buildingAccessLabel = Label.of("BUILDING_ACCESS");
+        final Label managerLabel = Label.of("MANAGER");
+
+        final ResourceKey roomThing = ResourceKey.newInstance("thing", JsonPointer.of("features/room"));
+        final ResourceKey roomInbox = ResourceKey.newInstance("message", JsonPointer.of("features/room/inbox"));
+        final ResourceKey buildingThing = ResourceKey.newInstance("thing", JsonPointer.of("features/building"));
+        final ResourceKey unrelatedThing = ResourceKey.newInstance("thing", JsonPointer.of("features/secret"));
+
+        // --- template: resource-bearing entries, no subjects, allowedAdditions = [SUBJECTS] ---
+        final PolicyEntry templateRoomAccess = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(
+                        Resource.newInstance(roomThing, EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none())),
+                        Resource.newInstance(roomInbox, EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_WRITE),
+                                Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+
+        final PolicyEntry templateBuildingAccess = PoliciesModelFactory.newPolicyEntry(buildingAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(
+                        Resource.newInstance(buildingThing, EffectedPermissions.newInstance(
+                                Permissions.newInstance(TestConstants.Policy.PERMISSION_READ),
+                                Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+
+        final Policy templatePolicy = PoliciesModelFactory.newPolicyBuilder(templateId)
+                .set(templateRoomAccess)
+                .set(templateBuildingAccess)
+                .build();
+
+        // --- main: imports template, holds the subject in an EXPLICIT local entry, then declares
+        //     per-resource IMPLICIT entries that only reference (local subject + template entry). ---
+        final SubjectId managerSubjectId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "facilityManager");
+        final PolicyEntry mainManager = ImmutablePolicyEntry.of(managerLabel,
+                Subjects.newInstance(Subject.newInstance(managerSubjectId)),
+                PoliciesModelFactory.emptyResources(),
+                ImportableType.EXPLICIT);
+
+        final PolicyEntry mainRoomAccess = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null,
+                Arrays.asList(
+                        PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                        PoliciesModelFactory.newEntryReference(templateId, roomAccessLabel)));
+
+        final PolicyEntry mainBuildingAccess = PoliciesModelFactory.newPolicyEntry(buildingAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null,
+                Arrays.asList(
+                        PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                        PoliciesModelFactory.newEntryReference(templateId, buildingAccessLabel)));
+
+        final Policy mainPolicy = PoliciesModelFactory.newPolicyBuilder(mainId)
+                .set(mainManager)
+                .set(mainRoomAccess)
+                .set(mainBuildingAccess)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(templateId, (EffectedImports) null))
+                .build();
+
+        // --- leaf: imports main with transitiveImports=[template], no entries of its own. ---
+        final EffectedImports leafImportOfMain = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), Collections.singletonList(templateId));
+        final Policy leafPolicy = PoliciesModelFactory.newPolicyBuilder(leafId)
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(mainId, leafImportOfMain))
+                .build();
+
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> loader = id -> {
+            if (templateId.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(templatePolicy));
+            } else if (mainId.equals(id)) {
+                return CompletableFuture.completedFuture(Optional.of(mainPolicy));
+            }
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        // --- Resolve leaf's effective policy. ---
+        final Policy resolved = leafPolicy.withResolvedImports(loader).toCompletableFuture().join();
+
+        // EXPLICIT manager entry must not leak through implicit-only import.
+        final Label mainPrefixedManager = PoliciesModelFactory.newImportedLabel(mainId, managerLabel);
+        assertThat(resolved.getEntryFor(mainPrefixedManager)).isNotPresent();
+
+        // Per-resource entries from main must appear under the main-import prefix
+        // with template's resources merged in via the import-reference, and the
+        // manager's subject merged in via the local reference.
+        final Label mainPrefixedRoom = PoliciesModelFactory.newImportedLabel(mainId, roomAccessLabel);
+        final PolicyEntry resolvedRoom = resolved.getEntryFor(mainPrefixedRoom)
+                .orElseThrow(() -> new AssertionError("Expected ROOM_ACCESS entry not found"));
+        final Set<String> roomSubjectIds = StreamSupport.stream(resolvedRoom.getSubjects().spliterator(), false)
+                .map(s -> s.getId().toString())
+                .collect(java.util.stream.Collectors.toSet());
+        assertThat(roomSubjectIds).containsExactly(managerSubjectId.toString());
+        assertThat(resolvedRoom.getResources().getResource(roomThing)).isPresent();
+        assertThat(resolvedRoom.getResources().getResource(roomInbox)).isPresent();
+
+        final Label mainPrefixedBuilding = PoliciesModelFactory.newImportedLabel(mainId, buildingAccessLabel);
+        final PolicyEntry resolvedBuilding = resolved.getEntryFor(mainPrefixedBuilding)
+                .orElseThrow(() -> new AssertionError("Expected BUILDING_ACCESS entry not found"));
+        final Set<String> buildingSubjectIds = StreamSupport.stream(resolvedBuilding.getSubjects().spliterator(), false)
+                .map(s -> s.getId().toString())
+                .collect(java.util.stream.Collectors.toSet());
+        assertThat(buildingSubjectIds).containsExactly(managerSubjectId.toString());
+        assertThat(resolvedBuilding.getResources().getResource(buildingThing)).isPresent();
+
+        // --- Verify the resolved policy actually enforces these permissions. ---
+        final Enforcer enforcer = PolicyEnforcers.defaultEvaluator(resolved);
+        final AuthorizationContext managerCtx = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED,
+                AuthorizationSubject.newInstance(managerSubjectId.toString()));
+        final AuthorizationContext strangerCtx = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED,
+                AuthorizationSubject.newInstance("google:stranger"));
+
+        assertThat(enforcer.hasUnrestrictedPermissions(roomThing, managerCtx,
+                TestConstants.Policy.PERMISSION_READ)).isTrue();
+        assertThat(enforcer.hasUnrestrictedPermissions(roomInbox, managerCtx,
+                TestConstants.Policy.PERMISSION_WRITE)).isTrue();
+        assertThat(enforcer.hasUnrestrictedPermissions(buildingThing, managerCtx,
+                TestConstants.Policy.PERMISSION_READ)).isTrue();
+
+        // Permissions not granted by the template must not be available.
+        assertThat(enforcer.hasUnrestrictedPermissions(roomThing, managerCtx,
+                TestConstants.Policy.PERMISSION_WRITE)).isFalse();
+        assertThat(enforcer.hasUnrestrictedPermissions(buildingThing, managerCtx,
+                TestConstants.Policy.PERMISSION_WRITE)).isFalse();
+        assertThat(enforcer.hasUnrestrictedPermissions(unrelatedThing, managerCtx,
+                TestConstants.Policy.PERMISSION_READ)).isFalse();
+
+        // A different subject must not be authorized by any of the resolved entries.
+        assertThat(enforcer.hasUnrestrictedPermissions(roomThing, strangerCtx,
+                TestConstants.Policy.PERMISSION_READ)).isFalse();
+        assertThat(enforcer.hasUnrestrictedPermissions(roomInbox, strangerCtx,
+                TestConstants.Policy.PERMISSION_WRITE)).isFalse();
+        assertThat(enforcer.hasUnrestrictedPermissions(buildingThing, strangerCtx,
+                TestConstants.Policy.PERMISSION_READ)).isFalse();
     }
 
     /**

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcement.java
@@ -309,9 +309,15 @@ public final class PolicyCommandEnforcement
     }
 
     private CompletableFuture<Optional<PolicyEnforcer>> resolveSourceEnforcer(final PolicyId sourceId) {
+        // Source-side READ checks must see the same effective grants the caller has on the source policy at
+        // enforcement time, which includes operator-configured namespace-root entries. Without the ns-policy
+        // merge, a caller whose READ on the source comes only via the namespace-root (e.g. a global devops
+        // admin) fails hasSourceSideRead for every entry in the source and silently loses all imported
+        // entries in the resolved view.
         return policyResolver.apply(sourceId)
                 .thenCompose(opt -> opt.isPresent()
-                        ? PolicyEnforcer.withResolvedImports(opt.get(), policyResolver).thenApply(Optional::of)
+                        ? PolicyEnforcer.withResolvedImportsAndNamespacePolicies(opt.get(), policyResolver,
+                                namespacePoliciesConfig).thenApply(Optional::of)
                         : CompletableFuture.completedFuture(Optional.<PolicyEnforcer>empty()))
                 .toCompletableFuture();
     }

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementResolvedViewTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementResolvedViewTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.policies.service.enforcement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -27,23 +28,33 @@ import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.AllowedAddition;
 import org.eclipse.ditto.policies.model.EffectedImports;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.EntryReference;
 import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
 import org.eclipse.ditto.policies.model.PolicyImports;
+import org.eclipse.ditto.policies.model.Resource;
 import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.Resources;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommandResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyResponse;
 import org.junit.Test;
@@ -154,6 +165,297 @@ public final class PolicyCommandEnforcementResolvedViewTest {
         assertThat(filteredEntries.toString())
                 .as("ADMIN subject must not leak via namespace-root entry")
                 .doesNotContain(ADMIN_ID.toString());
+    }
+
+    /**
+     * Customer-shaped 3-policy graph driven end-to-end through {@link PolicyCommandEnforcement#filterResponse}
+     * for a resolved-view request: template defines per-resource access entries, an intermediate "main" policy
+     * imports the template and uses local + import references to combine a manager subject with the template's
+     * resources, and a leaf policy imports main with {@code transitiveImports=[template]} and no entries of its
+     * own.
+     *
+     * <p>Verifies that the rebuilt response JSON contains main's per-resource access entries (with the
+     * manager subject and template resources merged in via references) under the {@code imported-<mainId>-<label>}
+     * prefix, that the EXPLICIT manager-only entry is not pulled into the leaf (leaf imports main with empty
+     * entries list), and that none of these entries are dropped by the source-side READ filter — the viewer
+     * has source-side READ on main via an IMPLICIT VIEWER entry that grants {@code policy:/ READ} to the
+     * caller subject.</p>
+     */
+    @Test
+    public void resolvedViewMergesTransitiveImportAndReferencesEndToEnd() throws Exception {
+        final PolicyId leafId = IMPORTING_ID;
+        final PolicyId mainId = PolicyId.of("test.nsleak", "main");
+        final PolicyId templateId = PolicyId.of("test.nsleak", "template");
+
+        final Label viewerLabel = Label.of("VIEWER");
+        final Label managerLabel = Label.of("MANAGER");
+        final Label roomAccessLabel = Label.of("ROOM_ACCESS");
+        final Label buildingAccessLabel = Label.of("BUILDING_ACCESS");
+
+        final ResourceKey roomThing = ResourceKey.newInstance("thing", JsonPointer.of("features/room"));
+        final ResourceKey roomInbox = ResourceKey.newInstance("message", JsonPointer.of("features/room/inbox"));
+        final ResourceKey buildingThing = ResourceKey.newInstance("thing", JsonPointer.of("features/building"));
+
+        // --- template: resource-bearing entries, no subjects, allowedAdditions=[SUBJECTS]. ---
+        final PolicyEntry templateRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(
+                        Resource.newInstance(roomThing, EffectedPermissions.newInstance(
+                                Permissions.newInstance(Permission.READ), Permissions.none())),
+                        Resource.newInstance(roomInbox, EffectedPermissions.newInstance(
+                                Permissions.newInstance(Permission.WRITE), Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+        final PolicyEntry templateBuilding = PoliciesModelFactory.newPolicyEntry(buildingAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(
+                        Resource.newInstance(buildingThing, EffectedPermissions.newInstance(
+                                Permissions.newInstance(Permission.READ), Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+        final Policy template = PoliciesModelFactory.newPolicyBuilder(templateId)
+                .set(templateRoom)
+                .set(templateBuilding)
+                .build();
+
+        // --- main: imports template; carries the manager subject in an EXPLICIT-only entry (not pulled
+        //     into the leaf), per-resource IMPLICIT entries with references only, plus an IMPLICIT VIEWER
+        //     entry granting the caller policy:/ READ so the source-side READ check passes for every entry. ---
+        final SubjectId managerSubjectId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "manager");
+        final PolicyEntry mainViewer = PoliciesModelFactory.newPolicyEntry(viewerLabel,
+                Subjects.newInstance(Subject.newInstance(VIEWER_ID)),
+                Resources.newInstance(Resource.newInstance(POLICY_ROOT, EffectedPermissions.newInstance(
+                        Permissions.newInstance(Permission.READ), Permissions.none()))),
+                ImportableType.IMPLICIT);
+        final PolicyEntry mainManager = PoliciesModelFactory.newPolicyEntry(managerLabel,
+                Subjects.newInstance(Subject.newInstance(managerSubjectId)),
+                PoliciesModelFactory.emptyResources(),
+                ImportableType.EXPLICIT);
+        final List<EntryReference> roomRefs = Arrays.asList(
+                PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                PoliciesModelFactory.newEntryReference(templateId, roomAccessLabel));
+        final List<EntryReference> buildingRefs = Arrays.asList(
+                PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                PoliciesModelFactory.newEntryReference(templateId, buildingAccessLabel));
+        final PolicyEntry mainRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null, roomRefs);
+        final PolicyEntry mainBuilding = PoliciesModelFactory.newPolicyEntry(buildingAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null, buildingRefs);
+        final Policy main = PoliciesModelFactory.newPolicyBuilder(mainId)
+                .set(mainViewer)
+                .set(mainManager)
+                .set(mainRoom)
+                .set(mainBuilding)
+                .setPolicyImports(PolicyImports.newInstance(PoliciesModelFactory.newPolicyImport(
+                        templateId, (EffectedImports) null)))
+                .build();
+
+        // --- leaf: imports main with empty entries list + transitiveImports=[template], no own entries. ---
+        final EffectedImports leafImport = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), Collections.singletonList(templateId));
+        final Policy leaf = PoliciesModelFactory.newPolicyBuilder(leafId)
+                .setPolicyImports(PolicyImports.newInstance(
+                        PoliciesModelFactory.newPolicyImport(mainId, leafImport)))
+                .build();
+
+        final JsonObject filteredEntries = runResolvedView(leaf,
+                policyResolver(leaf, main, template), emptyNamespacePoliciesConfig());
+
+        // Per-resource entries from main appear under imported-<mainId>-<label> with references resolved:
+        // manager's subject from the local reference + template's resources from the import reference.
+        // Resource keys ("thing:/features/room") contain slashes that JsonPointer interprets as path
+        // separators, so navigate level by level via getField rather than dotted pointer paths.
+        final String mainPrefixedRoom = "imported-" + mainId + "-" + roomAccessLabel;
+        assertThat(filteredEntries.getField(mainPrefixedRoom))
+                .as("resolved leaf must expose main's ROOM_ACCESS under the imported-<mainId>- prefix")
+                .isPresent();
+        final JsonObject roomEntry = filteredEntries.getField(mainPrefixedRoom)
+                .orElseThrow().getValue().asObject();
+        final JsonObject roomSubjects = roomEntry.getField("subjects").orElseThrow().getValue().asObject();
+        assertThat(roomSubjects.getField(managerSubjectId.toString()))
+                .as("ROOM_ACCESS subject must be merged in from the local reference to MANAGER")
+                .isPresent();
+        // Resource keys carry '/' (e.g. "thing:/features/room"), which both getValue() and getField()
+        // would parse as JsonPointer separators, so check membership via the literal key list instead.
+        final List<String> roomResourceKeys = roomEntry.getField("resources").orElseThrow().getValue().asObject()
+                .getKeys().stream().map(JsonKey::toString).toList();
+        assertThat(roomResourceKeys)
+                .as("ROOM_ACCESS must inherit template's resources")
+                .contains("thing:/features/room", "message:/features/room/inbox");
+
+        final String mainPrefixedBuilding = "imported-" + mainId + "-" + buildingAccessLabel;
+        final JsonObject buildingEntry = filteredEntries.getField(mainPrefixedBuilding)
+                .orElseThrow().getValue().asObject();
+        final JsonObject buildingSubjects = buildingEntry.getField("subjects").orElseThrow().getValue().asObject();
+        assertThat(buildingSubjects.getField(managerSubjectId.toString())).isPresent();
+        final List<String> buildingResourceKeys = buildingEntry.getField("resources").orElseThrow().getValue()
+                .asObject().getKeys().stream().map(JsonKey::toString).toList();
+        assertThat(buildingResourceKeys).contains("thing:/features/building");
+
+        // Bare template entries land transitively under imported-<mainId>-imported-<templateId>-<label>.
+        // They carry the template's resources but no subjects (no contribution to enforcement).
+        final String mainPrefixedTemplateRoom = "imported-" + mainId + "-imported-" + templateId
+                + "-" + roomAccessLabel;
+        assertThat(filteredEntries.getField(mainPrefixedTemplateRoom))
+                .as("template's ROOM_ACCESS must be present as a transitive nested-prefix entry")
+                .isPresent();
+
+        // The EXPLICIT MANAGER entry is not selected (leaf's import has entries:[]), so it must not appear.
+        final String mainPrefixedManager = "imported-" + mainId + "-" + managerLabel;
+        assertThat(filteredEntries.getField(mainPrefixedManager))
+                .as("EXPLICIT MANAGER entry must not leak through implicit-only import")
+                .isNotPresent();
+
+        // Source-side READ filter must NOT have dropped the imported entries — the viewer has READ on
+        // policy:/ via main's VIEWER entry, which passes hasSourceSideRead() for every entry in main.
+        assertThat(filteredEntries.toString())
+                .as("manager subject must be exposed because viewer has source-side READ on main")
+                .contains(managerSubjectId.toString());
+    }
+
+    /**
+     * Regression test for the production symptom captured in {@code /tmp/cit-rg-resolved-{before,after}.json}:
+     * a leaf policy with seven imports — one of which uses {@code transitiveImports} into a "main" policy that
+     * holds the manager subject in an {@code importable=explicit} entry and exposes resources only via
+     * {@code importable=implicit} entries with local + import {@code references} — was returning a resolved
+     * view that contained entries from six of the seven imports but was missing every entry contributed by the
+     * {@code main} import.
+     *
+     * <p>Root cause: {@link PolicyCommandEnforcement#resolveSourceEnforcer} built each source enforcer with
+     * {@link PolicyEnforcer#withResolvedImports} — without namespace-root policies. The source-side READ filter
+     * inside {@link PolicyCommandEnforcement#mergeAndDropUnreadable} therefore evaluated the caller's
+     * {@code policy:/entries/&lt;label&gt;} READ against the source's own subjects only. A caller whose READ on
+     * main comes solely from the operator-configured namespace-root (e.g. a global devops admin) failed
+     * {@code hasSourceSideRead} for every entry in main, and every {@code imported-&lt;mainId&gt;-…} entry was
+     * stripped. Fix: source enforcers are now built with
+     * {@link PolicyEnforcer#withResolvedImportsAndNamespacePolicies} so namespace-root subjects participate in
+     * the source-side READ evaluation the same way they do in the importing-policy evaluation. The two existing
+     * tests in this class pin the security invariant — a caller with no legitimate path to the source still
+     * gets the entries dropped.</p>
+     */
+    @Test
+    public void resolvedViewExposesImportedEntriesWhenCallerHasReadOnSourceViaNamespaceRoot() throws Exception {
+        // Caller has no direct subject in 'main'; their access on main comes only from the namespace-root policy.
+        // The leafId reused from IMPORTING_ID stays in the same "test.nsleak" namespace as main, so both are
+        // covered by the same namespace-root binding below.
+        final PolicyId leafId = IMPORTING_ID;
+        final PolicyId mainId = PolicyId.of("test.nsleak", "main");
+        final PolicyId templateId = PolicyId.of("test.nsleak", "template");
+        final PolicyId nsRootId = PolicyId.of("global", "admin-access");
+
+        final Label managerLabel = Label.of("MANAGER");
+        final Label roomAccessLabel = Label.of("ROOM_ACCESS");
+        final Label devopsLabel = Label.of("DEVOPS_ADMIN");
+        final ResourceKey roomThing = ResourceKey.newInstance("thing", JsonPointer.of("features/room"));
+
+        // --- namespace-root policy: grants the caller policy:/ READ+WRITE across the namespace. ---
+        final SubjectId devopsId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "devops-admin");
+        final Policy nsRoot = Policy.newBuilder(nsRootId)
+                .forLabel(devopsLabel)
+                .setSubject(Subject.newInstance(devopsId))
+                .setGrantedPermissions(POLICY_ROOT, Permission.READ, Permission.WRITE)
+                .setGrantedPermissions(THING_ROOT, Permission.READ, Permission.WRITE)
+                .setImportable(ImportableType.IMPLICIT)
+                .build();
+
+        // --- template: IMPLICIT access entry with resources, no subjects, allowedAdditions=[SUBJECTS]. ---
+        final PolicyEntry templateRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                Resources.newInstance(Resource.newInstance(roomThing, EffectedPermissions.newInstance(
+                        Permissions.newInstance(Permission.READ), Permissions.none()))),
+                null, ImportableType.IMPLICIT,
+                Collections.singleton(AllowedAddition.SUBJECTS), null);
+        final Policy template = PoliciesModelFactory.newPolicyBuilder(templateId)
+                .set(templateRoom)
+                .build();
+
+        // --- main: imports template; manager subject lives in an EXPLICIT entry (never pulled into leaf via
+        //     entries:[], but referenced locally by ROOM_ACCESS); resource access lives in an IMPLICIT entry
+        //     with no own subjects/resources and only references. Crucially, NO entry in main grants the caller
+        //     any policy:/ permission — the caller's source-side READ depends entirely on the namespace-root
+        //     policy that the current resolveSourceEnforcer fails to merge in. ---
+        final SubjectId managerId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "manager");
+        final PolicyEntry mainManager = PoliciesModelFactory.newPolicyEntry(managerLabel,
+                Subjects.newInstance(Subject.newInstance(managerId)),
+                PoliciesModelFactory.emptyResources(),
+                ImportableType.EXPLICIT);
+        final List<EntryReference> roomRefs = Arrays.asList(
+                PoliciesModelFactory.newLocalEntryReference(managerLabel),
+                PoliciesModelFactory.newEntryReference(templateId, roomAccessLabel));
+        final PolicyEntry mainRoom = PoliciesModelFactory.newPolicyEntry(roomAccessLabel,
+                PoliciesModelFactory.emptySubjects(),
+                PoliciesModelFactory.emptyResources(),
+                null, ImportableType.IMPLICIT, null, roomRefs);
+        final Policy main = PoliciesModelFactory.newPolicyBuilder(mainId)
+                .set(mainManager)
+                .set(mainRoom)
+                .setPolicyImports(PolicyImports.newInstance(PoliciesModelFactory.newPolicyImport(
+                        templateId, (EffectedImports) null)))
+                .build();
+
+        // --- leaf: imports main with empty entries list + transitiveImports=[template], no own entries.
+        //     The caller's only avenue to READ leaf is via the namespace-root binding configured below. ---
+        final EffectedImports leafImport = PoliciesModelFactory.newEffectedImportedLabels(
+                Collections.emptyList(), Collections.singletonList(templateId));
+        final Policy leaf = PoliciesModelFactory.newPolicyBuilder(leafId)
+                .setPolicyImports(PolicyImports.newInstance(
+                        PoliciesModelFactory.newPolicyImport(mainId, leafImport)))
+                .build();
+
+        // --- Call as devops admin; bind the namespace test.nsleak to the namespace-root policy so the caller
+        //     gets policy:/ READ+WRITE in leaf via the merged namespace entries. ---
+        final DittoHeaders devopsHeaders = DittoHeaders.newBuilder()
+                .authorizationContext(AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
+                        AuthorizationSubject.newInstance(devopsId)))
+                .putHeader(DittoHeaderDefinition.POLICY_VIEW.getKey(), "resolved")
+                .correlationId("ns-admin-source-side-read-bug")
+                .build();
+        final Function<PolicyId, CompletionStage<Optional<Policy>>> resolver =
+                policyResolver(leaf, main, template, nsRoot);
+        final NamespacePoliciesConfig nsConfig =
+                namespacePoliciesConfigBinding("test.nsleak", nsRootId);
+        final PolicyCommandEnforcement enforcement = new PolicyCommandEnforcement(resolver, nsConfig);
+        final PolicyEnforcer importingEnforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(leaf, resolver, nsConfig)
+                .toCompletableFuture().get();
+        final RetrievePolicyResponse rawResponse = RetrievePolicyResponse.of(leafId, leaf.toJson(), devopsHeaders);
+
+        final PolicyCommandResponse<?> filtered = enforcement.filterResponse(rawResponse, importingEnforcer)
+                .toCompletableFuture().get();
+        final JsonObject filteredEntries = ((RetrievePolicyResponse) filtered).getEntity()
+                .asObject().getValue("entries").orElseThrow().asObject();
+
+        // The namespace-root entry must appear (the caller can read leaf at all only via this entry).
+        final String nsImportedDevops = "nsimported-" + nsRootId + "-" + devopsLabel;
+        assertThat(filteredEntries.getField(nsImportedDevops))
+                .as("namespace-root admin entry must be exposed in the resolved view")
+                .isPresent();
+
+        // EXPECTED (currently failing): main's IMPLICIT ROOM_ACCESS — with manager subject merged from the local
+        // reference and template's resource merged from the import reference — must appear in the resolved view.
+        // ACTUAL: stripped, because resolveSourceEnforcer builds main without namespace-policy merge so the caller's
+        // namespace-root-granted READ is invisible to hasSourceSideRead.
+        final String mainPrefixedRoom = "imported-" + mainId + "-" + roomAccessLabel;
+        assertThat(filteredEntries.getField(mainPrefixedRoom))
+                .as("main's IMPLICIT ROOM_ACCESS must be exposed — caller has READ on every policy in the " +
+                        "namespace via the namespace-root admin entry, so the source-side READ filter " +
+                        "must NOT drop main's contributed entries")
+                .isPresent();
+        final JsonObject roomEntry = filteredEntries.getField(mainPrefixedRoom)
+                .orElseThrow().getValue().asObject();
+        final JsonObject roomSubjects = roomEntry.getField("subjects").orElseThrow().getValue().asObject();
+        assertThat(roomSubjects.getField(managerId.toString()))
+                .as("manager subject must be merged in from main's local reference to MANAGER")
+                .isPresent();
+        final List<String> roomResourceKeys = roomEntry.getField("resources").orElseThrow().getValue().asObject()
+                .getKeys().stream().map(JsonKey::toString).toList();
+        assertThat(roomResourceKeys)
+                .as("template's resource must be merged in via the import reference")
+                .contains("thing:/features/room");
     }
 
     /**


### PR DESCRIPTION
## Summary

`PolicyCommandEnforcement.resolveSourceEnforcer` built each source enforcer with `withResolvedImports`, *without* merging operator-configured namespace-root policies. The source-side READ filter in `mergeAndDropUnreadable` therefore evaluated the caller's `policy:/entries/<label>` READ against the source policy's own subjects only. A caller whose READ on the source came solely via the namespace-root (e.g. a global devops admin) failed `hasSourceSideRead` for every entry in that source, and every `imported-<srcId>-…` entry was silently stripped from the `?policy-view=resolved` response — even though the same caller had legitimate operator-granted access on every policy in the namespace.

Switch `resolveSourceEnforcer` to `withResolvedImportsAndNamespacePolicies` so namespace-root subjects participate in the source-side READ evaluation the same way they do in the importing-policy evaluation. The two existing security-regression tests in `PolicyCommandEnforcementResolvedViewTest` still pass — a caller with no legitimate path to the source still loses the imported entries.

Adds regression coverage for the `imports` + `references` + `transitiveImports` combination across the three layers exercised by the resolved view:

- `PolicyImporterTest` — model-layer end-to-end resolution of a 3-policy graph (template / main-with-local-and-import-references / leaf-with-transitiveImports), including enforcer-applied permissions.
- `PolicyEnforcerCacheTest` — integration-style test backed by an in-memory raw-policy map running real `withResolvedImportsAndNamespacePolicies`, covering both initial resolution and cache reload after `invalidate(mainId)`.
- `PolicyCommandEnforcementResolvedViewTest` — end-to-end merge with references plus the regression test for the namespace-root source-side READ path (the bug fixed here).