### PR TITLE
fix http gaetway route segments strict matching

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,6 +39,8 @@ import org.apache.pekko.actor.Status;
 import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.http.javadsl.model.MediaTypes;
 import org.apache.pekko.http.javadsl.server.AllDirectives;
+import org.apache.pekko.http.javadsl.server.Directives;
+import org.apache.pekko.http.javadsl.server.PathMatchers;
 import org.apache.pekko.http.javadsl.server.RequestContext;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.stream.ActorAttributes;
@@ -97,6 +100,29 @@ public abstract class AbstractRoute extends AllDirectives {
     private final HttpRequestActorPropsFactory httpRequestActorPropsFactory;
     private final Attributes supervisionStrategy;
     private final Set<String> mediaTypeJsonWithFallbacks;
+
+    /**
+     * Matches a leading {@code /<pathSegment>} only if the next path segment equals {@code pathSegment}
+     * <em>completely</em> (not merely as a prefix), then delegates to {@code inner}; otherwise the request is
+     * rejected so that sibling routes get a chance to match.
+     * <p>
+     * This must be used instead of {@code rawPathPrefix(slash().concat(PathMatchers.segment(constant)), ...)}:
+     * the Pekko {@link PathMatchers#segment(String)} matcher matches the given constant only as a <em>prefix</em>
+     * of the next path segment (it is implemented via {@code Path.startsWith}), so e.g. a {@code "logging"} matcher
+     * would also match {@code /loggingh}, leaving the trailing characters dangling and silently mis-routing the
+     * request. Capturing the full segment and comparing it for equality enforces a proper segment boundary.
+     *
+     * @param pathSegment the constant path segment which must be matched in its entirety.
+     * @param inner supplies the route to apply once the segment matched.
+     * @return the route matching {@code /<pathSegment>} followed by {@code inner}.
+     */
+    public static Route rawPathPrefixSegment(final String pathSegment, final Supplier<Route> inner) {
+        // Equivalent to the framework's own pathPrefix(PathMatchers.Segment){...} but with a plain synchronous
+        // equality check instead of an Unmarshaller: consume a leading slash, capture the whole next segment and
+        // compare it for equality.
+        return Directives.pathPrefix(PathMatchers.segment(), segment ->
+                pathSegment.equals(segment) ? inner.get() : Directives.reject());
+    }
 
     /**
      * Constructs a {@code AbstractRoute} object.

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/connections/ConnectionsRoute.java
@@ -104,7 +104,7 @@ public final class ConnectionsRoute extends AbstractRoute {
      * @return the {@code /connections} route.
      */
     public Route buildConnectionsRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_CONNECTIONS), () ->  // /connections
