### PR TITLE
fix partial-access filter stripping thingId and audit fields from SSE/WebSocket events

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,6 +91,7 @@ import org.eclipse.ditto.internal.models.signalenrichment.SignalEnrichmentFacade
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.counter.Counter;
+import org.eclipse.ditto.internal.utils.protocol.AdaptablePartialAccessFilter;
 import org.eclipse.ditto.internal.utils.protocol.JsonPartialAccessFilter;
 import org.eclipse.ditto.internal.utils.protocol.PartialAccessPathResolver;
 import org.eclipse.ditto.internal.utils.pubsub.StreamingType;
@@ -914,7 +916,8 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
             return JsonFactory.newObject();
         }
 
-        final Set<JsonPointer> accessiblePaths = result.getAccessiblePaths();
+        final Set<JsonPointer> accessiblePaths = new HashSet<>(result.getAccessiblePaths());
+        accessiblePaths.addAll(AdaptablePartialAccessFilter.ALWAYS_INCLUDED_THING_FIELDS);
         return JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
     }
 

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
@@ -365,7 +365,12 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
 
         final JsonObject filtered = filterJsonByPartialAccessPaths(thing, event, subscriberAuthContext);
 
-        assertThat(filtered.getValue("thingId")).isEmpty(); // Not in accessible paths
+        // thingId is an entity-identity field that must always be visible to any subscriber
+        // holding at least partial read access. _namespace/_revision/_modified/_created are
+        // verified separately in filterJsonByPartialAccessPathsPreservesAuditFieldsForPartialReader
+        // (they only appear in the SSE payload when the user explicitly selects them via
+        // ?fields=... since they are HIDDEN fields by default).
+        assertThat(filtered.getValue("thingId")).contains(JsonValue.of("test:thing"));
         assertThat(filtered.getValue("attributes")).isPresent();
         assertThat(filtered.getValue("attributes").get().asObject().getValue("foo")).isPresent();
         assertThat(filtered.getValue("features")).isPresent();
@@ -375,6 +380,49 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
                 .getValue("properties").get().asObject()
                 .getValue("baz")).isPresent();
         assertThat(filtered.getValue("policyId")).isEmpty();
+    }
+
+    @Test
+    public void filterJsonByPartialAccessPathsPreservesAuditFieldsForPartialReader() throws Exception {
+        final java.time.Instant created = java.time.Instant.parse("2026-01-01T00:00:00Z");
+        final java.time.Instant modified = java.time.Instant.parse("2026-06-01T12:00:00Z");
+        final Thing thing = Thing.newBuilder()
+                .setId(ThingId.of("test:thing"))
+                .setPolicyId(org.eclipse.ditto.policies.model.PolicyId.of("test:policy"))
+                .setRevision(42L)
+                .setCreated(created)
+                .setModified(modified)
+                .setAttributes(Attributes.newBuilder().set("foo", "bar").build())
+                .build();
+        final AuthorizationSubject partialReader = AuthorizationSubject.newInstance("test:partial-reader");
+
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.PARTIAL_ACCESS_PATHS.getKey(),
+                        "{\"subjects\":[\"test:partial-reader\"],\"paths\":{\"attributes\":[0]}}")
+                .readGrantedSubjects(Collections.singletonList(partialReader))
+                .build();
+
+        final ThingModifiedEvent<?> event = ThingModified.of(thing, 42L, modified, headers, null);
+
+        final AuthorizationContext subscriberAuthContext = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, partialReader);
+
+        // Build the thing JSON with SPECIAL fields included, mirroring the production path where a
+        // caller has explicitly opted into hidden identity/audit fields via ?fields=_revision,...
+        final JsonObject thingJson = thing.toJson(org.eclipse.ditto.base.model.json.JsonSchemaVersion.LATEST,
+                org.eclipse.ditto.base.model.json.FieldType.regularOrSpecial());
+        final JsonObject filtered = filterJsonByPartialAccessPaths(thingJson, event, subscriberAuthContext);
+
+        // Identity + audit fields must pass through even though the policy only grants /attributes:
+        assertThat(filtered.getValue("thingId")).contains(JsonValue.of("test:thing"));
+        assertThat(filtered.getValue("_namespace")).contains(JsonValue.of("test"));
+        assertThat(filtered.getValue("_revision")).contains(JsonValue.of(42L));
+        assertThat(filtered.getValue("_modified")).contains(JsonValue.of(modified.toString()));
+        assertThat(filtered.getValue("_created")).contains(JsonValue.of(created.toString()));
+        // policyId is not allowlisted and must remain filtered out:
+        assertThat(filtered.getValue("policyId")).isEmpty();
+        // The actually-granted resource is present:
+        assertThat(filtered.getValue("attributes")).isPresent();
     }
 
     @Test
