### PR TITLE
Categorize cluster (de)serialization metrics and drop per-op allocation in metric wrappers

### DIFF
--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
@@ -21,7 +21,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -40,8 +44,14 @@ import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.json.Jsonifiable;
 import org.eclipse.ditto.base.model.signals.JsonParsable;
+import org.eclipse.ditto.base.model.signals.WithResource;
 import org.eclipse.ditto.base.model.signals.WithType;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgements;
+import org.eclipse.ditto.base.model.signals.announcements.Announcement;
 import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
+import org.eclipse.ditto.base.model.signals.events.Event;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.counter.Counter;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
@@ -90,14 +100,19 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
 
     private static final String METRIC_NAME_SUFFIX = "_serializer_messages";
     private static final String METRIC_DIRECTION = "direction";
+    private static final String METRIC_CATEGORY = "category";
+    private static final String METRIC_RESOURCE_TYPE = "resource_type";
+    private static final String DIRECTION_IN = "in";
+    private static final String DIRECTION_OUT = "out";
+    private static final String RESOURCE_TYPE_OTHER = "other";
 
     private final int identifier;
     private final MappingStrategies mappingStrategies;
     private final Function<Object, String> manifestProvider;
     private final BufferPool byteBufferPool;
     private final Long defaultBufferSize;
-    private final Counter inCounter;
-    private final Counter outCounter;
+    private final Map<Category, ConcurrentMap<String, Counter>> inCounters;
+    private final Map<Category, ConcurrentMap<String, Counter>> outCounters;
     private final String serializerName;
 
     /**
@@ -127,10 +142,54 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
         final var maxPoolEntries = config.withFallback(FALLBACK_CONF).getInt(CONFIG_DIRECT_BUFFER_POOL_LIMIT);
         byteBufferPool = new DirectByteBufferPool(defaultBufferSize.intValue(), maxPoolEntries);
 
-        inCounter = DittoMetrics.counter(serializerName.toLowerCase() + METRIC_NAME_SUFFIX)
-                .tag(METRIC_DIRECTION, "in");
-        outCounter = DittoMetrics.counter(serializerName.toLowerCase() + METRIC_NAME_SUFFIX)
-                .tag(METRIC_DIRECTION, "out");
+        inCounters = newCategoryCounterCache();
+        outCounters = newCategoryCounterCache();
+    }
+
+    private static Map<Category, ConcurrentMap<String, Counter>> newCategoryCounterCache() {
+        final Map<Category, ConcurrentMap<String, Counter>> cache = new EnumMap<>(Category.class);
+        for (final Category category : Category.values()) {
+            cache.put(category, new ConcurrentHashMap<>());
+        }
+        return cache;
+    }
+
+    /**
+     * Increments the {@code <serializer>_serializer_messages} counter tagged with the {@code direction}, the coarse
+     * signal {@code category} and the {@code resource_type} of the passed {@code object}. The fully tagged counters
+     * are cached per {@code (category, resource_type)} combination so that on the hot (de)serialization path only a map
+     * lookup and the increment are performed; the tagged counter is built at most once per combination and serializer.
+     *
+     * @param countersByCategory the direction-specific counter cache ({@link #inCounters} or {@link #outCounters}).
+     * @param direction the {@code direction} tag value ({@value #DIRECTION_IN} or {@value #DIRECTION_OUT}).
+     * @param object the (de)serialized object to classify.
+     */
+    private void incrementCounter(final Map<Category, ConcurrentMap<String, Counter>> countersByCategory,
+            final String direction, final Object object) {
+
+        final var category = Category.of(object);
+        final var resourceType = resourceTypeOf(object);
+        final var countersByResourceType = countersByCategory.get(category);
+        var counter = countersByResourceType.get(resourceType);
+        if (null == counter) {
+            // slow path, hit at most once per (category, resource_type) combination for a serializer's lifetime:
+            counter = countersByResourceType.computeIfAbsent(resourceType,
+                    rt -> DittoMetrics.counter(serializerName.toLowerCase() + METRIC_NAME_SUFFIX)
+                            .tag(METRIC_DIRECTION, direction)
+                            .tag(METRIC_CATEGORY, category.getTag())
+                            .tag(METRIC_RESOURCE_TYPE, rt));
+        }
+        counter.increment();
+    }
+
+    private static String resourceTypeOf(final Object object) {
+        final String result;
+        if (object instanceof WithResource withResource) {
+            result = withResource.getResourceType();
+        } else {
+            result = RESOURCE_TYPE_OTHER;
+        }
+        return result;
     }
 
     @Override
