### PR TITLE
Require all doc pages in llms.txt, exclude only protocol-examples

### DIFF
--- a/documentation/src/main/resources/_plugins/llms_markdown_generator.rb
+++ b/documentation/src/main/resources/_plugins/llms_markdown_generator.rb
@@ -116,7 +116,18 @@ end
 # shipping a stale link or description.
 module LlmsTxtIndex
   RELEASE_NOTES_PREFIX = 'release_notes_'
+  # Per-command protocol example pages (e.g. protocol-examples-creatething.html)
+  # are auto-generated boilerplate and intentionally not enumerated in llms.txt -
+  # the single curated "protocol-examples.html" overview stands in for the family.
+  # Note the trailing dash: this excludes the "protocol-examples-*" children but
+  # not the "protocol-examples" overview itself, which is linked.
+  PROTOCOL_EXAMPLES_PREFIX = 'protocol-examples-'
   DOC_PAGES_PATH = 'pages/ditto/'
+
+  # Permalinks (without ".html") that are deliberately not required in llms.txt.
+  def self.excluded?(permalink)
+    permalink.start_with?(RELEASE_NOTES_PREFIX, PROTOCOL_EXAMPLES_PREFIX)
+  end
 
   def self.doc_link_regex(site)
     %r{^- \[[^\]]+\]\(#{Regexp.escape(site.config['url'].to_s)}/([\w.\-]+)\.html\.md\)}
@@ -185,10 +196,12 @@ module LlmsTxtIndex
     errors
   end
 
-  # Doc pages that exist but aren't linked from llms.txt at all. This is
-  # advisory only (which pages deserve a spot in the curated index is an
-  # editorial call, not a correctness bug) - historical release_notes_* pages
-  # are excluded since only the current latest is ever meant to be linked.
+  # Doc pages that exist but aren't linked from llms.txt at all. Every doc page
+  # is expected to be listed by default; the only permitted omissions are the
+  # excluded?() families (historical release_notes_*, of which only the latest
+  # is ever linked, and the auto-generated protocol-examples-* children). Any
+  # other unlisted page is treated as a build failure so the curated index
+  # can't silently drift out of sync as pages are added.
   def self.unlisted_pages(site, raw)
     listed = listed_slugs(site, raw)
 
@@ -197,7 +210,7 @@ module LlmsTxtIndex
       permalink && permalink.end_with?('.html') &&
         page.ext == '.md' &&
         page.relative_path.start_with?(DOC_PAGES_PATH) &&
-        !permalink.start_with?(RELEASE_NOTES_PREFIX) &&
+        !excluded?(permalink.delete_suffix('.html')) &&
         !listed.include?(permalink.delete_suffix('.html'))
     end.map { |page| page.data['permalink'] }.sort
   end
@@ -245,8 +258,11 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
     unlisted = LlmsTxtIndex.unlisted_pages(site, raw_llms_txt)
     unless unlisted.empty?
-      Jekyll.logger.warn "LlmsTxt:", "#{unlisted.size} doc page(s) not listed in llms.txt (informational, not a failure):"
-      unlisted.each { |permalink| Jekyll.logger.warn "LlmsTxt:", "  #{permalink}" }
+      Jekyll.logger.error "LlmsTxt:", "#{unlisted.size} doc page(s) not listed in llms.txt:"
+      unlisted.each { |permalink| Jekyll.logger.error "LlmsTxt:", "  #{permalink}" }
+      Jekyll.logger.error "LlmsTxt:", "Add each page to llms.txt (or, for auto-generated protocol example pages, " \
+                                      "confirm it matches the '#{LlmsTxtIndex::PROTOCOL_EXAMPLES_PREFIX}' naming)."
+      raise "llms.txt is missing #{unlisted.size} doc page(s). See log above."
     end
   end
 end

--- a/documentation/src/main/resources/llms.txt
+++ b/documentation/src/main/resources/llms.txt
@@ -13,6 +13,7 @@ Eclipse Ditto provides five microservices (Things, Policies, Gateway, Connectivi
 - [Overview](https://www.eclipse.dev/ditto/intro-overview.html.md): What Eclipse Ditto is, what it is not, and when to use it
 - [Digital Twins](https://www.eclipse.dev/ditto/intro-digitaltwins.html.md): The digital twin concept and how Ditto implements it
 - [Hello World](https://www.eclipse.dev/ditto/intro-hello-world.html.md): Quick-start guide for creating your first digital twin
+- [Glossary](https://www.eclipse.dev/ditto/glossary.html.md): Definitions of the core terms used throughout the Ditto documentation
 
 ## Core Concepts
 
@@ -51,6 +52,12 @@ Eclipse Ditto provides five microservices (Things, Policies, Gateway, Connectivi
 - [Running Ditto](https://www.eclipse.dev/ditto/installation-running.html.md): Running Ditto via Docker Compose or Kubernetes/Helm
 - [Operating Ditto](https://www.eclipse.dev/ditto/installation-operating.html.md): Configuration, monitoring, and operational aspects
 - [Extending Ditto](https://www.eclipse.dev/ditto/installation-extending.html.md): Custom protocol adapters and other extension points
+- [Operating - Authentication](https://www.eclipse.dev/ditto/operating-authentication.html.md): Configuring authentication (pre-authentication, OpenID Connect / OAuth 2.0, JWT)
+- [Operating - Configuration](https://www.eclipse.dev/ditto/operating-configuration.html.md): Configuring Ditto via environment variables, system properties, and config files
+- [Operating - DevOps Commands](https://www.eclipse.dev/ditto/operating-devops.html.md): DevOps piggyback commands for logging, dynamic config, namespace management, and cleanup
+- [Operating - MongoDB](https://www.eclipse.dev/ditto/operating-mongodb.html.md): MongoDB database configuration, tuning, and indexes
+- [Operating - Monitoring & Tracing](https://www.eclipse.dev/ditto/operating-monitoring.html.md): Monitoring, logging, and tracing (Prometheus, Grafana, OpenTelemetry, ELK)
+- [Operating - Security Hardening](https://www.eclipse.dev/ditto/operating-security-hardening.html.md): Security hardening recommendations for production deployments
 
 ## HTTP API
 
@@ -68,6 +75,7 @@ Eclipse Ditto provides five microservices (Things, Policies, Gateway, Connectivi
 - [Manage Connections via HTTP](https://www.eclipse.dev/ditto/connectivity-manage-connections.html.md): CRUD operations for connections
 - [Payload Mapping](https://www.eclipse.dev/ditto/connectivity-mapping.html.md): Transforming messages between external formats and Ditto Protocol
 - [Header Mapping](https://www.eclipse.dev/ditto/connectivity-header-mapping.html.md): Mapping external message headers
+- [Response Diversion](https://www.eclipse.dev/ditto/connectivity-response-diversion.html.md): Routing connection responses to a different address or protocol
 
 ## Ditto Protocol
 
@@ -77,6 +85,7 @@ Eclipse Ditto provides five microservices (Things, Policies, Gateway, Connectivi
 - [Protocol Topic](https://www.eclipse.dev/ditto/protocol-specification-topic.html.md): Topic path structure (namespace/name/group/channel/criterion/action)
 - [Things Commands](https://www.eclipse.dev/ditto/protocol-specification-things.html.md): Protocol commands for the Things entity group
 - [Policies Commands](https://www.eclipse.dev/ditto/protocol-specification-policies.html.md): Protocol commands for the Policies entity group
+- [Connections Commands](https://www.eclipse.dev/ditto/protocol-specification-connections.html.md): Protocol commands for the Connections entity group
 - [Protocol Bindings](https://www.eclipse.dev/ditto/protocol-bindings.html.md): How the Ditto Protocol is bound to transport protocols
 
 ## Client SDKs
@@ -125,4 +134,7 @@ Eclipse Ditto provides five microservices (Things, Policies, Gateway, Connectivi
 - [Streaming Subscriptions](https://www.eclipse.dev/ditto/protocol-specification-streaming-subscription.html.md): Protocol for streaming historical events
 - [Protocol Examples](https://www.eclipse.dev/ditto/protocol-examples.html.md): Overview of Ditto Protocol message examples
 - [User Interface](https://www.eclipse.dev/ditto/user-interface.html.md): Ditto Explorer UI for managing Things and Policies
+- [Sandbox](https://www.eclipse.dev/ditto/sandbox.html.md): The public Ditto sandbox environment for trying out Ditto
+- [Presentations](https://www.eclipse.dev/ditto/presentations.html.md): Talks and slide decks about Eclipse Ditto
+- [Feedback](https://www.eclipse.dev/ditto/feedback.html.md): Where to get help - bug tracker, forum, chat, and mailing list
 - [Release Notes](https://www.eclipse.dev/ditto/release_notes_394.html.md): Latest release notes


### PR DESCRIPTION
## What

The `llms.txt` curated index only emitted an informational warning for doc
pages it didn't link, so 103 pages were silently missing from the index —
12 real content pages plus the auto-generated `protocol-examples-*` family.

This makes being listed the default:

- Adds the 12 missing content pages to `llms.txt`:
  - `glossary`
  - `operating-authentication`, `operating-configuration`, `operating-devops`,
    `operating-mongodb`, `operating-monitoring`, `operating-security-hardening`
  - `connectivity-response-diversion`
  - `protocol-specification-connections`
  - `sandbox`, `presentations`, `feedback`
- Escalates the "unlisted page" check in `llms_markdown_generator.rb` from a
  warning to a build failure.

Only two families remain permitted omissions:

- The auto-generated `protocol-examples-*` children (the curated
  `protocol-examples` overview stands in for the family).
- Historical `release_notes_*` pages, where only the latest is ever linked —
  already enforced separately by the existing `validate` step.

As a result the index can no longer silently drift out of sync: a newly added
doc page that isn't listed (and isn't one of the excluded families) now fails
the Jekyll build instead of printing an ignorable notice.
