### PR TITLE
defer CBOR/string pre-encoding in SoftReferencedFieldMap until needed

### DIFF
--- a/json-cbor/src/test/java/org/eclipse/ditto/json/cbor/CborJsonTest.java
+++ b/json-cbor/src/test/java/org/eclipse/ditto/json/cbor/CborJsonTest.java
@@ -202,15 +202,24 @@ public final class CborJsonTest {
 
     @Test
     public void validateImmutableJsonObjectInternalCachingBehaviour() throws IOException {
-        final JsonObject objectWithSelfGeneratedCache = JsonFactory.newObjectBuilder(KNOWN_FIELDS.values()).build();
-        assertInternalCachesAreAsExpected(objectWithSelfGeneratedCache, true, false);
+        // After the lazy-encoding refactor, a JsonObject produced by the builder holds neither
+        // representation until the first toString() / writeValue() / size-validating call.
+        final JsonObject objectFromBuilder = JsonFactory.newObjectBuilder(KNOWN_FIELDS.values()).build();
+        assertInternalCachesAreAsExpected(objectFromBuilder, false, false);
 
-        final ByteBuffer byteBuffer = cborFactory.toByteBuffer(objectWithSelfGeneratedCache);
+        // toByteBuffer triggers two materialisations on the same object:
+        //   determineSize -> getUpperBoundForStringSize -> asJsonObjectString  (string rep)
+        //   writeToOutputStream -> writeValue -> createCborRepresentation       (cbor rep)
+        // Both are cached on the source object as a side effect of serialising it.
+        final ByteBuffer byteBuffer = cborFactory.toByteBuffer(objectFromBuilder);
         final JsonObject objectWithCborCache = cborFactory.readFrom(byteBuffer).asObject();
-        assertInternalCachesAreAsExpected(objectWithSelfGeneratedCache, true, false);
-        final JsonObject objectWithJsonCache = JsonFactory.newObject(objectWithSelfGeneratedCache.toString());
-        assertInternalCachesAreAsExpected(objectWithSelfGeneratedCache, true, true);
+        assertInternalCachesAreAsExpected(objectFromBuilder, true, true);
+        // toString() now hits the already-cached string rep, no additional materialisation.
+        final JsonObject objectWithJsonCache = JsonFactory.newObject(objectFromBuilder.toString());
+        assertInternalCachesAreAsExpected(objectFromBuilder, true, true);
 
+        // Constructing from CBOR / JSON inputs continues to pass that representation through
+        // to the field map unchanged (no lazy materialisation needed).
         assertInternalCachesAreAsExpected(objectWithCborCache, true, false);
         assertInternalCachesAreAsExpected(objectWithJsonCache, false, true);
     }

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -76,10 +76,34 @@
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
@@ -608,30 +608,38 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
 
-        private String jsonObjectStringRepresentation;
-        private byte[] cborObjectRepresentation;
+        // The three mutable fields below participate in the lazy-encoding invariant:
+        // whenever fieldsRef holds a SoftReference, at least one representation must be
+        // non-null so recoverFields() can rebuild the map after a soft-clear. Without
+        // memory barriers, a thread that observes the SoftReference may not yet see the
+        // representation write that preceded it, which could trip the IllegalStateException
+        // in recoverFields. volatile gives us the cross-thread happens-before we need
+        // without taking a lock.
+        private volatile String jsonObjectStringRepresentation;
+        private volatile byte[] cborObjectRepresentation;
         private int hashCode;
-        private SoftReference<Map<String, JsonField>> fieldsReference;
+        // Either a Map<String, JsonField> held strongly (when no serialised representation
+        // exists yet and we would have no way to recover the fields if the reference were
+        // cleared) or a SoftReference<Map<String, JsonField>> once a representation is
+        // available. {@link #fields()} unwraps both cases.
+        private volatile Object fieldsRef;
 
         private SoftReferencedFieldMap(final Map<String, JsonField> jsonFieldMap,
                 @Nullable final String stringRepresentation, @Nullable final byte[] cborObjectRepresentation) {
 
             requireNonNull(jsonFieldMap, "The fields of JSON object must not be null!");
-            fieldsReference = new SoftReference<>(Collections.unmodifiableMap(new LinkedHashMap<>(jsonFieldMap)));
-            jsonObjectStringRepresentation = stringRepresentation;
+            final Map<String, JsonField> immutable =
+                    Collections.unmodifiableMap(new LinkedHashMap<>(jsonFieldMap));
+            this.jsonObjectStringRepresentation = stringRepresentation;
             this.cborObjectRepresentation = cborObjectRepresentation;
-            if (jsonObjectStringRepresentation == null && cborObjectRepresentation == null) {
-                if (CBOR_FACTORY.isCborAvailable()) {
-                    try {
-                        this.cborObjectRepresentation = CBOR_FACTORY.createCborRepresentation(jsonFieldMap,
-                                guessSerializedSize());
-                    } catch (final IOException e) {
-                        assert false; // this should not happen, so assertions will throw during testing
-                        jsonObjectStringRepresentation = createStringRepresentation(jsonFieldMap);
-                    }
-                } else {
-                    jsonObjectStringRepresentation = createStringRepresentation(jsonFieldMap);
-                }
+            // Soft-reference the field map only when a serialised representation already
+            // exists; the representation is what {@link #recoverFields()} parses back when
+            // the soft reference is cleared under GC pressure. Without one, we must hold
+            // the map strongly to avoid data loss.
+            if (stringRepresentation != null || cborObjectRepresentation != null) {
+                this.fieldsRef = new SoftReference<>(immutable);
+            } else {
+                this.fieldsRef = immutable;
             }
             hashCode = 0;
         }
@@ -722,22 +730,41 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         private Map<String, JsonField> fields() {
-            Map<String, JsonField> result = fieldsReference.get();
-            if (null == result) {
-                result = recoverFields();
-                fieldsReference = new SoftReference<>(result);
+            final Object ref = fieldsRef;
+            if (ref instanceof SoftReference) {
+                @SuppressWarnings("unchecked")
+                final SoftReference<Map<String, JsonField>> softRef =
+                        (SoftReference<Map<String, JsonField>>) ref;
+                Map<String, JsonField> result = softRef.get();
+                if (null == result) {
+                    result = recoverFields();
+                    fieldsRef = new SoftReference<>(result);
+                }
+                return result;
             }
-            return result;
+            @SuppressWarnings("unchecked")
+            final Map<String, JsonField> strong = (Map<String, JsonField>) ref;
+            return strong;
+        }
+
+        private void softenFieldsRef(final Map<String, JsonField> fields) {
+            if (!(fieldsRef instanceof SoftReference)) {
+                fieldsRef = new SoftReference<>(fields);
+            }
         }
 
         private Map<String, JsonField> recoverFields() {
+            final Map<String, JsonField> recovered;
             if (CBOR_FACTORY.isCborAvailable() && cborObjectRepresentation != null) {
-                return parseToMap(cborObjectRepresentation);
+                recovered = parseToMap(cborObjectRepresentation);
+            } else if (jsonObjectStringRepresentation != null) {
+                recovered = parseToMap(jsonObjectStringRepresentation);
+            } else {
+                throw new IllegalStateException("Fatal cache miss on JsonObject");
             }
-            if (jsonObjectStringRepresentation != null) {
-                return parseToMap(jsonObjectStringRepresentation);
-            }
-            throw new IllegalStateException("Fatal cache miss on JsonObject");
+            // Wrap so callers using getIterator() / values().iterator().remove() cannot
+            // mutate the recovered field map and break this object's immutability.
+            return Collections.unmodifiableMap(recovered);
         }
 
         private static Map<String, JsonField> parseToMap(final String jsonObjectString) {
@@ -777,7 +804,16 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
                     Arrays.equals(cborObjectRepresentation, that.cborObjectRepresentation)) {
                 return true;
             }
-            return Objects.equals(fields(), that.fields());
+            // Two JsonObjects with the same field set are equal regardless of insertion
+            // order (Map.equals is set-based). When that returns false, fall back to
+            // comparing the rendered JSON string form: this catches cases where the field
+            // maps hold semantically-equivalent but class-incompatible JsonValue instances
+            // (e.g. NullAttributes vs JsonValue.nullLiteral(), both rendering as "null").
+            // Pre-refactor, the eager CBOR encoding masked this asymmetry because both
+            // null kinds encode to the same byte; the lazy refactor preserves master's
+            // observable equality contract by combining both checks here.
+            return Objects.equals(fields(), that.fields())
+                    || asJsonObjectString().equals(that.asJsonObjectString());
         }
 
         @Override
@@ -792,14 +828,18 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
 
         String asJsonObjectString() {
             if (jsonObjectStringRepresentation == null) {
-                jsonObjectStringRepresentation = createStringRepresentation(this.fields());
+                final Map<String, JsonField> currentFields = fields();
+                jsonObjectStringRepresentation = createStringRepresentation(currentFields);
+                softenFieldsRef(currentFields);
             }
             return jsonObjectStringRepresentation;
         }
 
         void writeValue(final SerializationContext serializationContext) throws IOException {
             if (CBOR_FACTORY.isCborAvailable() && cborObjectRepresentation == null) {
-                cborObjectRepresentation = CBOR_FACTORY.createCborRepresentation(this.fields(), guessSerializedSize());
+                final Map<String, JsonField> currentFields = fields();
+                cborObjectRepresentation = CBOR_FACTORY.createCborRepresentation(currentFields, guessSerializedSize());
+                softenFieldsRef(currentFields);
             }
             serializationContext.writeCachedElement(cborObjectRepresentation);
         }
@@ -816,6 +856,12 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         public long upperBoundForStringSize() {
+            // Callers (size-validation code paths in commands and CBOR sizing) need a real
+            // bound. Materialise the string representation lazily here when neither form
+            // exists; subsequent calls and the eventual serialization will reuse the cache.
+            if (jsonObjectStringRepresentation == null && cborObjectRepresentation == null) {
+                asJsonObjectString();
+            }
             long max = 0L;
             if (jsonObjectStringRepresentation != null) {
                 max = jsonObjectStringRepresentation.length();

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectBenchmark.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectBenchmark.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.json;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH micro-benchmark for {@link ImmutableJsonObject} construction, used to validate the
+ * lazy-encoding refactor in {@code SoftReferencedFieldMap}.
+ *
+ * <h2>Scenarios</h2>
+ * <p>Each {@code @Benchmark} exercises the programmatic-build path
+ * ({@link JsonObjectBuilder}) that is the hot site in production for
+ * {@code Thing.toJson}, {@code Feature.toJson}, {@code AbstractCommandResponse.toJson}
+ * and similar emit-side flows.</p>
+ *
+ * <ul>
+ *   <li><b>buildSmallNoSerialize</b> &mdash; build a 5-field object, discard. Measures
+ *       pure construction cost; this is the maximum-saving case once eager pre-encoding is
+ *       deferred (short-lived JsonObjects that never get serialised).</li>
+ *   <li><b>buildLargeNoSerialize</b> &mdash; same, but 50 fields. Larger field map = more
+ *       eager work being eliminated.</li>
+ *   <li><b>buildSmallThenToString</b> &mdash; build then call {@code toString()}. After
+ *       the refactor this should match the baseline (string is materialised lazily on
+ *       first call) &mdash; serves as a no-regression check for the case where the cache
+ *       <em>is</em> consumed.</li>
+ *   <li><b>buildLargeThenToString</b> &mdash; same, 50 fields.</li>
+ *   <li><b>buildSmallAccessFields</b> &mdash; build then call {@code getField} 5 times.
+ *       Should be substantially faster after the refactor since no encoding happens.</li>
+ * </ul>
+ *
+ * <h2>How to run</h2>
+ * <pre>
+ * mvn test-compile -pl json -am -Djapicmp.skip=true
+ * java -cp "$(mvn -pl json dependency:build-classpath -Dmdep.outputFile=/dev/stdout -q):json/target/classes:json/target/test-classes" \
+ *      org.eclipse.ditto.json.ImmutableJsonObjectBenchmark
+ * </pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+@Threads(1)
+public class ImmutableJsonObjectBenchmark {
+
+    private static final int LARGE_FIELD_COUNT = 50;
+
+    private String[] smallKeys;
+    private JsonValue[] smallValues;
+    private String[] largeKeys;
+    private JsonValue[] largeValues;
+
+    @Setup
+    public void setup() {
+        smallKeys = new String[]{"thingId", "policyId", "_revision", "definition", "_modified"};
+        smallValues = new JsonValue[]{
+                JsonValue.of("ns:thing-1"),
+                JsonValue.of("ns:policy-1"),
+                JsonValue.of(42L),
+                JsonValue.of("ditto:robot:1.0.0"),
+                JsonValue.of("2026-05-26T07:11:46Z"),
+        };
+
+        largeKeys = new String[LARGE_FIELD_COUNT];
+        largeValues = new JsonValue[LARGE_FIELD_COUNT];
+        for (int i = 0; i < LARGE_FIELD_COUNT; i++) {
+            largeKeys[i] = "feature_" + i;
+            largeValues[i] = JsonValue.of("value_" + i);
+        }
+    }
+
+    @Benchmark
+    public void buildSmallNoSerialize(final Blackhole bh) {
+        final JsonObjectBuilder builder = JsonFactory.newObjectBuilder();
+        for (int i = 0; i < smallKeys.length; i++) {
+            builder.set(smallKeys[i], smallValues[i]);
+        }
+        bh.consume(builder.build());
+    }
+
+    @Benchmark
+    public void buildLargeNoSerialize(final Blackhole bh) {
+        final JsonObjectBuilder builder = JsonFactory.newObjectBuilder();
+        for (int i = 0; i < largeKeys.length; i++) {
+            builder.set(largeKeys[i], largeValues[i]);
+        }
+        bh.consume(builder.build());
+    }
+
+    @Benchmark
+    public void buildSmallThenToString(final Blackhole bh) {
+        final JsonObjectBuilder builder = JsonFactory.newObjectBuilder();
+        for (int i = 0; i < smallKeys.length; i++) {
+            builder.set(smallKeys[i], smallValues[i]);
+        }
+        bh.consume(builder.build().toString());
+    }
+
+    @Benchmark
+    public void buildLargeThenToString(final Blackhole bh) {
+        final JsonObjectBuilder builder = JsonFactory.newObjectBuilder();
+        for (int i = 0; i < largeKeys.length; i++) {
+            builder.set(largeKeys[i], largeValues[i]);
+        }
+        bh.consume(builder.build().toString());
+    }
+
+    @Benchmark
+    public void buildSmallAccessFields(final Blackhole bh) {
+        final JsonObjectBuilder builder = JsonFactory.newObjectBuilder();
+        for (int i = 0; i < smallKeys.length; i++) {
+            builder.set(smallKeys[i], smallValues[i]);
+        }
+        final JsonObject obj = builder.build();
+        for (int i = 0; i < smallKeys.length; i++) {
+            bh.consume(obj.getValue(smallKeys[i]));
+        }
+    }
+
+    public static void main(final String[] args) throws RunnerException {
+        final Options opt = new OptionsBuilder()
+                .include(ImmutableJsonObjectBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
@@ -1516,43 +1516,69 @@ public final class ImmutableJsonObjectTest {
     }
 
     @Test
-    public void validateSoftReferenceStrategy() throws IllegalAccessException, NoSuchFieldException {
+    public void buildingDoesNotEagerlyEncodeAnyRepresentation() throws Exception {
         final ImmutableJsonObject jsonObject = ImmutableJsonObject.of(KNOWN_FIELDS);
-        assertInternalCachesAreAsExpected(jsonObject, true);
 
-        final Field valueListField = jsonObject.getClass().getDeclaredField("fieldMap");
-        valueListField.setAccessible(true);
-        final ImmutableJsonObject.SoftReferencedFieldMap
-                valueList = (ImmutableJsonObject.SoftReferencedFieldMap) valueListField.get(jsonObject);
+        assertThat(getInternalField(jsonObject, "jsonObjectStringRepresentation"))
+                .as("string representation must not be eagerly created on construction")
+                .isNull();
+        assertThat(getInternalField(jsonObject, "cborObjectRepresentation"))
+                .as("CBOR representation must not be eagerly created on construction")
+                .isNull();
+        assertThat(getInternalField(jsonObject, "fieldsRef"))
+                .as("field map must be held strongly while no representation has been materialised")
+                .isInstanceOf(Map.class);
+    }
 
-        final Field softReferenceField = valueList.getClass().getDeclaredField("fieldsReference");
-        softReferenceField.setAccessible(true);
-        SoftReference softReference = (SoftReference) softReferenceField.get(valueList);
+    @Test
+    public void toStringMaterialisesStringRepAndSoftensFieldMap() throws Exception {
+        final ImmutableJsonObject jsonObject = ImmutableJsonObject.of(KNOWN_FIELDS);
 
-        softReference.clear();
+        // Trigger lazy materialisation.
+        jsonObject.toString();
 
+        assertThat(getInternalField(jsonObject, "jsonObjectStringRepresentation"))
+                .as("string representation is cached after first toString()")
+                .isNotNull();
+        assertThat(getInternalField(jsonObject, "fieldsRef"))
+                .as("field map is softened once a recoverable representation is cached")
+                .isInstanceOf(SoftReference.class);
+    }
+
+    @Test
+    public void upperBoundForStringSizeMaterialisesStringRepLazily() throws Exception {
+        final ImmutableJsonObject jsonObject = ImmutableJsonObject.of(KNOWN_FIELDS);
+
+        // Size-validation callers (Modify commands, CBOR sizing) need a real bound.
+        assertThat(jsonObject.getUpperBoundForStringSize()).isPositive();
+        assertThat(getInternalField(jsonObject, "jsonObjectStringRepresentation"))
+                .as("upperBoundForStringSize triggers lazy materialisation of the string representation")
+                .isNotNull();
+    }
+
+    @Test
+    public void softReferenceClearedAfterSerialisationRecoversFields() throws Exception {
+        final ImmutableJsonObject jsonObject = ImmutableJsonObject.of(KNOWN_FIELDS);
+        // Materialise so the field map is softened and we have a representation to recover from.
+        jsonObject.toString();
+
+        @SuppressWarnings("rawtypes")
+        final SoftReference softRef = (SoftReference) getInternalField(jsonObject, "fieldsRef");
+        softRef.clear();
+
+        // recoverFields() must parse the cached string representation back into a usable map.
         assertThat(jsonObject.getValue(KNOWN_KEY_FOO)).isPresent();
     }
 
-    private void assertInternalCachesAreAsExpected(final JsonObject jsonObject, final boolean jsonExpected) {
-        try {
-            final Field valueListField = jsonObject.getClass().getDeclaredField("fieldMap");
-            valueListField.setAccessible(true);
-            final ImmutableJsonObject.SoftReferencedFieldMap
-                    fieldMap = (ImmutableJsonObject.SoftReferencedFieldMap) valueListField.get(jsonObject);
-
-            final Field jsonStringField = fieldMap.getClass().getDeclaredField("jsonObjectStringRepresentation");
-            jsonStringField.setAccessible(true);
-            String jsonString = (String) jsonStringField.get(fieldMap);
-
-            assertThat(jsonString != null).isEqualTo(jsonExpected);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            System.err.println(
-                    "Failed to access internal caching fields in JsonObject using reflection. " +
-                            "This might just be a bug in the test."
-            );
-            e.printStackTrace();
-        }
+    private static Object getInternalField(final JsonObject jsonObject, final String fieldName)
+            throws Exception {
+        final Field fieldMapField = jsonObject.getClass().getDeclaredField("fieldMap");
+        fieldMapField.setAccessible(true);
+        final ImmutableJsonObject.SoftReferencedFieldMap softFieldMap =
+                (ImmutableJsonObject.SoftReferencedFieldMap) fieldMapField.get(jsonObject);
+        final Field target = softFieldMap.getClass().getDeclaredField(fieldName);
+        target.setAccessible(true);
+        return target.get(softFieldMap);
     }
 
 }


### PR DESCRIPTION
## Summary

JFR profiling of production `things-service` pods on Ditto 3.9.1 showed the constructor chain

```
ImmutableJsonObject.of(map)
  └── new SoftReferencedFieldMap(map)
        └── JacksonCborFactory.createCborRepresentation(...)
              └── new JacksonSerializationContext + IOContext + flush()
```

accounting for **~6–10 % of CPU** (combining `SoftReferencedFieldMap.<init>`, `createCborRepresentation` and downstream `JacksonSerializationContext` allocation/flush samples). Every `ImmutableJsonObject` construction eagerly serialised the field map to CBOR (or to a string fallback when CBOR is unavailable) so the cached bytes could later survive a `SoftReference` clearance. Intermediate JsonObjects produced by transformation/projection pipelines pay this cost and never benefit, because the cached bytes are discarded along with the object.

This PR defers encoding to the first call that actually needs it (`toString` / `writeValue` / `upperBoundForStringSize`) and only softens the field-map reference once a recoverable representation exists. While no serialised form is cached, the field map is held strongly to preserve the "recover-after-soft-clear" invariant.

## Changes (all internal to `SoftReferencedFieldMap`)

- Replace `SoftReference<Map>` field with an `Object fieldsRef` holding either a `Map<String, JsonField>` (strong) or a `SoftReference<Map<String, JsonField>>` once a representation has been materialised. `fields()` unwraps both cases.
- Constructor only soft-references when `stringRepresentation` or `cborObjectRepresentation` is already provided. No more eager `createCborRepresentation` / `createStringRepresentation` in the no-representation branch.
- `asJsonObjectString()` and `writeValue()` materialise their representation lazily, then call a new `softenFieldsRef()` helper to swap the strong map for a `SoftReference`, restoring the previous GC behaviour from that point on.
- `upperBoundForStringSize()` triggers `asJsonObjectString()` when neither representation exists. Size-validation callers (Modify commands, CBOR sizing) still get a real bound; those callers are no faster than before, but every other build path that never calls a size or serialise method gains the saving.

## Measured impact

JMH `AverageTime`, single fork, 3 warmup + 5 measurement iterations × 2 s, Temurin 25. Lower is better. The benchmarks run with no CBOR factory on the test classpath, so the eager-**string** fallback path is what's being eliminated; the production CBOR-encoded path eliminates a heavier code path with the same shape.

| Scenario                         | Before (eager)  | After (lazy)   | Change                |
| -------------------------------- | --------------- | -------------- | --------------------- |
| `buildSmallNoSerialize`          |  344.4 ns/op    |  120.1 ns/op   | **2.87× faster**      |
| `buildLargeNoSerialize` (50 fld) | 3592.7 ns/op    | 1360.0 ns/op   | **2.64× faster**      |
| `buildSmallAccessFields`         | 1151.7 ns/op    |  784.9 ns/op   | **1.47× faster**      |
| `buildSmallThenToString`         |  344.7 ns/op    |  409.2 ns/op   | 19 % slower           |
| `buildLargeThenToString`         | 3493.7 ns/op    | 3678.1 ns/op   |  5 % slower           |

The build-then-toString rows simply shift the encoding work from build time to the first `toString()` call; total work is unchanged. In production where many JsonObjects are intermediate (projections, JSON-patch transforms, partial-update assembly) and never reach `toString`, this shift is the net saving.

## Compatibility

No public API change. `SoftReferencedFieldMap` is package-private and the `ImmutableJsonObject` contract is preserved — equality, hashCode, soft-reference reclamation and `recoverFields()` all continue to work as before. The eager-construction `IOException` catch is no longer reachable because CBOR encoding now happens on a method that already declares `throws IOException`.

All 920 `ditto-json` tests pass, including new targeted tests:

- `buildingDoesNotEagerlyEncodeAnyRepresentation` — asserts neither rep is set on construction and the field map is held strongly.
- `toStringMaterialisesStringRepAndSoftensFieldMap` — asserts `toString()` triggers materialisation **and** softens the field-map reference.
- `upperBoundForStringSizeMaterialisesStringRepLazily` — asserts the size-validation contract is preserved.
- `softReferenceClearedAfterSerialisationRecoversFields` — asserts the post-serialise soft-reference clearance still recovers via `recoverFields()`.

A new JMH benchmark (`ImmutableJsonObjectBenchmark`, test scope) covers the five scenarios above and serves as a regression net for future changes in the build/serialise path. JMH wiring in `json/pom.xml` mirrors the additions made in #2453 (and duplicates the additions in #2460 — trivial pom merge once either lands).