+        return rawPathPrefixSegment(PATH_CONNECTIONS, () ->  // /connections
                 Optional.ofNullable(devOpsAuthenticationDirective)
                         .orElse((realm, dh, route) -> route)
                         .authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS, dittoHeaders,

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
@@ -117,23 +117,23 @@ public final class DevOpsRoute extends AbstractRoute {
         checkNotNull(ctx, "ctx");
         checkNotNull(queryParameters, "queryParameters");
 
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_DEVOPS), () ->  // /devops
+        return rawPathPrefixSegment(PATH_DEVOPS, () ->  // /devops
                 devOpsAuthenticationDirective.authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_DEVOPS,
                         DittoHeaders.newBuilder().correlationId(correlationId).build(),
                         concat(
-                                rawPathPrefix(PathMatchers.slash().concat(PATH_LOGGING),
+                                rawPathPrefixSegment(PATH_LOGGING,
                                         () -> // /devops/logging
                                                 logging(ctx, createHeaders(queryParameters))
                                 ),
-                                rawPathPrefix(PathMatchers.slash().concat(PATH_PIGGYBACK),
+                                rawPathPrefixSegment(PATH_PIGGYBACK,
                                         () -> // /devops/piggyback
                                                 piggyback(ctx, createHeaders(queryParameters))
                                 ),
-                                rawPathPrefix(PathMatchers.slash().concat(PATH_CONFIG),
+                                rawPathPrefixSegment(PATH_CONFIG,
                                         () -> // /devops/config
                                                 config(ctx, createHeaders(queryParameters))
                                 ),
-                                rawPathPrefix(PathMatchers.slash().concat(PATH_WOT),
+                                rawPathPrefixSegment(PATH_WOT,
                                         () -> // /devops/wot
                                                 wotRoutes(ctx, createHeaders(queryParameters))
                                 )
@@ -146,7 +146,7 @@ public final class DevOpsRoute extends AbstractRoute {
      * @return {@code /devops/wot/config} route.
      */
     private Route wotRoutes(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_WOT_CONFIG), () -> concat(
+        return rawPathPrefixSegment(PATH_WOT_CONFIG, () -> concat(
             // /devops/wot/config
             pathEndOrSingleSlash(() -> concat(
                 get(() -> handlePerRequest(ctx, RetrieveWotValidationConfig.of(WotValidationConfigId.GLOBAL, dittoHeaders))),
@@ -166,7 +166,7 @@ public final class DevOpsRoute extends AbstractRoute {
                 get(() -> handlePerRequest(ctx, RetrieveMergedWotValidationConfig.of(WotValidationConfigId.GLOBAL, dittoHeaders)))
             ),
             // /devops/wot/config/dynamicConfigs/{scopeId}
-            pathPrefix(PATH_WOT_DYNAMIC_CONFIGS, () -> concat(
+            rawPathPrefixSegment(PATH_WOT_DYNAMIC_CONFIGS, () -> concat(
                 // /devops/wot/config/dynamicConfigs/{scopeId}
                 pathPrefix(PathMatchers.segment(), scopeId ->
                     pathEndOrSingleSlash(() -> concat(

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
@@ -124,7 +124,7 @@ public final class PoliciesRoute extends AbstractRoute {
      */
     public Route buildPoliciesRoute(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final AuthenticationResult authenticationResult) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_POLICIES), () ->
+        return rawPathPrefixSegment(PATH_POLICIES, () ->
                 concat(
                         policies(ctx, dittoHeaders),
                         rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), policyId ->
@@ -251,7 +251,7 @@ public final class PoliciesRoute extends AbstractRoute {
      * @return {@code /policies/<policyId>/imports} route.
      */
     private Route policyImports(final RequestContext ctx, final DittoHeaders dittoHeaders, final PolicyId policyId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_IMPORTS), () -> // /policies/<policyId>/imports
+        return rawPathPrefixSegment(PATH_IMPORTS, () -> // /policies/<policyId>/imports
                 policyImportsRoute.buildPolicyImportsRoute(ctx, dittoHeaders, policyId)
         );
     }
@@ -263,7 +263,7 @@ public final class PoliciesRoute extends AbstractRoute {
      */
     private Route policyEntries(final RequestContext ctx, final DittoHeaders dittoHeaders, final PolicyId policyId,
             final AuthenticationResult authResult) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_ENTRIES), () -> // /policies/<policyId>/entries
+        return rawPathPrefixSegment(PATH_ENTRIES, () -> // /policies/<policyId>/entries
                 policyEntriesRoute.buildPolicyEntriesRoute(ctx, dittoHeaders, policyId, authResult)
         );
     }
@@ -274,9 +274,9 @@ public final class PoliciesRoute extends AbstractRoute {
     private Route policyActions(final RequestContext ctx, final DittoHeaders dittoHeaders, final PolicyId policyId,
             final AuthenticationResult authenticationResult) {
 
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_ACTIONS), () -> concat(
+        return rawPathPrefixSegment(PATH_ACTIONS, () -> concat(
                 // POST /policies/<policyId>/actions/activateTokenIntegration
-                rawPathPrefix(PathMatchers.slash().concat(ActivateTokenIntegration.NAME), () ->
+                rawPathPrefixSegment(ActivateTokenIntegration.NAME, () ->
                         pathEndOrSingleSlash(() ->
                                 extractJwt(dittoHeaders, authenticationResult, ActivateTokenIntegration.NAME, jwt ->
                                         post(() -> handleSubjectAnnouncement(this, dittoHeaders, sa ->
@@ -286,7 +286,7 @@ public final class PoliciesRoute extends AbstractRoute {
                         )
                 ),
                 // POST /policies/<policyId>/actions/deactivateTokenIntegration
-                rawPathPrefix(PathMatchers.slash().concat(DeactivateTokenIntegration.NAME), () ->
+                rawPathPrefixSegment(DeactivateTokenIntegration.NAME, () ->
                         pathEndOrSingleSlash(() ->
                                 extractJwt(dittoHeaders, authenticationResult, DeactivateTokenIntegration.NAME, jwt ->
                                         post(() -> handlePerRequest(ctx, topLevelDeactivateTokenIntegration(

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyEntriesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PolicyEntriesRoute.java
@@ -215,7 +215,7 @@ final class PolicyEntriesRoute extends AbstractRoute {
             final PolicyId policyId) {
 
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), label ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_SUFFIX_SUBJECTS), () ->
+                rawPathPrefixSegment(PATH_SUFFIX_SUBJECTS, () ->
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         get(() -> // GET /entries/<label>/subjects
@@ -250,7 +250,7 @@ final class PolicyEntriesRoute extends AbstractRoute {
             final PolicyId policyId) {
 
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), label ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_SUFFIX_SUBJECTS), () ->
+                rawPathPrefixSegment(PATH_SUFFIX_SUBJECTS, () ->
                         rawPathPrefix(PathMatchers.slash().concat(PathMatchers.remaining()), subjectId ->
                                 concat(
                                         get(() -> // GET /entries/<label>/subjects/<subjectId>
@@ -298,7 +298,7 @@ final class PolicyEntriesRoute extends AbstractRoute {
             final PolicyId policyId) {
 
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), label ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_SUFFIX_RESOURCES), () ->
+                rawPathPrefixSegment(PATH_SUFFIX_RESOURCES, () ->
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         get(() -> // GET /entries/<label>/resources
@@ -335,7 +335,7 @@ final class PolicyEntriesRoute extends AbstractRoute {
             final PolicyId policyId) {
 
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), label ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_SUFFIX_RESOURCES), () ->
+                rawPathPrefixSegment(PATH_SUFFIX_RESOURCES, () ->
                         extractUnmatchedPath(resource ->
                                 concat(
                                         get(() -> // GET /entries/<label>/resources/<resource>
@@ -541,9 +541,9 @@ final class PolicyEntriesRoute extends AbstractRoute {
             final PolicyId policyId, final AuthenticationResult authResult) {
 
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), label ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_ACTIONS), () -> concat(
+                rawPathPrefixSegment(PATH_ACTIONS, () -> concat(
                         // POST /entries/<label>/actions/activateTokenIntegration
-                        rawPathPrefix(PathMatchers.slash().concat(ActivateTokenIntegration.NAME), () ->
+                        rawPathPrefixSegment(ActivateTokenIntegration.NAME, () ->
                                 pathEndOrSingleSlash(() ->
                                         PoliciesRoute.extractJwt(dittoHeaders,
                                                 authResult,
@@ -561,7 +561,7 @@ final class PolicyEntriesRoute extends AbstractRoute {
                                         )
                                 )),
                         // POST /entries/<label>/actions/deactivateTokenIntegration
-                        rawPathPrefix(PathMatchers.slash().concat(DeactivateTokenIntegration.NAME), () ->
+                        rawPathPrefixSegment(DeactivateTokenIntegration.NAME, () ->
                                 pathEndOrSingleSlash(() ->
                                         PoliciesRoute.extractJwt(dittoHeaders,
                                                 authResult,

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.gateway.service.endpoints.routes.sse;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+import static org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute.rawPathPrefixSegment;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -291,7 +292,7 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
             final Supplier<CompletionStage<DittoHeaders>> dittoHeadersSupplier) {
 
         // /things
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_THINGS), () -> {
+        return rawPathPrefixSegment(PATH_THINGS, () -> {
             final CompletionStage<DittoHeaders> dhcs = dittoHeadersSupplier.get()
                     .thenApply(ThingsSseRouteBuilder::getDittoHeadersWithCorrelationId);
 
@@ -342,12 +343,14 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
     private Route buildSearchSseRoute(final RequestContext ctx,
             final Supplier<CompletionStage<DittoHeaders>> dittoHeadersSupplier) {
 
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_SEARCH).slash().concat(PATH_THINGS), () ->
-                pathEndOrSingleSlash(() -> {
-                    final CompletionStage<DittoHeaders> dittoHeaders = dittoHeadersSupplier.get()
-                            .thenApply(ThingsSseRouteBuilder::getDittoHeadersWithCorrelationId);
-                    return parameterMap(parameters -> createSearchSseRoute(ctx, dittoHeaders, parameters));
-                })
+        return rawPathPrefixSegment(PATH_SEARCH, () ->
+                rawPathPrefixSegment(PATH_THINGS, () ->
+                        pathEndOrSingleSlash(() -> {
+                            final CompletionStage<DittoHeaders> dittoHeaders = dittoHeadersSupplier.get()
+                                    .thenApply(ThingsSseRouteBuilder::getDittoHeadersWithCorrelationId);
+                            return parameterMap(parameters -> createSearchSseRoute(ctx, dittoHeaders, parameters));
+                        })
+                )
         );
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/status/OverallStatusRoute.java
@@ -12,13 +12,14 @@
  */
 package org.eclipse.ditto.gateway.service.endpoints.routes.status;
 
+import static org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute.rawPathPrefixSegment;
+
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import org.apache.pekko.http.javadsl.model.ContentTypes;
 import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.http.javadsl.model.StatusCodes;
-import org.apache.pekko.http.javadsl.server.PathMatchers;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.http.javadsl.server.directives.RouteDirectives;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -67,14 +68,14 @@ public final class OverallStatusRoute extends RouteDirectives {
      * @return the {@code /status} route.
      */
     public Route buildOverallStatusRoute(final String correlationId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_OVERALL), () ->  // /overall/*
+        return rawPathPrefixSegment(PATH_OVERALL, () ->  // /overall/*
             devOpsAuthenticationDirective.authenticateDevOps(DevOpsOAuth2AuthenticationDirective.REALM_STATUS,
                     DittoHeaders.newBuilder().correlationId(correlationId).build(),
                     get(() -> // GET
                             // /overall/status
                             // /overall/status/health
                             // /overall/status/cluster
-                            rawPathPrefix(PathMatchers.slash().concat(PATH_STATUS), () -> concat(
+                            rawPathPrefixSegment(PATH_STATUS, () -> concat(
                                     // /status
                                     pathEndOrSingleSlash(() -> completeWithFuture(createOverallStatusResponse())),
                                     // /status/health

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
@@ -81,7 +81,7 @@ final class FeaturesRoute extends AbstractRoute {
      * @return the {@code /features} route.
      */
     public Route buildFeaturesRoute(final RequestContext ctx, final DittoHeaders dittoHeaders, final ThingId thingId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_FEATURES), () ->
+        return rawPathPrefixSegment(PATH_FEATURES, () ->
                 concat(
                         features(ctx, dittoHeaders, thingId),
                         featuresEntry(ctx, dittoHeaders, thingId),
@@ -185,7 +185,7 @@ final class FeaturesRoute extends AbstractRoute {
     private Route featuresEntryDefinition(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final ThingId thingId) {
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), featureId ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_DEFINITION), () ->
+                rawPathPrefixSegment(PATH_DEFINITION, () ->
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         // GET /features/{featureId}/definition
@@ -230,7 +230,7 @@ final class FeaturesRoute extends AbstractRoute {
     private Route featuresEntryProperties(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final ThingId thingId) {
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), featureId ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_PROPERTIES), () ->
+                rawPathPrefixSegment(PATH_PROPERTIES, () ->
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         // GET /features/{featureId}/properties?fields=<fieldsString>
@@ -337,7 +337,7 @@ final class FeaturesRoute extends AbstractRoute {
     private Route featuresEntryDesiredProperties(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final ThingId thingId) {
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), featureId ->
-                rawPathPrefix(PathMatchers.slash().concat(PATH_DESIRED_PROPERTIES), () ->
+                rawPathPrefixSegment(PATH_DESIRED_PROPERTIES, () ->
                         pathEndOrSingleSlash(() ->
                                 concat(
                                         // GET /features/{featureId}/desiredProperties?fields=<fieldsString>

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/MessagesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/MessagesRoute.java
@@ -128,8 +128,8 @@ final class MessagesRoute extends AbstractRoute {
      * @return route for claim messages resource.
      */
     private Route claimMessages(final RequestContext ctx, final DittoHeaders dittoHeaders, final ThingId thingId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_INBOX), () -> // /inbox
-                rawPathPrefix(PathMatchers.slash().concat(PATH_CLAIM), () -> // /inbox/claim
+        return rawPathPrefixSegment(PATH_INBOX, () -> // /inbox
+                rawPathPrefixSegment(PATH_CLAIM, () -> // /inbox/claim
                         post(() ->
                                 pathEndOrSingleSlash(() ->
                                         withCustomRequestTimeout(dittoHeaders.getTimeout().orElse(null),

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/ThingsRoute.java
@@ -160,7 +160,7 @@ public final class ThingsRoute extends AbstractRoute {
      * @return the {@code /things} route.
      */
     public Route buildThingsRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_THINGS), () ->
+        return rawPathPrefixSegment(PATH_THINGS, () ->
                 concat(
                         things(ctx, dittoHeaders),
                         rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()),
@@ -515,7 +515,7 @@ public final class ThingsRoute extends AbstractRoute {
      */
     private Route thingsEntryAttributes(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final ThingId thingId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_ATTRIBUTES), () ->
+        return rawPathPrefixSegment(PATH_ATTRIBUTES, () ->
                 pathEndOrSingleSlash(() ->
                         concat(
                                 // GET /things/<thingId>/attributes?fields=<fieldsString>
@@ -619,7 +619,7 @@ public final class ThingsRoute extends AbstractRoute {
      */
     private Route thingsEntryDefinition(final RequestContext ctx, final DittoHeaders dittoHeaders,
             final ThingId thingId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_THING_DEFINITION), () ->
+        return rawPathPrefixSegment(PATH_THING_DEFINITION, () ->
                 pathEndOrSingleSlash(() ->
                         concat(
                                 // GET /things/<thingId>/definition
@@ -657,7 +657,7 @@ public final class ThingsRoute extends AbstractRoute {
     private Route thingsEntryMigrateDefinition(final RequestContext ctx,
             final DittoHeaders dittoHeaders,
             final ThingId thingId) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_MIGRATE_DEFINITION), () ->
+        return rawPathPrefixSegment(PATH_MIGRATE_DEFINITION, () ->
                 pathEndOrSingleSlash(() ->
                         // POST /things/<thingId>/migrateDefinition
                         ensureMediaTypeJsonWithFallbacksThenExtractDataBytes(ctx, dittoHeaders,

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/thingsearch/ThingSearchRoute.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import org.apache.pekko.http.javadsl.server.Directives;
-import org.apache.pekko.http.javadsl.server.PathMatchers;
 import org.apache.pekko.http.javadsl.server.RequestContext;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
@@ -79,8 +77,8 @@ public final class ThingSearchRoute extends AbstractRoute {
      * @return the {@code /search}} route.
      */
     public Route buildSearchRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return Directives.rawPathPrefix(PathMatchers.slash().concat(PATH_SEARCH), () ->
-                Directives.rawPathPrefix(PathMatchers.slash().concat(PATH_THINGS),
+        return rawPathPrefixSegment(PATH_SEARCH, () ->
+                rawPathPrefixSegment(PATH_THINGS,
                         () -> // /search/things
                                 concat(
                                         // /search/things/count

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/whoami/WhoamiRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/whoami/WhoamiRoute.java
@@ -41,7 +41,7 @@ public final class WhoamiRoute extends AbstractRoute {
     }
 
     public Route buildWhoamiRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return rawPathPrefix(PathMatchers.slash().concat(PATH_WHOAMI), () -> whoami(ctx, dittoHeaders));
+        return rawPathPrefixSegment(PATH_WHOAMI, () -> whoami(ctx, dittoHeaders));
     }
 
     private Route whoami(final RequestContext ctx, final DittoHeaders dittoHeaders) {

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRouteTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.endpoints.routes;
+
+import static org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute.rawPathPrefixSegment;
+
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.StatusCodes;
+import org.apache.pekko.http.javadsl.server.Directives;
+import org.apache.pekko.http.javadsl.testkit.JUnitRouteTest;
+import org.apache.pekko.http.javadsl.testkit.TestRoute;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link AbstractRoute#rawPathPrefixSegment(String, java.util.function.Supplier)}.
+ * <p>
+ * The contract is strict, full-segment matching (not prefix matching): {@code /<segment>} is only matched when the
+ * next path segment equals the constant <em>in its entirety</em>, and a non-match rejects so that sibling routes
+ * still get a chance to match the unconsumed path.
+ */
+public final class AbstractRouteTest extends JUnitRouteTest {
+
+    private static final String SEGMENT = "logging";
+
+    @Test
+    public void exactSegmentMatchesAndDelegatesToInner() {
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/logging"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("matched");
+    }
+
+    @Test
+    public void exactSegmentWithTrailingSlashStillMatches() {
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.pathEndOrSingleSlash(
+                        () -> Directives.complete("matched"))));
+
+        underTest.run(HttpRequest.GET("/logging/"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("matched");
+    }
+
+    @Test
+    public void segmentWithTrailingSuffixIsRejected() {
+        // "loggingh" must NOT be matched as a prefix of "logging"; the request must be rejected (404) instead of
+        // being silently routed to the "logging" handler with the trailing characters dangling.
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/loggingh"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void rejectionBacktracksSoSiblingRouteCanMatch() {
+        // A non-matching segment must leave the path untouched so a sibling route whose constant is a *superstring*
+        // of the first still matches. With prefix matching the first route would wrongly swallow "/loggingh".
+        final TestRoute underTest = testRoute(Directives.concat(
+                rawPathPrefixSegment("logging", () -> Directives.complete("logging-route")),
+                rawPathPrefixSegment("loggingh", () -> Directives.complete("loggingh-route"))));
+
+        underTest.run(HttpRequest.GET("/logging"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("logging-route");
+        underTest.run(HttpRequest.GET("/loggingh"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("loggingh-route");
+    }
+
+    @Test
+    public void innerReceivesTheRemainingPath() {
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment("things", () ->
+                        rawPathPrefixSegment("foo", () -> Directives.complete("nested"))));
+
+        // exact nested match
+        underTest.run(HttpRequest.GET("/things/foo"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("nested");
+        // a typo in the outer segment must not leak into the nested matcher
+        underTest.run(HttpRequest.GET("/thingsX/foo"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+        // a typo in the inner segment must be rejected as well
+        underTest.run(HttpRequest.GET("/things/foobar"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void innerReceivesExactUnmatchedRemainderWithDeeperPath() {
+        // Exactly one segment plus its leading slash must be consumed; everything after the matched segment is
+        // handed to the inner verbatim. This is the contract the production consumers rely on (policy "resources"
+        // -> extractUnmatchedPath, "subjects" -> remaining()).
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment("resources", () ->
+                        Directives.extractUnmatchedPath(Directives::complete)));
+
+        underTest.run(HttpRequest.GET("/resources/a/b"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("/a/b");
+    }
+
+    @Test
+    public void innerReceivesEmptyRemainderWhenSegmentIsWholePath() {
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment("resources", () ->
+                        Directives.extractUnmatchedPath(Directives::complete)));
+
+        underTest.run(HttpRequest.GET("/resources"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("");
+    }
+
+    @Test
+    public void innerReceivesSingleSlashRemainderForTrailingSlash() {
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment("resources", () ->
+                        Directives.extractUnmatchedPath(Directives::complete)));
+
+        underTest.run(HttpRequest.GET("/resources/"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("/");
+    }
+
+    @Test
+    public void segmentMatchIsCaseSensitive() {
+        // The match uses String.equals, so a differently-cased segment must not match.
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/LOGGING"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void rootPathDoesNotMatchSegment() {
+        // The root path carries no segment to capture, so the matcher must reject.
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void shorterRequestThanConstantIsRejected() {
+        // Symmetric to segmentWithTrailingSuffixIsRejected: a request shorter than the constant must not match.
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/log"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void encodedSegmentIsDecodedBeforeComparison() {
+        // Characterization test: PathMatchers.segment() yields the decoded segment, so "%67" (== 'g') decodes to
+        // "logging" and matches. This documents the (decode-then-compare) behavior of the new matcher.
+        final TestRoute underTest = testRoute(
+                rawPathPrefixSegment(SEGMENT, () -> Directives.complete("matched")));
+
+        underTest.run(HttpRequest.GET("/loggin%67"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("matched");
+    }
+
+}

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRouteTest.java
@@ -89,6 +89,15 @@ public final class DevOpsRouteTest extends EndpointTestBase {
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
     }
 
+    @Test
+    public void testLoggingWithTypoInPathSegmentIsRejected() {
+        // "loggingh" must not be matched as a prefix of the "logging" route segment;
+        // a malformed segment must be rejected (404) instead of being silently treated
+        // as a logger-config request to all services.
+        final var result = underTest.run(HttpRequest.GET("/devops/loggingh/gateway"));
+        result.assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
     private static DevOpsConfig getInsecureDevopsConfig() {
         return DefaultDevOpsConfig.of(ConfigFactory.parseString("devops.secured=false"));
     }


### PR DESCRIPTION
This PR addresses a strange behavior where if for example 
/devops/logging/gaDeway 
is called it is correctly timing out as there is no such service but if we add a letter to the 'logging' segment
/devops/loggingA/gaDeway 
the logging part is matched as a prefix then the rest 'A/gaDeway' is passed along but since the next handle checks for leading slash the segment is dropped and the call is handled as it was 
/devops/logging

This behavior can potentially reach at any place where no strict segment matching is done.

System tests run:
https://github.com/eclipse-ditto/ditto/actions/runs/28428560314