### PR TITLE
Fix ClusterSingletonManagerIsStuck causing status-route bind restarts on rolling updates

### DIFF
--- a/base/service/src/main/java/org/eclipse/ditto/base/service/actors/DittoRootActor.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/actors/DittoRootActor.java
@@ -17,6 +17,7 @@ import static org.apache.pekko.http.javadsl.server.Directives.logResult;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.BindException;
 import java.net.ConnectException;
 import java.util.NoSuchElementException;
 
@@ -39,6 +40,7 @@ import org.apache.pekko.actor.Props;
 import org.apache.pekko.actor.Status;
 import org.apache.pekko.actor.SupervisorStrategy;
 import org.apache.pekko.cluster.Cluster;
+import org.apache.pekko.cluster.singleton.ClusterSingletonManagerIsStuck;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.japi.pf.DeciderBuilder;
@@ -94,6 +96,15 @@ public abstract class DittoRootActor extends AbstractActor {
                         "DittoRuntimeException '{}' should not be escalated to ConnectivityRootActor. Simply resuming Actor.",
                         e.getErrorCode());
                 return SupervisorStrategy.resume();
+            }).match(ClusterSingletonManagerIsStuck.class, e -> {
+                // Do NOT escalate: escalating restarts this root actor, which re-runs its constructor and
+                // re-binds the HTTP status route on an already-bound port -> BindException -> system.terminate().
+                // Restarting only the stuck ClusterSingletonManager child is exactly the recovery Pekko intends:
+                // it starts from a clean state and takes over the singleton once the previous oldest node has
+                // been removed from the cluster. Typically observed during rolling updates.
+                log.warning("ClusterSingletonManager is stuck: <{}>. Restarting the cluster singleton manager " +
+                        "child to recover from a clean state.", e.getMessage());
+                return SupervisorStrategy.restart();
             }).match(Throwable.class, e -> {
                 log.error(e, "Escalating above root actor!");
                 return (SupervisorStrategy.Directive) SupervisorStrategy.escalate();
@@ -167,22 +178,42 @@ public abstract class DittoRootActor extends AbstractActor {
         }
 
         final ActorSystem system = getContext().getSystem();
+        final String bindHostname = hostname;
 
         Http.get(system)
-                .newServerAt(hostname, httpConfig.getPort())
+                .newServerAt(bindHostname, httpConfig.getPort())
                 .bindFlow(createStatusRoute(system, healthCheckingActor).flow(system))
                 .thenAccept(theBinding -> {
                     theBinding.addToCoordinatedShutdown(httpConfig.getCoordinatedShutdownTimeout(), system);
                     log.info("Created new server binding for the status route.");
                 })
                 .exceptionally(failure -> {
-                    log.error(failure,
-                            "Could not create the server binding for the status route because of: <{}>",
-                            failure.getMessage());
-                    log.error("Terminating the actor system");
-                    system.terminate();
+                    if (isCausedByBindException(failure)) {
+                        // The port is already bound - e.g. by a previous binding of this same JVM that survived
+                        // an actor restart. Do not terminate the actor system; the existing binding keeps serving
+                        // the status route. Terminating here would kill the pod (and, on restart, hit the same
+                        // already-in-use port), causing avoidable rolling-update restarts.
+                        log.warning("Could not bind the status route to port <{}> because the address is already " +
+                                "in use: <{}>. Keeping the actor system alive - an existing binding continues to " +
+                                "serve the status route.", httpConfig.getPort(), failure.getMessage());
+                    } else {
+                        log.error(failure,
+                                "Could not create the server binding for the status route because of: <{}>",
+                                failure.getMessage());
+                        log.error("Terminating the actor system");
+                        system.terminate();
+                    }
                     return null;
                 });
+    }
+
+    private static boolean isCausedByBindException(final Throwable failure) {
+        for (Throwable cause = failure; cause != null && cause != cause.getCause(); cause = cause.getCause()) {
+            if (cause instanceof BindException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Route createStatusRoute(final ActorSystem actorSystem, final ActorRef healthCheckingActor) {

--- a/base/service/src/test/java/org/eclipse/ditto/base/service/actors/AbstractDittoRootActorTest.java
+++ b/base/service/src/test/java/org/eclipse/ditto/base/service/actors/AbstractDittoRootActorTest.java
@@ -30,6 +30,7 @@ import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.Props;
 import org.apache.pekko.cluster.Cluster;
+import org.apache.pekko.cluster.singleton.ClusterSingletonManagerIsStuck;
 import org.apache.pekko.japi.pf.ReceiveBuilder;
 import org.apache.pekko.stream.Attributes;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -154,6 +155,39 @@ public abstract class AbstractDittoRootActorTest {
             throwingActor.tell(new UnknownException(), getRef());
 
             assertRestartSuccess(underTest, throwingActor, this);
+        }};
+    }
+
+    @Test
+    public void clusterSingletonManagerIsStuckRestartsChildInsteadOfTerminating() {
+        final ActorSystem system = createAndRememberForCleanUp();
+
+        if (disableLogging()) {
+            system.eventStream().setLogLevel(Attributes.logLevelOff());
+        }
+
+        new TestKit(system) {{
+            final ActorRef underTest = getRootActorName()
+                    .map(name -> watch(system.actorOf(getRootActorProps(system), name)))
+                    .orElseGet(() -> watch(system.actorOf(getRootActorProps(system))));
+
+            // the Props factory notifies us on every (re)creation of the child, so a restart is observable
+            underTest.tell(new StartChildActor(
+                    Props.create(ThrowingActor.class, () -> new ThrowingActor(getRef())),
+                    "singletonLikeChild"
+            ), getRef());
+
+            final ActorRef throwingActor = expectMsgClass(Duration.ofSeconds(100L), ActorRef.class);
+
+            // a stuck cluster singleton manager must NOT escalate (which would restart the root actor and
+            // re-bind the status route port); it must restart the failing child from a clean state
+            throwingActor.tell(new ClusterSingletonManagerIsStuck("test: previous oldest is unresponsive"), getRef());
+
+            // the child is recreated (its Props factory runs again) - proving a child restart, not root termination
+            expectMsgClass(Duration.ofSeconds(100L), ActorRef.class);
+
+            // and the root actor is still alive (no Terminated received)
+            expectNoMessage();
         }};
     }
 

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.4.0  # chart version is effectively set by release-job
+version: 4.4.1  # chart version is effectively set by release-job
 appVersion: 3.9.4
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -194,6 +194,8 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES
+              value: "{{ .Values.global.cluster.singletonMinNumberOfHandOverRetries }}"
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -179,6 +179,8 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES
+              value: "{{ .Values.global.cluster.singletonMinNumberOfHandOverRetries }}"
             {{- if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_PORT
               value: "{{ .Values.global.prometheus.port }}"

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -198,6 +198,8 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES
+              value: "{{ .Values.global.cluster.singletonMinNumberOfHandOverRetries }}"
             - name: JSON_ESCAPING_BUFFER_FACTOR
               value: "{{ .Values.global.json.escapingBufferFactor }}"
             - name: REMOTE_MAX_FRAMESIZE

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -198,6 +198,8 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES
+              value: "{{ .Values.global.cluster.singletonMinNumberOfHandOverRetries }}"
             - name: JSON_ESCAPING_BUFFER_FACTOR
               value: "{{ .Values.global.json.escapingBufferFactor }}"
             - name: REMOTE_MAX_FRAMESIZE

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -198,6 +198,8 @@ spec:
               value: "{{ .Values.global.cluster.downingStableAfter }}"
             - name: CLUSTER_DOWNING_DOWN_ALL_WHEN_UNSTABLE
               value: "{{ .Values.global.cluster.downAllWhenUnstable }}"
+            - name: PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES
+              value: "{{ .Values.global.cluster.singletonMinNumberOfHandOverRetries }}"
             - name: JSON_ESCAPING_BUFFER_FACTOR
               value: "{{ .Values.global.json.escapingBufferFactor }}"
             - name: REMOTE_MAX_FRAMESIZE

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -64,6 +64,14 @@ global:
     downingStableAfter: 15s
     # downAllWhenUnstable is a configuration of the Pekko SBR (split brain resolver)
     downAllWhenUnstable: "on"
+    # singletonMinNumberOfHandOverRetries configures pekko.cluster.singleton.min-number-of-hand-over-retries:
+    #  when a node becomes the new "oldest" it must hand the cluster singleton over from the previous oldest.
+    #  If the retries (1s interval each) are exhausted before the previous oldest is observed as removed from
+    #  the cluster, a ClusterSingletonManagerIsStuck is raised. During rolling updates gossip dissemination of
+    #  the previous oldest's Leaving -> Exiting -> Removed transition can exceed the Pekko default of 15 retries,
+    #  so a larger budget lets the new oldest wait and then take over cleanly. It is only a ceiling: the hand-over
+    #  still completes as soon as the previous oldest confirms or is removed.
+    singletonMinNumberOfHandOverRetries: 30
   # pubsub holds Ditto's cluster pub/sub configuration shared by all services
   pubsub:
     # preSerializeFanoutEnabled serializes a published signal once and reuses it across all remote fan-out

--- a/internal/utils/config/src/main/resources/ditto-pekko-config.conf
+++ b/internal/utils/config/src/main/resources/ditto-pekko-config.conf
@@ -266,6 +266,19 @@ pekko {
         rebalance-relative-limit = ${?PEKKO_CLUSTER_SHARDING_LEAST_SHARD_ALLOCATION_STRATEGY_REBALANCE_RELATIVE_LIMIT}
       }
     }
+
+    singleton {
+      # Raised from the Pekko default of 15. When a node becomes the new "oldest" it hands the singleton over
+      # from the previous oldest; if the retries are exhausted before the previous oldest is observed as removed
+      # from the cluster, a ClusterSingletonManagerIsStuck is thrown. During rolling updates the whole ditto
+      # cluster (all services) churns and gossip dissemination of the previous oldest's Leaving -> Exiting ->
+      # Removed transition can take longer than 15s, so the new oldest gave up too early and got stuck (which
+      # cascaded into a status-route re-bind + BindException + pod restart). A larger budget lets the new oldest
+      # wait for the removal to be gossiped and then take over cleanly. It is only a ceiling: hand-over still
+      # completes as soon as the previous oldest confirms or is removed.
+      min-number-of-hand-over-retries = 30
+      min-number-of-hand-over-retries = ${?PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES}
+    }
   }
 
   coordinated-shutdown {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/util/RootSupervisorStrategyFactory.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/util/RootSupervisorStrategyFactory.java
@@ -21,6 +21,7 @@ import org.apache.pekko.actor.ActorKilledException;
 import org.apache.pekko.actor.InvalidActorNameException;
 import org.apache.pekko.actor.OneForOneStrategy;
 import org.apache.pekko.actor.SupervisorStrategy;
+import org.apache.pekko.cluster.singleton.ClusterSingletonManagerIsStuck;
 import org.apache.pekko.event.LoggingAdapter;
 import org.apache.pekko.japi.pf.DeciderBuilder;
 import org.apache.pekko.pattern.AskTimeoutException;
@@ -74,6 +75,15 @@ public final class RootSupervisorStrategyFactory {
                             "DittoRuntimeException '{}' should not be escalated to RootActor. Simply resuming Actor.",
                             e.getErrorCode());
                     return SupervisorStrategy.resume();
+                }).match(ClusterSingletonManagerIsStuck.class, e -> {
+                    // Do NOT escalate: restart only the stuck ClusterSingletonManager child so it recovers from a
+                    // clean state and takes over once the previous oldest is removed from the cluster. Escalating
+                    // would restart the root actor (see DittoRootActor for the full rationale). Typically observed
+                    // during rolling updates.
+                    log.warning("ClusterSingletonManager is stuck: {}. Restarting the cluster singleton manager " +
+                            "child to recover from a clean state.", e.getMessage());
+                    log.info(RESTARTING_CHILD_MSG);
+                    return SupervisorStrategy.restart();
                 }).match(Throwable.class, e -> {
                     log.error(e, "Escalating above root actor!");
                     return SupervisorStrategy.escalate();


### PR DESCRIPTION
On every rolling update, service pods (first observed on connectivity) restarted 1-3x with `Bind failed ... Address already in use` on `<podIP>:8080` (the HTTP status route).

## Root cause

When a newly-oldest node cannot hand the cluster singleton over from the previous oldest before its retry budget is exhausted, the `ClusterSingletonManager` throws `ClusterSingletonManagerIsStuck`. During a rolling update the whole Ditto cluster (all services share one Pekko cluster) churns, and gossip dissemination of the previous oldest's `Leaving -> Exiting -> Removed` transition can take longer than the Pekko default budget of 15 retries (1s each). Prod logs showed the new oldest throwing stuck ~8s *after* the previous oldest had already been removed from the cluster.

`DittoRootActor`'s supervision decider escalated the exception, which restarted the root actor, which re-ran its constructor and re-bound the status route on the still-bound port -> `BindException` -> `system.terminate()` -> pod restart. This repeated until the old oldest was fully gone. Affects all services that extend `DittoRootActor`.

## Changes

- **`DittoRootActor` decider**: handle `ClusterSingletonManagerIsStuck` by `restart()`-ing the stuck singleton child (the recovery Pekko intends: start from a clean state and take over once the previous oldest is removed) instead of escalating and restarting the whole root actor.
- **`bindHttpStatusRoute`**: tolerate a `BindException` (port already held, e.g. by a prior binding that survived an actor restart) by logging a warning and keeping the actor system alive; only `system.terminate()` on genuinely fatal bind failures.
- **`pekko.cluster.singleton.min-number-of-hand-over-retries`**: raised from the Pekko default of 15 to 30 (env `PEKKO_CLUSTER_SINGLETON_MIN_NUMBER_OF_HAND_OVER_RETRIES`) so the new oldest waits for the previous oldest's removal to be gossiped and then takes over cleanly, avoiding the stuck exception in the first place. It is only a ceiling — hand-over still completes as soon as the previous oldest confirms or is removed.
- **Helm**: expose the setting as `global.cluster.singletonMinNumberOfHandOverRetries`, wired into all five service deployments; bump chart version.
- **Test**: `AbstractDittoRootActorTest` now asserts a stuck singleton restarts the child rather than terminating the root actor (runs for all five service root actors).