@@ -155,7 +214,7 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
             try {
                 serializeIntoByteBuffer(jsonObject, buf);
                 LOG.trace("toBinary jsonStr about to send 'out': {}", jsonObject);
-                outCounter.increment();
+                incrementCounter(outCounters, DIRECTION_OUT, object);
             } catch (final BufferOverflowException e) {
                 final var errorMessage = MessageFormat.format(
                         "Could not put bytes of JSON string <{0}> into ByteBuffer due to BufferOverflow",
@@ -282,7 +341,7 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
                         serializerName,
                         BinaryToHexConverter.createDebugMessageByTryingToConvertToHexString(buf));
             }
-            inCounter.increment();
+            incrementCounter(inCounters, DIRECTION_IN, jsonifiable);
             return jsonifiable;
         } catch (final NotSerializableException e) {
             return e;
@@ -446,6 +505,53 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
     private static String getDefaultManifestOrThrow(final JsonObject jsonObject) throws NotSerializableException {
         return jsonObject.getValue(Command.JsonFields.TYPE)
                 .orElseThrow(() -> new NotSerializableException("No type found for inner JSON!"));
+    }
+
+    /**
+     * Coarse, low-cardinality classification of a (de)serialized message, used as the {@code category} metric tag to
+     * understand the composition of cluster (de)serialization traffic - e.g. distinguishing event fan-out from command
+     * load. It is combined with the {@code resource_type} tag (derived from {@link WithResource#getResourceType()}).
+     */
+    private enum Category {
+
+        EVENT("event"),
+        COMMAND("command"),
+        RESPONSE("response"),
+        ACKNOWLEDGEMENT("acknowledgement"),
+        ANNOUNCEMENT("announcement"),
+        ERROR("error"),
+        OTHER("other");
+
+        private final String tag;
+
+        Category(final String tag) {
+            this.tag = tag;
+        }
+
+        private String getTag() {
+            return tag;
+        }
+
+        private static Category of(final Object object) {
+            final Category result;
+            // order matters: more specific types must be checked first (e.g. an Acknowledgement is a CommandResponse):
+            if (object instanceof Event) {
+                result = EVENT;
+            } else if (object instanceof Announcement) {
+                result = ANNOUNCEMENT;
+            } else if (object instanceof Acknowledgement || object instanceof Acknowledgements) {
+                result = ACKNOWLEDGEMENT;
+            } else if (object instanceof CommandResponse) {
+                result = RESPONSE;
+            } else if (object instanceof Command) {
+                result = COMMAND;
+            } else if (object instanceof DittoRuntimeException) {
+                result = ERROR;
+            } else {
+                result = OTHER;
+            }
+            return result;
+        }
     }
 
 }

--- a/internal/utils/cluster/src/test/java/org/eclipse/ditto/internal/utils/cluster/SharedJsonifiableSerializerTest.java
+++ b/internal/utils/cluster/src/test/java/org/eclipse/ditto/internal/utils/cluster/SharedJsonifiableSerializerTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.internal.utils.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.AutoCloseableSoftAssertions;
@@ -27,6 +28,10 @@ import org.eclipse.ditto.base.model.signals.GlobalErrorRegistry;
 import org.eclipse.ditto.base.model.signals.ShardedMessageEnvelope;
 import org.eclipse.ditto.base.model.signals.commands.GlobalCommandRegistry;
 import org.eclipse.ditto.base.model.signals.commands.GlobalCommandResponseRegistry;
