### PR TITLE
fix: include resolved IP in blocked host error messages

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/DefaultHostValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/DefaultHostValidator.java
@@ -104,22 +104,28 @@ final class DefaultHostValidator implements HostValidator {
         try {
             final InetAddress[] inetAddresses = resolver.resolve(host);
             for (final InetAddress requestAddress : inetAddresses) {
+                final String resolvedAddress = requestAddress.getHostAddress();
                 if (requestAddress.isLoopbackAddress()) {
-                    return HostValidationResult.blocked(host, "the hostname resolved to a loopback address.");
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a loopback address (%s).", resolvedAddress));
                 } else if (requestAddress.isSiteLocalAddress()) {
-                    return HostValidationResult.blocked(host, "the hostname resolved to a site local address.");
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a site local address (%s).", resolvedAddress));
                 } else if (requestAddress.isMulticastAddress()) {
-                    return HostValidationResult.blocked(host, "the hostname resolved to a multicast address.");
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a multicast address (%s).", resolvedAddress));
                 } else if (requestAddress.isAnyLocalAddress()) {
-                    return HostValidationResult.blocked(host, "the hostname resolved to a wildcard address.");
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a wildcard address (%s).", resolvedAddress));
                 } else if (blockedAddresses.contains(requestAddress)) {
-                    // host is contained in the block-list --> block
-                    return HostValidationResult.blocked(host);
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a blocked address (%s).", resolvedAddress));
                 }
                 for (final String subnet : blockedSubnets) {
                     if (SubnetValidator.matches(subnet, requestAddress.getHostAddress())) {
-                        // ip is contained in the blocked-subnet --> block
-                        return HostValidationResult.blocked(host, "the hostname resides in a blocked subnet.");
+                        return HostValidationResult.blocked(host,
+                                String.format("the hostname resolved to address %s which resides in blocked subnet %s.",
+                                        resolvedAddress, subnet));
                     }
                 }
             }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidationResult.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidationResult.java
@@ -85,7 +85,8 @@ final class HostValidationResult {
         final var errorMessage = String.format("The configured host '%s' may not be used for the " +
                 "connection because %s", host, message);
         return ConnectionConfigurationInvalidException.newBuilder(errorMessage)
-                .description("It is a blocked or otherwise forbidden hostname which may not be used.")
+                .description("The host is blocked or resolves to a forbidden address. " +
+                        "If the host is valid, add it to the allowed hostnames configuration.")
                 .dittoHeaders(dittoHeaders)
                 .build();
     }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidatorTest.java
@@ -609,7 +609,7 @@ public class ConnectionValidatorTest {
         final ConnectionValidator underTest = getConnectionValidator();
         assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
                 .isThrownBy(() -> underTest.validate(connection, DittoHeaders.empty(), actorSystem))
-                .withMessageContaining("the host is blocked");
+                .withMessageContaining("blocked");
     }
 
     @Test


### PR DESCRIPTION
 ## Summary
  
  Fixes #681
  
  When a valid hostname resolves to a blocked address (loopback, site-local, multicast, or blocked subnet), the error
  message now includes the resolved IP address that triggered the block. This helps users understand why a publicly
  valid domain is being rejected — for example, when a domain resolves to a local Docker network alias internally.
  
  ## Changes
  
  - `DefaultHostValidator`: Each blocked-address check now includes the resolved IP in the error message (e.g., "the
  hostname resolved to a loopback address (127.0.0.1)")
  - `HostValidationResult`: Updated exception description to mention allowed hostnames configuration as a remediation
  path
  - Updated test assertion to match the new message format
  
  ## Before/After
  
  **Before:** `The configured host 'mqtt.example.org' may not be used for the connection because the host is blocked.`
  
  **After:** `The configured host 'mqtt.example.org' may not be used for the connection because the hostname resolved to
  a site local address (192.168.1.5).`
  
  Signed-off-by: Aman Jain <aman.jain57@gmail.com>