### PR TITLE
Make gateway devops/status passwords optional under oauth2 auth

### DIFF
--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -15,6 +15,19 @@ sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
 ## [Unreleased]
 
+## [4.5.0]
+
+### Changed
+- The gateway devops and status `Secret` passwords are now only materialised when they are actually consumed,
+  i.e. when the respective `devops.authMethod` / `devops.statusAuthMethod` is `basic` (or an explicit password
+  is provided). When `oauth2` (JWT) devops authentication is used, no password is generated and the
+  corresponding `devops-password` / `status-password` env var references are marked `optional`
+
+### Fixed
+- Stop the gateway `Secret` from churning on every render (and restarting the gateway on every ArgoCD sync)
+  when devops passwords are not explicitly set: the `randAlphaNum` fallback previously regenerated the password
+  on each template render even under `oauth2` auth where it was never used
+
 ## [4.4.0]
 
 Bumped Ditto `appVersion` to `3.9.4`.

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.4.1  # chart version is effectively set by release-job
+version: 4.5.0  # chart version is effectively set by release-job
 appVersion: 3.9.4
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -244,6 +244,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.gateway.config.authentication.devops.existingSecret | default ( printf "%s-gateway-secret" ( include "ditto.fullname" . )) }}
                   key: devops-password
+                  # absent when devops.authMethod is "oauth2" (JWT): no password Secret is created
+                  optional: true
             - name: DEVOPS_STATUS_SECURED
               value: "{{ .Values.gateway.config.authentication.devops.statusSecured }}"
             - name: STATUS_AUTHENTICATION_METHOD
@@ -253,6 +255,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.gateway.config.authentication.devops.existingSecret | default ( printf "%s-gateway-secret" ( include "ditto.fullname" . )) }}
                   key: status-password
+                  # absent when devops.statusAuthMethod is "oauth2" (JWT): no password Secret is created
+                  optional: true
             - name: WS_SUBSCRIBER_BACKPRESSURE
               value: "{{ .Values.gateway.config.websocket.subscriber.backpressureQueueSize }}"
             - name: WS_PUBLISHER_BACKPRESSURE

--- a/deployment/helm/ditto/templates/gateway-secret.yaml
+++ b/deployment/helm/ditto/templates/gateway-secret.yaml
@@ -9,6 +9,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 {{- if not .Values.gateway.config.authentication.devops.existingSecret }}
+{{- $devops := .Values.gateway.config.authentication.devops }}
+{{- /* A password is only consumed when the auth method is "basic" (username: devops). Under
+       "oauth2" (JWT) it is never used, so we must not materialise it: otherwise the randAlphaNum
+       fallback regenerates on every render, churning the Secret and restarting the gateway on
+       every ArgoCD sync. */}}
+{{- $needsDevopsPassword := or $devops.devopsPassword (eq $devops.authMethod "basic") }}
+{{- $needsStatusPassword := or $devops.statusPassword (eq $devops.statusAuthMethod "basic") }}
+{{- if or $needsDevopsPassword $needsStatusPassword }}
 ---
 apiVersion: v1
 kind: Secret
@@ -20,14 +28,19 @@ metadata:
 {{ include "ditto.labels" . | indent 4 }}
 type: Opaque
 data:
-  {{- if .Values.gateway.config.authentication.devops.devopsPassword }}
-  devops-password: {{ .Values.gateway.config.authentication.devops.devopsPassword | b64enc | quote }}
+  {{- if $needsDevopsPassword }}
+  {{- if $devops.devopsPassword }}
+  devops-password: {{ $devops.devopsPassword | b64enc | quote }}
   {{- else }}
   devops-password: {{ randAlphaNum 12 | b64enc | quote }}
   {{- end }}
-  {{- if .Values.gateway.config.authentication.devops.statusPassword }}
-  status-password: {{ .Values.gateway.config.authentication.devops.statusPassword | b64enc | quote }}
+  {{- end }}
+  {{- if $needsStatusPassword }}
+  {{- if $devops.statusPassword }}
+  status-password: {{ $devops.statusPassword | b64enc | quote }}
   {{- else }}
   status-password: {{ randAlphaNum 12 | b64enc | quote }}
   {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Problem

The gateway devops/status password `Secret` (`gateway-secret.yaml`) is always rendered, and when no
explicit password is configured the `randAlphaNum` fallback generates a **new** value on every template
render. Under `oauth2` (JWT) devops authentication the password is never consumed, yet this churns the
`Secret` on each render — which restarts the gateway on every ArgoCD sync.

## Changes

- **`gateway-secret.yaml`**: the `Secret` — and each individual `devops-password` / `status-password`
  key — is now only materialised when it is actually consumed, i.e. when the respective
  `devops.authMethod` / `devops.statusAuthMethod` is `basic`, or an explicit password is provided.
  Under `oauth2` no password is generated, so there is nothing left to churn.
- **`gateway-deployment.yaml`**: the `devops-password` / `status-password` env `secretKeyRef`s are marked
  `optional: true`, so the gateway starts cleanly when the Secret/key is absent under `oauth2`.
- **Helm chart**: bumped `version` to `4.5.0` and documented the change in the chart `CHANGELOG.md`
  (`Changed` + `Fixed`).

No behaviour change for `basic` devops auth or for explicitly-configured passwords.