### PR TITLE
Memoize JSON header-value parsing and skip re-validation of trusted DittoHeaders

### DIFF
--- a/base/model/pom.xml
+++ b/base/model/pom.xml
@@ -51,10 +51,34 @@
             <artifactId>pekko-testkit_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.children="append">
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeaders.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeaders.java
@@ -152,11 +152,11 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
         }
     }
 
-    private static JsonObject getAuthorizationContextAsJson(final Map<String, ? extends CharSequence> headers) {
-        final CharSequence jsonObjectString = headers.get(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey());
+    private JsonObject getAuthorizationContextAsJson() {
+        @Nullable final Header authContextHeader = headers.get(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey());
         final JsonObject result;
-        if (null != jsonObjectString) {
-            result = JsonObject.of(jsonObjectString.toString());
+        if (null != authContextHeader) {
+            result = authContextHeader.getParsedValue().asObject();
         } else {
             result = JsonObject.empty();
         }
@@ -194,14 +194,14 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
 
     @Override
     public AuthorizationContext getAuthorizationContext() {
-        return AuthorizationModelFactory.newAuthContext(getAuthorizationContextAsJson(headers));
+        return AuthorizationModelFactory.newAuthContext(getAuthorizationContextAsJson());
     }
 
     protected JsonArray getJsonArrayForDefinition(final HeaderDefinition definition) {
         @Nullable final Header jsonArrayHeader = headers.get(definition.getKey());
         final JsonArray result;
         if (null != jsonArrayHeader) {
-            result = JsonArray.of(jsonArrayHeader.getValue());
+            result = jsonArrayHeader.getParsedValue().asArray();
         } else {
             result = JsonArray.empty();
         }
@@ -449,7 +449,7 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
             final Class<?> type = getSerializationTypeForKey(key);
             final JsonValue jsonValue = CharSequence.class.isAssignableFrom(type)
                     ? JsonValue.of(header.getValue())
-                    : JsonFactory.readFrom(header.getValue());
+                    : header.getParsedValue();
             jsonObjectBuilder.set(header.getKey(), jsonValue);
         });
         return jsonObjectBuilder.build();

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilder.java
@@ -78,6 +78,34 @@ final class DefaultDittoHeadersBuilder extends AbstractDittoHeadersBuilder<Defau
     }
 
     /**
+     * Returns a new instance of {@code DittoHeadersBuilder} initialized with the given headers, <em>skipping</em>
+     * header value type validation. Only use this for headers originating from a trusted, already-validated source
+     * (e.g. deserialization of cluster-internal messages), applying the same performance optimization the
+     * {@code DittoHeaders}-based constructor already applies to already-built {@code DittoHeaders}.
+     *
+     * @param headers the header map which provides the initial properties of the builder.
+     * @return a builder for creating {@code DittoHeaders} object.
+     * @throws NullPointerException if {@code headers} is {@code null}.
+     */
+    static DefaultDittoHeadersBuilder ofTrusted(final Map<String, String> headers) {
+        if (headers instanceof DittoHeaders) {
+            return new DefaultDittoHeadersBuilder((DittoHeaders) headers);
+        }
+        return new DefaultDittoHeadersBuilder((DittoHeaders) ImmutableDittoHeaders.of(headers));
+    }
+
+    /**
+     * Like {@link #ofTrusted(Map)} but seeded from a {@code JsonObject}. Skips value type validation.
+     *
+     * @param jsonObject the JSON object which provides the initial properties of the builder.
+     * @return a builder for creating {@code DittoHeaders} object.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
+    static DefaultDittoHeadersBuilder ofTrusted(final JsonObject jsonObject) {
+        return ofTrusted(toMap(jsonObject));
+    }
+
+    /**
      * Returns an empty {@code DittoHeaders} object.
      *
      * @return empty DittoHeaders.

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaders.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaders.java
@@ -102,6 +102,21 @@ public interface DittoHeaders extends Jsonifiable<JsonObject>, Map<String, Strin
     }
 
     /**
+     * Returns {@code DittoHeaders} initialized with the entries of the given {@code jsonObject}, <em>skipping</em>
+     * header value type validation. Only use this for a trusted, already-validated source such as the deserialization
+     * of cluster-internal messages: the values were validated when the {@code DittoHeaders} were first created, so
+     * re-validating (and thereby re-parsing every JSON-typed value) on every hop is redundant work.
+     *
+     * @param jsonObject the JSON object which provides the properties of the returned DittoHeaders.
+     * @return the DittoHeaders.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @since 3.9.5
+     */
+    static DittoHeaders newFromTrustedJson(final JsonObject jsonObject) {
+        return DefaultDittoHeadersBuilder.ofTrusted(jsonObject).build();
+    }
+
+    /**
      * Returns a mutable builder with a fluent API for immutable {@code DittoHeaders}. The builder is initialised with
      * the entries of this instance.
      *

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
@@ -14,7 +14,11 @@ package org.eclipse.ditto.base.model.headers;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonValue;
 
 /**
  * Package internal representation of a header with its key in the original capitalization.
@@ -29,6 +33,16 @@ final class Header implements CharSequence {
 
     private final String key;
     private final String value;
+
+    /*
+     * Lazily memoized JSON representation of {@link #value} for headers whose serialization type is a
+     * JsonObject / JsonArray. Parsing a header value is a pure function of the (immutable) value string, so this
+     * cache is an idempotent derived value: the field is intentionally non-final and unsynchronized (benign data
+     * race, same pattern as {@link String#hashCode()}) and does not affect the observable immutability of Header.
+     * Only populated on demand via {@link #getParsedValue()} for headers that actually hold JSON.
+     */
+    @Nullable
+    private JsonValue parsedValue;
 
     private Header(final String key, final String value) {
         this.key = key;
@@ -45,6 +59,23 @@ final class Header implements CharSequence {
 
     String getValue() {
         return value;
+    }
+
+    /**
+     * Returns the header value parsed as a {@link JsonValue}, memoizing the result for subsequent calls.
+     * Must only be called for headers whose value is a JSON object or array (i.e. whose serialization type is not a
+     * plain {@code CharSequence}); calling it for a non-JSON value fails the same way the previous per-access parsing
+     * did.
+     *
+     * @return the parsed (and cached) JSON representation of the header value.
+     */
+    JsonValue getParsedValue() {
+        JsonValue result = parsedValue;
+        if (null == result) {
+            result = JsonFactory.readFrom(value);
+            parsedValue = result;
+        }
+        return result;
     }
 
     @Override

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/HeaderValueParsingBenchmark.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/HeaderValueParsingBenchmark.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.model.headers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.common.ResponseType;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmark quantifying the effect of memoizing JSON-typed {@link Header} value parsing versus the previous
+ * behaviour of re-parsing header value strings on every serialization / accessor call.
+ *
+ * <p>Models a realistic signal {@code DittoHeaders} instance carrying the JSON-typed headers that dominate
+ * production things-service CPU (authorization-context, read-subjects, expected-response-types) plus a couple of
+ * plain string headers. Because {@code DittoHeaders} is immutable and its header map is shared across unmutated
+ * copies, a single instance is serialized / accessed many times over its lifetime; this benchmark measures a
+ * reused instance.</p>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+@Threads(1)
+public class HeaderValueParsingBenchmark {
+
+    private DittoHeaders dittoHeaders;
+    private List<Header> jsonHeaders;
+    private String authContextHeaderValue;
+    private String readSubjectsHeaderValue;
+    private JsonObject headersJson;
+
+    @Setup
+    public void setup() {
+        final AuthorizationContext authorizationContext = AuthorizationModelFactory.newAuthContext(
+                DittoAuthorizationContextType.PRE_AUTHENTICATED_CONNECTION,
+                AuthorizationModelFactory.newAuthSubject("ditto:connection-subject-1"),
+                AuthorizationModelFactory.newAuthSubject("ditto:connection-subject-2"),
+                AuthorizationModelFactory.newAuthSubject("nginx:ditto"));
+
+        dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId("benchmark-correlation-id-0123456789")
+                .contentType("application/json")
+                .authorizationContext(authorizationContext)
+                .readGrantedSubjects(Arrays.asList(
+                        AuthorizationModelFactory.newAuthSubject("ditto:connection-subject-1"),
+                        AuthorizationModelFactory.newAuthSubject("ditto:connection-subject-2"),
+                        AuthorizationModelFactory.newAuthSubject("nginx:ditto")))
+                .expectedResponseTypes(ResponseType.RESPONSE, ResponseType.ERROR)
+                .build();
+
+        // Collect the JSON-typed headers (object/array values) to contrast re-parse vs. cache-hit directly.
+        final AbstractDittoHeaders abstractDittoHeaders = (AbstractDittoHeaders) dittoHeaders;
+        jsonHeaders = new ArrayList<>();
+        for (final Header header : abstractDittoHeaders.headers.values()) {
+            final String value = header.getValue().trim();
+            if (!value.isEmpty() && ('{' == value.charAt(0) || '[' == value.charAt(0))) {
+                jsonHeaders.add(header);
+            }
+        }
+        authContextHeaderValue = dittoHeaders.get(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey());
+        readSubjectsHeaderValue = dittoHeaders.get(DittoHeaderDefinition.READ_SUBJECTS.getKey());
+        headersJson = dittoHeaders.toJson();
+    }
+
+    /** Baseline: re-parse each JSON-typed header value on every call (the pre-memoization behaviour). */
+    @Benchmark
+    public void reparseEachTime(final Blackhole blackhole) {
+        for (int i = 0; i < jsonHeaders.size(); i++) {
+            blackhole.consume(JsonFactory.readFrom(jsonHeaders.get(i).getValue()));
+        }
+    }
+
+    /** Memoized: read the cached parse for each JSON-typed header. */
+    @Benchmark
+    public void memoizedAccess(final Blackhole blackhole) {
+        for (int i = 0; i < jsonHeaders.size(); i++) {
+            blackhole.consume(jsonHeaders.get(i).getParsedValue());
+        }
+    }
+
+    /** Realistic end-to-end serialization of a reused headers instance (now cache-backed). */
+    @Benchmark
+    public JsonObject toJson() {
+        return dittoHeaders.toJson();
+    }
+
+    /** Realistic accessor that parses the read-subjects array (now cache-backed). */
+    @Benchmark
+    public Object getReadGrantedSubjects() {
+        return dittoHeaders.getReadGrantedSubjects();
+    }
+
+    /** Realistic accessor that parses the authorization-context object (now cache-backed). */
+    @Benchmark
+    public Object getAuthorizationContext() {
+        return dittoHeaders.getAuthorizationContext();
+    }
+
+    /** Pre-memoization equivalent of {@link #getReadGrantedSubjects()}: re-parses the array string each call. */
+    @Benchmark
+    public Object getReadGrantedSubjects_reparse() {
+        return JsonArray.of(readSubjectsHeaderValue).stream()
+                .map(JsonValue::asString)
+                .map(AuthorizationModelFactory::newAuthSubject)
+                .collect(Collectors.toSet());
+    }
+
+    /** Pre-memoization equivalent of {@link #getAuthorizationContext()}: re-parses the object string each call. */
+    @Benchmark
+    public Object getAuthorizationContext_reparse() {
+        return AuthorizationModelFactory.newAuthContext(JsonObject.of(authContextHeaderValue));
+    }
+
+    // --- cluster-deserialization build from JSON, with vs. without value-type (re-)validation ---
+
+    /** Current behaviour: build headers from the wire JSON, validating (re-parsing) every JSON-typed value. */
+    @Benchmark
+    public DittoHeaders buildFromJson_validated() {
+        return DittoHeaders.newBuilder(headersJson).build();
+    }
+
+    /** Build headers from trusted wire JSON, skipping redundant value-type validation. */
+    @Benchmark
+    public DittoHeaders buildFromJson_trusted() {
+        return DittoHeaders.newFromTrustedJson(headersJson);
+    }
+
+    public static void main(final String[] args) throws RunnerException {
+        final Options options = new OptionsBuilder()
+                .include(HeaderValueParsingBenchmark.class.getSimpleName())
+                .build();
+        new Runner(options).run();
+    }
+
+}

--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
@@ -38,7 +38,6 @@ import org.apache.pekko.serialization.SerializerWithStringManifest;
 import org.eclipse.ditto.base.model.exceptions.DittoJsonException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
@@ -428,9 +427,11 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
     protected abstract JsonValue deserializeFromByteBuffer(ByteBuffer byteBuffer);
 
     private static DittoHeaders deserializeDittoHeaders(final JsonObject jsonObject) {
+        // Deserialization happens on trusted, cluster-internal traffic whose headers were already validated when
+        // first created, so we skip redundant value-type (re-)validation here (which would re-parse every JSON-typed
+        // header value on each hop).
         return jsonObject.getValue(JSON_DITTO_HEADERS)
-                .map(DittoHeaders::newBuilder)
-                .map(DittoHeadersBuilder::build)
+                .map(DittoHeaders::newFromTrustedJson)
                 .orElseGet(DittoHeaders::empty);
     }
 


### PR DESCRIPTION
## What

`DittoHeaders` stores every header value as a `String` and re-parses the JSON-typed values (e.g. `authorization-context`, `read-subjects`, `expected-response-types`) from text every time they are validated, serialized or accessed. Since `DittoHeaders` is immutable, parsing a value is a pure function of that string, so most of this work is redundant. This PR removes it in two places.

## Why

Profiling the Things service in production (10-minute JFR) showed roughly **11% of CPU** spent parsing header values through the JSON layer — split about evenly between build-time value-type validation and `toJson()`/accessor calls — and dominated by `DittoHeaders`. The dominant callers were `JsonObjectValueValidator.tryToParseJsonObject`, `AbstractDittoHeaders.toJson` and `getJsonArrayForDefinition`. This cost scales linearly with signal throughput (every signal carries headers), so it grows with load.

## Changes

- **Memoize the parsed value on `Header`.** `Header` now lazily caches the parsed `JsonValue` (idempotent, unsynchronized — the same benign-race pattern as `String.hashCode()`). `toJson()`, `getAuthorizationContext()` and `getJsonArrayForDefinition()` reuse it instead of re-parsing. Because the header map is shared across unmutated `DittoHeaders` copies, a value is parsed at most once per distinct `Header`, no matter how often the instance is serialized or read.
- **Skip re-validation of trusted headers on deserialization.** Cluster-internal deserialization rebuilt headers through the validating builder, re-parsing every JSON-typed value on each hop even though the sending node already validated them when the headers were first created. New `DittoHeaders.newFromTrustedJson(JsonObject)` (and `DefaultDittoHeadersBuilder.ofTrusted(...)`) build headers without re-running value-type validation, applying the same trust reasoning as the existing `DittoHeaders`-based builder constructor. `AbstractJsonifiableWithDittoHeadersSerializer` now uses it. External/untrusted ingress continues to validate as before.

Both changes are independent of the underlying JSON parser.

## Benchmark

New JMH benchmark `HeaderValueParsingBenchmark` in `base/model` (JDK 25, `AverageTime`, ns/op):

| Operation                                   | before  | after  | speedup |
|---------------------------------------------|---------|--------|---------|
| `getAuthorizationContext`                   | 703     | 93     | ~7.5×   |
| `getReadGrantedSubjects`                    | 411     | 99     | ~4.2×   |
| `toJson`                                    | ~1300   | 199    | ~6×     |
| parse → cache-hit (per JSON header set)     | 1087    | 3.5    | ~310×   |
| header deserialization (build from wire JSON) | 1584  | 594    | ~2.7×   |

## Notes

- New public API `DittoHeaders.newFromTrustedJson(JsonObject)` is tagged `@since 3.9.5`.
- No behaviour change. `mvn verify` is green on `base/model` (743 tests, japicmp API-compatibility clean) and `internal/utils/cluster` (73 tests, including serializer round-trips).