+import org.eclipse.ditto.base.model.signals.events.GlobalEventRegistry;
+import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
+import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
+import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracingInitResource;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.Thing;
@@ -35,6 +40,7 @@ import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.CreateThingResponse;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThings;
+import org.eclipse.ditto.things.model.signals.events.ThingCreated;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -58,18 +64,24 @@ public final class SharedJsonifiableSerializerTest {
 
     private static enum SerializerImplementation {
 
-        JSONIFIABLE_SERIALIZER {
+        JSONIFIABLE_SERIALIZER("json_serializer_messages") {
             @Override
             public AbstractJsonifiableWithDittoHeadersSerializer getInstance(final ExtendedActorSystem actorSystem) {
                 return new JsonJsonifiableSerializer(actorSystem);
             }
         },
-        CBOR_JSONIFIABLE_SERIALIZER {
+        CBOR_JSONIFIABLE_SERIALIZER("cbor_serializer_messages") {
             @Override
             public AbstractJsonifiableWithDittoHeadersSerializer getInstance(final ExtendedActorSystem actorSystem) {
                 return new CborJsonifiableSerializer(actorSystem);
             }
         };
+
+        private final String metricName;
+
+        SerializerImplementation(final String metricName) {
+            this.metricName = metricName;
+        }
 
         abstract AbstractJsonifiableWithDittoHeadersSerializer getInstance(ExtendedActorSystem actorSystem);
 
@@ -244,6 +256,111 @@ public final class SharedJsonifiableSerializerTest {
             DittoHeadersStrategy() {
                 super(MappingStrategiesBuilder.newInstance()
                         .add(DittoHeaders.class, jsonObject -> DittoHeaders.newBuilder(jsonObject).build())
+                        .build());
+            }
+
+        }
+
+    }
+
+    /**
+     * Verifies that the {@code <serializer>_serializer_messages} counter is tagged with the expected
+     * {@code direction}, coarse signal {@code category} and {@code resource_type} for the (de)serialized signal.
+     */
+    @RunWith(Parameterized.class)
+    public static final class CategoryAndResourceTypeTagTest {
+
+        private static final String TAG_DIRECTION = "direction";
+        private static final String TAG_CATEGORY = "category";
+        private static final String TAG_RESOURCE_TYPE = "resource_type";
+
+        @ClassRule
+        public static final DittoTracingInitResource DITTO_TRACING_INIT_RESOURCE =
+                DittoTracingInitResource.disableDittoTracing();
+
+        private static Thing thing;
+        private static ExtendedActorSystem actorSystem;
+
+        @Parameterized.Parameter
+        public SerializerImplementation serializerImplementation;
+
+        private AbstractJsonifiableWithDittoHeadersSerializer underTest;
+
+        @Parameterized.Parameters(name = "{0}")
+        public static SerializerImplementation[] getSerializers() {
+            return SerializerImplementation.values();
+        }
+
+        @BeforeClass
+        public static void setUpClass() {
+            thing = Thing.newBuilder().setId(ThingId.generateRandom()).build();
+            actorSystem = getActorSystem(ThingSignalsStrategy.class);
+        }
+
+        @AfterClass
+        public static void tearDownClass() {
+            TestKit.shutdownActorSystem(actorSystem);
+        }
+
+        @Before
+        public void setUp() {
+            underTest = serializerImplementation.getInstance(actorSystem);
+        }
+
+        @Test
+        public void thingCommandIsTaggedAsCommandOnThingResource() {
+            assertRoundTripTaggedWith(CreateThing.of(thing, null, DITTO_HEADERS), "command", "thing");
+        }
+
+        @Test
+        public void thingCommandResponseIsTaggedAsResponseOnThingResource() {
+            assertRoundTripTaggedWith(CreateThingResponse.of(thing, DITTO_HEADERS), "response", "thing");
+        }
+
+        @Test
+        public void thingEventIsTaggedAsEventOnThingResource() {
+            assertRoundTripTaggedWith(ThingCreated.of(thing, 1L, null, DITTO_HEADERS, null), "event", "thing");
+        }
+
+        private void assertRoundTripTaggedWith(final Object signal, final String expectedCategory,
+                final String expectedResourceType) {
+
+            final long outBefore = counterCount("out", expectedCategory, expectedResourceType);
+            final long inBefore = counterCount("in", expectedCategory, expectedResourceType);
+
+            final byte[] serialized = underTest.toBinary(signal);
+            final Object deserialized = underTest.fromBinary(serialized, underTest.manifest(signal));
+
+            try (final AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
+                softly.assertThat(deserialized)
+                        .as("round-trip result")
+                        .isEqualTo(signal);
+                softly.assertThat(counterCount("out", expectedCategory, expectedResourceType))
+                        .as("'out' count for category=<%s>, resource_type=<%s>", expectedCategory, expectedResourceType)
+                        .isEqualTo(outBefore + 1);
+                softly.assertThat(counterCount("in", expectedCategory, expectedResourceType))
+                        .as("'in' count for category=<%s>, resource_type=<%s>", expectedCategory, expectedResourceType)
+                        .isEqualTo(inBefore + 1);
+            }
+        }
+
+        private long counterCount(final String direction, final String category, final String resourceType) {
+            final TagSet tags = TagSet.ofTagCollection(List.of(
+                    Tag.of(TAG_DIRECTION, direction),
+                    Tag.of(TAG_CATEGORY, category),
+                    Tag.of(TAG_RESOURCE_TYPE, resourceType)));
+            return DittoMetrics.counter(serializerImplementation.metricName, tags).getCount();
+        }
+
+        private static final class ThingSignalsStrategy extends MappingStrategies {
+
+            ThingSignalsStrategy() {
+                super(MappingStrategiesBuilder.newInstance()
+                        .add(GlobalErrorRegistry.getInstance())
+                        .add(GlobalCommandRegistry.getInstance())
+                        .add(GlobalCommandResponseRegistry.getInstance())
+                        .add(GlobalEventRegistry.getInstance())
+                        .add(Thing.class, ThingsModelFactory::newThing)
                         .build());
             }
 

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
@@ -37,6 +37,14 @@ public final class KamonCounter implements Counter {
     private final String name;
     private final TagSet tags;
 
+    /**
+     * Memoized resolved Kamon counter. {@code name} and {@code tags} are immutable (and {@link #tag(Tag)} /
+     * {@link #tags(TagSet)} return new instances), so the resolved instrument is invariant and can be cached to avoid
+     * re-resolving it (registry lookup + tag-set conversion) on every {@link #increment()}.
+     */
+    @SuppressWarnings("squid:S3077")
+    private transient volatile kamon.metric.Counter kamonInternalCounter;
+
     private KamonCounter(final String name, final TagSet tags) {
         this.name = argumentNotEmpty(name, "name");
         this.tags = checkNotNull(tags, "tags");
@@ -102,7 +110,13 @@ public final class KamonCounter implements Counter {
     }
 
     private kamon.metric.Counter getKamonInternalCounter() {
-        return Kamon.counter(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+        kamon.metric.Counter result = kamonInternalCounter;
+        if (null == result) {
+            // benign race: for a given (name, tags) Kamon returns the same instrument, so a redundant resolve is safe:
+            result = Kamon.counter(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+            kamonInternalCounter = result;
+        }
+        return result;
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
@@ -34,6 +34,14 @@ public final class KamonGauge implements Gauge {
     private final String name;
     private final TagSet tags;
 
+    /**
+     * Memoized resolved Kamon gauge. {@code name} and {@code tags} are immutable (and {@link #tag(Tag)} /
+     * {@link #tags(TagSet)} return new instances), so the resolved instrument is invariant and can be cached to avoid
+     * re-resolving it (registry lookup + tag-set conversion) on every gauge operation.
+     */
+    @SuppressWarnings("squid:S3077")
+    private transient volatile kamon.metric.Gauge kamonInternalGauge;
+
     private KamonGauge(final String name, final TagSet tags) {
         this.name = name;
         this.tags = tags;
@@ -107,7 +115,13 @@ public final class KamonGauge implements Gauge {
     }
 
     private kamon.metric.Gauge getKamonInternalGauge() {
-        return Kamon.gauge(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+        kamon.metric.Gauge result = kamonInternalGauge;
+        if (null == result) {
+            // benign race: for a given (name, tags) Kamon returns the same instrument, so a redundant resolve is safe:
+            result = Kamon.gauge(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+            kamonInternalGauge = result;
+        }
+        return result;
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/histogram/KamonHistogram.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/histogram/KamonHistogram.java
@@ -42,6 +42,14 @@ public final class KamonHistogram implements Histogram {
     private final String name;
     private final TagSet tags;
 
+    /**
+     * Memoized resolved Kamon histogram. {@code name} and {@code tags} are immutable (and {@link #tag(Tag)} /
+     * {@link #tags(TagSet)} return new instances), so the resolved instrument is invariant and can be cached to avoid
+     * re-resolving it (registry lookup + tag-set conversion) on every {@link #record(Long)}.
+     */
+    @SuppressWarnings("squid:S3077")
+    private transient volatile kamon.metric.Histogram kamonInternalHistogram;
+
     private KamonHistogram(final String name, final TagSet tags) {
         this.name = name;
         this.tags = tags;
@@ -112,7 +120,13 @@ public final class KamonHistogram implements Histogram {
     }
 
     private kamon.metric.Histogram getKamonInternalHistogram() {
-        return Kamon.histogram(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+        kamon.metric.Histogram result = kamonInternalHistogram;
+        if (null == result) {
+            // benign race: for a given (name, tags) Kamon returns the same instrument, so a redundant resolve is safe:
+            result = Kamon.histogram(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+            kamonInternalHistogram = result;
+        }
+        return result;
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/PreparedKamonTimer.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/PreparedKamonTimer.java
@@ -46,6 +46,14 @@ final class PreparedKamonTimer implements PreparedTimer {
     private final Consumer<StartedTimer> additionalExpirationHandling;
     private TagSet tags;
 
+    /**
+     * Memoized resolved Kamon timer, invalidated whenever {@link #tags} changes (see {@link #tag(Tag)} /
+     * {@link #tags(TagSet)}). Avoids re-resolving the instrument (registry lookup + tag-set conversion) on every
+     * {@link #record(long, TimeUnit)} of a reused prepared timer.
+     */
+    @SuppressWarnings("squid:S3077")
+    private transient volatile kamon.metric.Timer kamonInternalTimer;
+
     private PreparedKamonTimer(final String name) {
         this(name, Duration.ofMinutes(5), startedTimer -> {}, TagSet.empty());
     }
@@ -101,12 +109,14 @@ final class PreparedKamonTimer implements PreparedTimer {
     @Override
     public PreparedTimer tag(final Tag tag) {
         tags = tags.putTag(tag);
+        kamonInternalTimer = null;
         return this;
     }
 
     @Override
     public PreparedTimer tags(final TagSet tags) {
         this.tags = this.tags.putAllTags(tags);
+        kamonInternalTimer = null;
         return this;
     }
 
@@ -189,7 +199,13 @@ final class PreparedKamonTimer implements PreparedTimer {
     }
 
     private kamon.metric.Timer getKamonInternalTimer() {
-        return Kamon.timer(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+        kamon.metric.Timer result = kamonInternalTimer;
+        if (null == result) {
+            // benign race: for a given (name, tags) Kamon returns the same instrument, so a redundant resolve is safe:
+            result = Kamon.timer(name).withTags(KamonTagSetConverter.getKamonTagSet(tags));
+            kamonInternalTimer = result;
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
## What & why

Two related improvements around cluster (de)serialization metrics: better **insight** into where serialization traffic comes from, and a lower-cost, **allocation-free** metric increment path.

### 1. Categorize cluster (de)serialization metrics

The `<serializer>_serializer_messages` counter (in `AbstractJsonifiableWithDittoHeadersSerializer`) currently only carries a `direction` (`in`/`out`) tag. That makes it hard to explain spikes in cluster CBOR/JSON serialization: a doubling of the counter could equally be event fan-out to more subscribers, a burst of inbound commands, a wave of policy `sudo` fetches, or response traffic — all indistinguishable.

This adds two low-cardinality tags derived at the (de)serialization site:

- **`category`** — coarse signal kind: `event`, `command`, `response`, `acknowledgement`, `announcement`, `error`, `other` (via `instanceof`, ordered so `Acknowledgement` is classified before `CommandResponse`).
- **`resource_type`** — from `WithResource#getResourceType()` (`thing`, `policy`, `connectivity`, `message`, `thing-search`, and the `*-sudo` variants…), or `other` for non-signal envelopes.

Together these let operators attribute spikes directly — e.g. `category=event,resource_type=thing` for live/streaming fan-out vs `category=command,resource_type=thing` for write load, and `resource_type=policy-sudo`/`thing-sudo` to spot cross-node enforcement policy fetches. `direction` is unchanged, so existing dashboards keep working; the new tags are additive.

Cardinality stays modest: ~7 categories × ~18 resource types × 2 directions per serializer, and most combinations never co-occur. The fully-tagged counters are cached per `(category, resource_type)` so the hot path is a map lookup + increment.

### 2. Memoize the resolved Kamon instrument in the metric wrappers

`KamonCounter`, `KamonGauge`, `KamonHistogram` and `PreparedKamonTimer` re-resolved their underlying Kamon instrument on **every** operation:

```java
Kamon.counter(name).withTags(KamonTagSetConverter.getKamonTagSet(tags)).increment();
```

That is a metric-registry lookup **plus a per-call allocation** of a Kamon `TagSet` (the `getKamonTagSet` builder) on every increment/record — even though `(name, tags)` is invariant for a given wrapper. This is now memoized in a `volatile` field, so the hot path becomes a volatile read + the actual op, with no per-op allocation.

`Counter`/`Gauge`/`Histogram` have immutable tags (copy-on-write `tag()`/`tags()`), so a plain lazy memo is safe. `PreparedKamonTimer` mutates its tags in place, so the cache is invalidated in `tag()`/`tags()`. `StoppedKamonTimer` is single-use per stop with dynamic segment tags and is intentionally left unchanged.

This benefits every metric in Ditto, and in particular the now-per-message serializer counter on the cluster (de)serialization hot path.

#### Micro-benchmark (JMH, AverageTime, JDK, 1 fork · 3 warmup · 5 measurement iterations)

| Benchmark                                  | ns/op        | vs. old |
|--------------------------------------------|--------------|---------|
| re-resolve per increment (old)             | 83.8 ± 1.9   | 1.0×    |
| re-resolve, tags converted once            | 33.3 ± 0.8   | 2.5×    |
| memoized wrapper (this PR)                 | 7.9 ± 1.1    | 10.6×   |
| pre-resolved instrument (theoretical floor)| 7.9 ± 2.1    | 10.6×   |

The memoized path matches the theoretical floor (the volatile read is free), and is ~10.6× faster than re-resolving. Of the ~84 ns saved, roughly ~50 ns was the per-call `TagSet` allocation/conversion and ~25 ns the registry `withTags` lookup. The allocation removal also reduces GC pressure on the hot path.

## Compatibility

- Existing metric names and the `direction` tag are unchanged; the `category`/`resource_type` tags are additive.
- No public API changes; the Kamon memoization is an internal implementation detail of the metric wrappers.
