### PR TITLE
Add Ditto 3.9.3 release notes and Helm chart 4.3.0

### DIFF
--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -15,6 +15,20 @@ sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
 ## [Unreleased]
 
+## [4.3.0]
+
+Bumped Ditto `appVersion` to `3.9.3`.
+
+### Added
+- New `namespaceFilteredMaxSize` (default `100`) under the policy-enforcer `cache` config of the
+  `policies`, `things` and `connectivity` services, bounding the per-enforcer cache of namespace-filtered
+  enforcers so the enforcer tree is no longer rebuilt per signal for policies with namespace-scoped entries
+  ([#2480](https://github.com/eclipse-ditto/ditto/pull/2480))
+
+### Fixed
+- Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
+  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478))
+
 ## [4.2.0]
 
 Bumped Ditto `appVersion` to `3.9.2`.

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,8 +16,8 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.2.2  # chart version is effectively set by release-job
-appVersion: 3.9.2
+version: 4.3.0  # chart version is effectively set by release-job
+appVersion: 3.9.3
 keywords:
   - iot-chart
   - digital-twin

--- a/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
+++ b/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
@@ -702,6 +702,9 @@ entries:
       - title: Release Notes
         output: web
         folderitems:
+          - title: 3.9.3
+            url: /release_notes_393.html
+            output: web
           - title: 3.9.2
             url: /release_notes_392.html
             output: web

--- a/documentation/src/main/resources/pages/ditto/release_notes_393.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_393.md
@@ -1,0 +1,67 @@
+---
+title: Release notes 3.9.3
+tags: [release_notes]
+published: true
+keywords: release notes, announcements, changelog
+summary: "Version 3.9.3 of Eclipse Ditto, released on 06.07.2026"
+permalink: release_notes_393.html
+---
+
+This is a bugfix release, no new features since [3.9.2](release_notes_392.html) were added.
+
+## Changelog
+
+Compared to the latest release [3.9.2](release_notes_392.html), the following changes and bugfixes were added.
+
+### Changes
+
+This is a complete list of the
+[merged pull requests](https://github.com/eclipse-ditto/ditto/pulls?q=is%3Apr+milestone%3A3.9.3).
+
+#### Cache partial-access-paths enrichment per Thing
+
+PR [#2481](https://github.com/eclipse-ditto/ditto/pull/2481) improves the performance of the partial-access-paths event
+enrichment introduced with the 3.9.0 partial-events feature. The accessible JSON paths per subject were previously
+recomputed for every `ThingEvent` of a Thing whose policy grants *restricted* READ to some subject. As the result only
+depends on the policy revision and the Thing structure (not on field values), it is now cached per Thing and reused
+across value-only updates. The cache can be disabled via `event.partial-access-events.cache.enabled` (default `true`,
+env `THING_EVENT_PARTIAL_ACCESS_EVENTS_CACHE_ENABLED`).
+
+#### Cache namespace-filtered policy enforcers
+
+PR [#2480](https://github.com/eclipse-ditto/ditto/pull/2480) improves the performance of policy enforcement for policies
+that use the namespace-scoped entries introduced with [#2325](https://github.com/eclipse-ditto/ditto/issues/2325) in
+3.9.0. The namespace-filtered enforcer, previously rebuilt on every enforced signal, is now cached per namespace and
+reused. The cache size is operator-configurable via
+`ditto.policies-enforcer-cache.namespace-filtered-enforcer-max-size` (default `100`, env
+`DITTO_POLICIES_ENFORCER_NAMESPACE_FILTERED_MAX_SIZE`), exposed through the Helm values and the policies, things and
+connectivity deployment templates.
+
+#### Dependency updates
+
+PR [#2475](https://github.com/eclipse-ditto/ditto/pull/2475) updates several third-party dependencies to their latest
+compatible versions.
+
+### Bugfixes
+
+#### Fix strict segment matching in HTTP gateway routes
+
+PR [#2479](https://github.com/eclipse-ditto/ditto/pull/2479) fixes a route matching issue where a path segment was
+matched as a prefix rather than requiring an exact match. For example, a request to `/devops/loggingA/...` matched the
+`logging` route as a prefix, the remainder was passed along, and — because the next handler strips a leading slash — the
+request was ultimately handled as if it targeted `/devops/logging`. Segment matching is now strict, so only exact segment
+names are matched.
+
+
+### Helm Chart
+
+The accompanying Helm chart was released as version `4.3.0`. It exposes the new
+`namespaceFilteredMaxSize` option (default `100`) on the policy-enforcer cache of the `policies`, `things`
+and `connectivity` services (PR [#2480](https://github.com/eclipse-ditto/ditto/pull/2480)) and includes a
+fix to the Swagger UI deployment so the OpenID Connect login works (PR
+[#2478](https://github.com/eclipse-ditto/ditto/pull/2478)).
+
+
+## Migration notes
+
+No known migration steps are required for this release.


### PR DESCRIPTION
Release notes for the 3.9.3 patch release (PRs #2481, #2480, #2475, #2479) and sidebar entry.

Bump Helm chart to 4.3.0 (appVersion 3.9.3) and document the accumulated unreleased chart changes in the CHANGELOG:
- Added: namespaceFilteredMaxSize policy-enforcer cache option (#2480)
- Fixed: Swagger UI OIDC JS mount (#2478)