### PR TITLE
Fix blank resource_type metric tag crashing cluster serialization

### DIFF
--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
@@ -184,7 +184,10 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
     private static String resourceTypeOf(final Object object) {
         final String result;
         if (object instanceof WithResource withResource) {
-            result = withResource.getResourceType();
+            final String resourceType = withResource.getResourceType();
+            // some signals (e.g. health signals) have no resource type and return a blank string; the metric tag value
+            // must not be blank, so fall back to the "other" bucket in that case:
+            result = (null == resourceType || resourceType.isBlank()) ? RESOURCE_TYPE_OTHER : resourceType;
         } else {
             result = RESOURCE_TYPE_OTHER;
         }

--- a/internal/utils/cluster/src/test/java/org/eclipse/ditto/internal/utils/cluster/SharedJsonifiableSerializerTest.java
+++ b/internal/utils/cluster/src/test/java/org/eclipse/ditto/internal/utils/cluster/SharedJsonifiableSerializerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.base.model.signals.ShardedMessageEnvelope;
 import org.eclipse.ditto.base.model.signals.commands.GlobalCommandRegistry;
 import org.eclipse.ditto.base.model.signals.commands.GlobalCommandResponseRegistry;
 import org.eclipse.ditto.base.model.signals.events.GlobalEventRegistry;
+import org.eclipse.ditto.internal.utils.health.RetrieveHealth;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
@@ -320,6 +321,13 @@ public final class SharedJsonifiableSerializerTest {
         @Test
         public void thingEventIsTaggedAsEventOnThingResource() {
             assertRoundTripTaggedWith(ThingCreated.of(thing, 1L, null, DITTO_HEADERS, null), "event", "thing");
+        }
+
+        @Test
+        public void signalWithBlankResourceTypeIsTaggedAsOther() {
+            // RetrieveHealth (and other health signals) return a blank resource type; the metric tag value must not be
+            // blank, so the serializer falls back to the "other" bucket instead of throwing an IllegalArgumentException:
+            assertRoundTripTaggedWith(RetrieveHealth.newInstance(), "command", "other");
         }
 
         private void assertRoundTripTaggedWith(final Object signal, final String expectedCategory,


### PR DESCRIPTION
## Problem

Serializing certain signals over Pekko Artery throws on the encoder thread:

```
java.lang.IllegalArgumentException: The value must not be blank.
	at org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag.validateString(Tag.java:55)
	at org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag.of(Tag.java:51)
	...
	at org.eclipse.ditto.internal.utils.cluster.AbstractJsonifiableWithDittoHeadersSerializer.incrementCounter(...:176)
	at org.eclipse.ditto.internal.utils.cluster.AbstractJsonifiableWithDittoHeadersSerializer.toBinary(...:217)
	at org.apache.pekko.remote.MessageSerializer$.serializeForArtery(MessageSerializer.scala:97)
```

## Cause

Since `6d7e225130` ("Categorize cluster (de)serialization metric by category + resource type"), the `<serializer>_serializer_messages` counter is tagged with the signal's `resource_type`, derived from `WithResource#getResourceType()`.

Health signals (`RetrieveHealth`, `RetrieveHealthResponse`, `ResetHealthEvents`, `ResetHealthEventsResponse`) intentionally return a **blank** string (they have no resource type). `Tag.of(key, value)` rejects blank values, so building the tagged counter throws. Because the counter is built lazily via `computeIfAbsent`, the failure prevents caching and recurs for every such health message on the remoting hot path.

## Fix

In `AbstractJsonifiableWithDittoHeadersSerializer#resourceTypeOf`, fall back to the existing `"other"` bucket when the resource type is `null` or blank, so the metric tag value is always valid.

A regression test in `SharedJsonifiableSerializerTest.CategoryAndResourceTypeTagTest` round-trips a `RetrieveHealth` and asserts it is tagged `category=command, resource_type=other` (this test reproduces the exception before the fix).