@@ -480,6 +528,12 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
     private JsonObject filterJsonByPartialAccessPaths(final Thing thing,
             final ThingModifiedEvent<?> event,
             final AuthorizationContext subscriberAuthContext) throws Exception {
+        return filterJsonByPartialAccessPaths(thing.toJson(), event, subscriberAuthContext);
+    }
+
+    private JsonObject filterJsonByPartialAccessPaths(final JsonObject thingJson,
+            final ThingModifiedEvent<?> event,
+            final AuthorizationContext subscriberAuthContext) throws Exception {
         final ThingsSseRouteBuilder routeBuilder = ThingsSseRouteBuilder.getInstance(
                 actorSystem, streamingActor.ref(), streamingConfig, proxyActor.ref(), HeaderTranslator.empty());
         final Method filterMethod = ThingsSseRouteBuilder.class.getDeclaredMethod(
@@ -489,7 +543,6 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
                 AuthorizationContext.class);
         filterMethod.setAccessible(true);
 
-        final JsonObject thingJson = thing.toJson();
         return (JsonObject) filterMethod.invoke(routeBuilder, thingJson, event, subscriberAuthContext);
     }
 

--- a/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilter.java
+++ b/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilter.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.protocol;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +37,22 @@ import org.eclipse.ditto.protocol.TopicPath;
  * Utility for filtering {@link Adaptable} payloads based on partial access paths.
  */
 public final class AdaptablePartialAccessFilter {
+
+    /**
+     * Thing identity and audit fields ({@code thingId}, {@code _namespace}, {@code _revision},
+     * {@code _modified}, {@code _created}) that must remain visible to any subscriber holding at
+     * least partial read access on the thing. These are field names from the Ditto Protocol
+     * (see {@code org.eclipse.ditto.things.model.Thing.JsonFields}) — they are hardcoded here
+     * rather than imported to keep the {@code internal/utils/protocol} module free of a
+     * dependency on {@code things/model}.
+     */
+    public static final Set<JsonPointer> ALWAYS_INCLUDED_THING_FIELDS = Set.of(
+            JsonPointer.of("thingId"),
+            JsonPointer.of("_namespace"),
+            JsonPointer.of("_revision"),
+            JsonPointer.of("_modified"),
+            JsonPointer.of("_created")
+    );
 
     private AdaptablePartialAccessFilter() {
         // No instantiation
@@ -162,8 +179,11 @@ public final class AdaptablePartialAccessFilter {
                 .map(JsonValue::asObject)
                 .orElse(JsonFactory.newObject());
 
-        final JsonObject filteredPayload = JsonPartialAccessFilter.filterJsonByPaths(
-                originalPayload, accessiblePaths);
+        // ThingCreated/ThingModified/ThingMerged events at path "/" carry the full thing JSON
+        // here; stripping the identity/audit fields would make the protocol message hard to use
+        // for the partial reader. For events with non-thing-rooted object payloads the allowlist
+        // pointers simply don't exist in the payload and the addition is a no-op.
+        final JsonObject filteredPayload = filterJsonByPathsWithAllowlist(originalPayload, accessiblePaths);
 
         final PayloadBuilder payloadBuilder = Payload.newBuilder(adaptable.getPayload())
                 .withValue(filteredPayload);
@@ -172,6 +192,18 @@ public final class AdaptablePartialAccessFilter {
         return ProtocolFactory.newAdaptableBuilder(adaptable)
                 .withPayload(payloadBuilder.build())
                 .build();
+    }
+
+    /**
+     * Filters {@code jsonObject} by {@code accessiblePaths}, with the thing-identity/audit
+     * allowlist ({@link #ALWAYS_INCLUDED_THING_FIELDS}) implicitly added. Used for both the
+     * payload value of full-thing events and for user-requested extra fields.
+     */
+    private static JsonObject filterJsonByPathsWithAllowlist(final JsonObject jsonObject,
+            final Set<JsonPointer> accessiblePaths) {
+        final Set<JsonPointer> pathsWithAllowlist = new HashSet<>(accessiblePaths);
+        pathsWithAllowlist.addAll(ALWAYS_INCLUDED_THING_FIELDS);
+        return JsonPartialAccessFilter.filterJsonByPaths(jsonObject, pathsWithAllowlist);
     }
 
 
@@ -198,8 +230,11 @@ public final class AdaptablePartialAccessFilter {
             return;
         }
 
-        final JsonObject filteredExtra = JsonPartialAccessFilter.filterJsonByPaths(
-                originalExtra.get(), accessiblePaths);
+        // The user explicitly opted into receiving these extra fields via the extraFields/fields
+        // parameter; identity and audit fields the subscriber would otherwise lose to per-path
+        // filtering must still come through (matches the SSE Thing-JSON contract and pre-3.9.0
+        // behaviour for WebSocket extras).
+        final JsonObject filteredExtra = filterJsonByPathsWithAllowlist(originalExtra.get(), accessiblePaths);
 
         if (filteredExtra.isEmpty()) {
             return;

--- a/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilterTest.java
+++ b/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilterTest.java
@@ -723,6 +723,96 @@ public final class AdaptablePartialAccessFilterTest {
         assertThat(extraObj.getValue(JsonPointer.of("/attributes/private"))).isEmpty();
     }
 
+    @Test
+    public void payloadFilterPreservesIdentityAndAuditFieldsForPartialAccess() {
+        // GIVEN: a ThingMerged-style event at path "/" carrying the full thing in the payload,
+        // and a partial reader granted only /attributes/public.
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.PARTIAL_ACCESS_PATHS.getKey(), PARTIAL_ACCESS_HEADER)
+                .readGrantedSubjects(Set.of(SUBJECT_PARTIAL))
+                .build();
+
+        final JsonObject fullThingPayload = JsonFactory.newObjectBuilder()
+                .set("thingId", JsonValue.of("org.eclipse.ditto.test:thing"))
+                .set("_namespace", JsonValue.of("org.eclipse.ditto.test"))
+                .set("_revision", JsonValue.of(7L))
+                .set("_modified", JsonValue.of("2026-06-01T12:00:00Z"))
+                .set("_created", JsonValue.of("2026-01-01T00:00:00Z"))
+                .set("policyId", JsonValue.of("org.eclipse.ditto.test:policy"))
+                .set("attributes", JsonFactory.newObjectBuilder()
+                        .set("public", JsonValue.of("public-value"))
+                        .set("private", JsonValue.of("private-value"))
+                        .build())
+                .build();
+
+        final Adaptable adaptable = createThingEventAdaptable(fullThingPayload, headers);
+        final AuthorizationContext context = authContext(SUBJECT_PARTIAL);
+
+        // WHEN
+        final Adaptable result = AdaptablePartialAccessFilter.filterAdaptableForPartialAccess(adaptable, context);
+
+        // THEN: identity + audit fields survive in the payload even though the policy only
+        // grants /attributes/public.
+        final JsonObject filteredPayload = result.getPayload().getValue()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .orElse(JsonFactory.newObject());
+        assertThat(filteredPayload.getValue("thingId")).contains(JsonValue.of("org.eclipse.ditto.test:thing"));
+        assertThat(filteredPayload.getValue("_namespace")).contains(JsonValue.of("org.eclipse.ditto.test"));
+        assertThat(filteredPayload.getValue("_revision")).contains(JsonValue.of(7L));
+        assertThat(filteredPayload.getValue("_modified")).contains(JsonValue.of("2026-06-01T12:00:00Z"));
+        assertThat(filteredPayload.getValue("_created")).contains(JsonValue.of("2026-01-01T00:00:00Z"));
+        // policyId is NOT in the allowlist — must remain filtered out.
+        assertThat(filteredPayload.getValue("policyId")).isEmpty();
+        // The actually-granted path is present, the ungranted sibling is dropped.
+        assertThat(filteredPayload.getValue(JsonPointer.of("/attributes/public"))).isPresent();
+        assertThat(filteredPayload.getValue(JsonPointer.of("/attributes/private"))).isEmpty();
+    }
+
+    @Test
+    public void extrasFilterPreservesIdentityAndAuditFieldsForPartialAccess() {
+        // GIVEN: partial reader is granted only /attributes/public, and explicitly requested
+        // extraFields covering thingId, audit metadata, the granted path, and a non-granted path.
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.PARTIAL_ACCESS_PATHS.getKey(), PARTIAL_ACCESS_HEADER)
+                .readGrantedSubjects(Set.of(SUBJECT_PARTIAL))
+                .build();
+
+        final JsonObject extraFields = JsonFactory.newObjectBuilder()
+                .set("thingId", JsonValue.of("org.eclipse.ditto.test:thing"))
+                .set("_namespace", JsonValue.of("org.eclipse.ditto.test"))
+                .set("_revision", JsonValue.of(7L))
+                .set("_modified", JsonValue.of("2026-06-01T12:00:00Z"))
+                .set("_created", JsonValue.of("2026-01-01T00:00:00Z"))
+                .set("policyId", JsonValue.of("org.eclipse.ditto.test:policy"))
+                .set("attributes", JsonFactory.newObjectBuilder()
+                        .set("public", JsonValue.of("public-value"))
+                        .set("private", JsonValue.of("private-value"))
+                        .build())
+                .build();
+
+        final Adaptable adaptable = createThingEventAdaptableWithExtra(createThingPayload(), extraFields, headers);
+        final AuthorizationContext context = authContext(SUBJECT_PARTIAL);
+
+        // WHEN
+        final Adaptable result = AdaptablePartialAccessFilter.filterAdaptableForPartialAccess(adaptable, context);
+
+        // THEN: identity + audit extras pass through despite the policy only granting /attributes/public.
+        final Optional<JsonObject> filteredExtra = result.getPayload().getExtra();
+        assertThat(filteredExtra).isPresent();
+        final JsonObject extraObj = filteredExtra.get();
+        assertThat(extraObj.getValue("thingId")).contains(JsonValue.of("org.eclipse.ditto.test:thing"));
+        assertThat(extraObj.getValue("_namespace")).contains(JsonValue.of("org.eclipse.ditto.test"));
+        assertThat(extraObj.getValue("_revision")).contains(JsonValue.of(7L));
+        assertThat(extraObj.getValue("_modified")).contains(JsonValue.of("2026-06-01T12:00:00Z"));
+        assertThat(extraObj.getValue("_created")).contains(JsonValue.of("2026-01-01T00:00:00Z"));
+        // policyId is NOT in the allowlist — must remain filtered out.
+        assertThat(extraObj.getValue("policyId")).isEmpty();
+        // The actually-granted path is present, the ungranted sibling is dropped.
+        assertThat(extraObj.getValue(JsonPointer.of("/attributes/public"))).isPresent();
+        assertThat(extraObj.getValue(JsonPointer.of("/attributes/private"))).isEmpty();
+    }
+
     private static Adaptable createThingEventAdaptableWithExtra(
             final JsonObject payload,
             final JsonObject extraFields,

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
@@ -100,10 +100,20 @@ final class ThingCommandEnforcement
             DittoLoggerFactory.getThreadSafeLogger(ThingCommandEnforcement.class.getName());
 
     /**
-     * Json fields that are always shown regardless of authorization.
+     * Json fields that are always shown regardless of authorization, provided the subject has at
+     * least partial read permissions on the thing. Covers entity identity ({@code thingId},
+     * {@code _namespace}) and audit metadata ({@code _revision}, {@code _modified},
+     * {@code _created}) which do not carry user data and which subscribers need in order to make
+     * sense of the response.
      */
     private static final JsonFieldSelector THING_QUERY_COMMAND_RESPONSE_ALLOWLIST =
-            JsonFactory.newFieldSelector(Thing.JsonFields.ID);
+            JsonFactory.newFieldSelector(
+                    Thing.JsonFields.ID,
+                    Thing.JsonFields.NAMESPACE,
+                    Thing.JsonFields.REVISION,
+                    Thing.JsonFields.MODIFIED,
+                    Thing.JsonFields.CREATED
+            );
     private final ActorSystem actorSystem;
     private final ActorRef policiesShardRegion;
     private final AskWithRetryConfig askWithRetryConfig;

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcementTest.java
@@ -342,9 +342,12 @@ public final class ThingCommandEnforcementTest extends AbstractThingEnforcementT
             thingPersistenceActorProbe.reply(retrieveThingResponseWithAttr);
 
             final JsonObject jsonObjectWithoutAttr = JsonObject.newBuilder()
-                    .set("thingId", "thing:id") // this is re-added as first field being a "special" field always visible after enforcement
-                    .set("_revision", 1)
+                    // thingId, _namespace, _revision are re-added by the entity-identity/audit
+                    // allowlist (THING_QUERY_COMMAND_RESPONSE_ALLOWLIST); ordering follows the
+                    // allowlist declaration order in ThingCommandEnforcement.
+                    .set("thingId", "thing:id")
                     .set("_namespace", "thing")
+                    .set("_revision", 1)
                     .set("policyId","policy:id")
                     .set("attributes",JsonObject.empty())
                     .build();


### PR DESCRIPTION
## Summary

The 3.9.0 partial-events feature (#2287) filters the emitted Thing JSON by
exact path match against the subscriber's policy grants. Top-level entity
fields that aren't a listed grant get stripped, including `thingId`. A
subscriber with READ on `thing:/attributes` therefore receives SSE events
without any way to identify which thing the change applies to — a behavior
regression versus 3.8.x.

The same code path also strips identity/audit fields from WebSocket payloads
of full-thing events (`ThingCreated`/`ThingModified`/`ThingMerged`) and from
user-requested `extraFields`.

## Fix

Always preserve `thingId`, `_namespace`, `_revision`, `_modified` and
`_created` when the subscriber holds at least partial READ access on the
thing:

* `ThingsSseRouteBuilder.filterJsonByPartialAccessPaths` injects the allowlist
  into `accessiblePaths` before `JsonPartialAccessFilter.filterJsonByPaths`.
* `AdaptablePartialAccessFilter` applies the same allowlist via a shared
  helper in both `filterAdaptablePayload` (full-thing event payloads) and
  `filterExtraFieldsIntoBuilder` (user-requested extras). The set of paths
  is exposed as `ALWAYS_INCLUDED_THING_FIELDS` so the SSE and connectivity
  filters share a single source of truth.
* `THING_QUERY_COMMAND_RESPONSE_ALLOWLIST` in `ThingCommandEnforcement` is
  widened from `thingId` alone to the same five-field set so `RetrieveThing`
  and the streaming filters stay consistent for any subscriber holding at
  least partial read access.

## What is NOT in the allowlist (intentional)

* `policyId` — reveals which Policy entity gates the thing; remains
  per-path policy-enforced.
* `_metadata` — currently per-path policy-enforced via `Enforcer.buildJsonView`
  in the standard query path (a READ grant on `thing:/attributes` does **not**
  propagate to `thing:/_metadata/attributes/...`). Auto-including it would
  expose data `RetrieveThing` does not, so the existing enforcement is
  retained.

## Affected files

| File | Change |
|------|--------|
| `gateway/service/.../ThingsSseRouteBuilder.java` | Inject allowlist before `JsonPartialAccessFilter` call. |
| `internal/utils/protocol/.../AdaptablePartialAccessFilter.java` | Expose `ALWAYS_INCLUDED_THING_FIELDS`; share `filterJsonByPathsWithAllowlist` helper across payload and extras filters. |
| `things/service/.../ThingCommandEnforcement.java` | Widen `THING_QUERY_COMMAND_RESPONSE_ALLOWLIST` from `thingId` to the five-field identity/audit set. |
| `*Test.java` (three test files) | Flip the buggy `thingId-is-stripped` assertion, add coverage for payload, extras, and `RetrieveThing` allowlist behavior. |

## Tests

* `internal/utils/protocol`: 45/45 (2 new tests covering payload + extras).
* `gateway/service` SSE: 22/22 (1 new test covering audit fields).
* `connectivity/service` `OutboundMappingProcessorTest`: 17/17.
* `things/service` `ThingCommandEnforcementTest`: 22/22 (existing field-order
  expectation updated to follow widened allowlist).