### PR TITLE
Build allinone jars in GitHub Actions instead of publishing them

### DIFF
--- a/.github/workflows/push-dockerhub-on-demand.yml
+++ b/.github/workflows/push-dockerhub-on-demand.yml
@@ -46,6 +46,8 @@ jobs:
         name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Check out the requested release tag so the allinone jar is built from its sources.
+          ref: ${{ inputs.dittoVersion }}
           persist-credentials: false
       -
         name: Set up QEMU
@@ -87,11 +89,46 @@ jobs:
           echo "Major version: $IMAGE_MAJOR_TAG"
           echo "Milestone or RC suffix: $MILESTONE_OR_RC_SUFFIX"
       -
+        name: Set up JDK 25
+        if: inputs.dittoImage != 'ditto-ui'
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          cache: 'maven'
+      -
+        name: Build allinone jar from sources
+        # The *-allinone.jar artifacts are no longer published to a Maven repository (they
+        # exceed the repo.eclipse.org upload size limit). Build the selected service's
+        # allinone jar from sources so the Docker image build can consume it locally.
+        if: inputs.dittoImage != 'ditto-ui'
+        env:
+          DITTO_IMAGE: ${{ inputs.dittoImage }}
+        run: |
+          case "$DITTO_IMAGE" in
+            ditto-policies)      MODULE=policies/service ;;
+            ditto-things)        MODULE=things/service ;;
+            ditto-gateway)       MODULE=gateway/service ;;
+            ditto-things-search) MODULE=thingsearch/service ;;
+            ditto-connectivity)  MODULE=connectivity/service ;;
+            *) echo "No Maven build needed for $DITTO_IMAGE"; exit 1 ;;
+          esac
+          mvn clean install -T4 --batch-mode --errors -DskipTests -Dmaven.javadoc.skip=true \
+            -Drevision=$IMAGE_TAG -pl "$MODULE" -am
+      -
+        name: Stage allinone jar for the Docker build context
+        if: inputs.dittoImage != 'ditto-ui'
+        run: |
+          mkdir -p docker-libs
+          find . -path '*/service/target/*-allinone.jar' -exec cp -v {} docker-libs/ \;
+          echo "Staged allinone jars:"
+          ls -lh docker-libs
+      -
         name: Build and push ditto-policies
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-policies'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -110,7 +147,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-things'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -129,7 +166,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-gateway'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -148,7 +185,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-things-search'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -167,7 +204,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG && inputs.dittoImage == 'ditto-connectivity'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -215,7 +252,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-policies'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -231,7 +268,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-things'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -247,7 +284,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-gateway'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -263,7 +300,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-things-search'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -279,7 +316,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG && inputs.dittoImage == 'ditto-connectivity'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -14,6 +14,17 @@ on:
   push:
     tags:
       - '**'
+  # Allow manually (re-)running the image build for an already-pushed release, e.g. to
+  # recover a release whose artifact publishing failed. Dispatch this workflow from the
+  # branch that contains the up-to-date build logic (e.g. master) and set 'dittoVersion' to
+  # the release tag: the matching tag is checked out and its sources are built, while the
+  # current workflow definition is used.
+  workflow_dispatch:
+    inputs:
+      dittoVersion:
+        description: 'Release tag to (re-)build images for (e.g. 3.9.5). Leave empty on tag pushes.'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -31,6 +42,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # On a tag push this resolves to the pushed tag; on manual dispatch it checks out
+          # the tag given via the 'dittoVersion' input so the built sources match the version.
+          ref: ${{ inputs.dittoVersion || github.ref }}
           persist-credentials: false
       -
         name: Set up QEMU
@@ -56,11 +70,15 @@ jobs:
       -
         name: Branch name
         id: branch_name
+        env:
+          DITTO_VERSION_INPUT: ${{ inputs.dittoVersion }}
         run: |
-          echo "IMAGE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "IMAGE_MINOR_TAG=$(echo ${GITHUB_REF#refs/tags/} | cut -d. -f-2)" >> $GITHUB_ENV
-          echo "IMAGE_MAJOR_TAG=$(echo ${GITHUB_REF#refs/tags/} | cut -d. -f-1)" >> $GITHUB_ENV
-          echo "MILESTONE_OR_RC_SUFFIX=$(echo ${GITHUB_REF#refs/tags/} | cut -d- -f2)" >> $GITHUB_ENV
+          # Use the manually supplied version when dispatched, otherwise the pushed tag.
+          TAG="${DITTO_VERSION_INPUT:-${GITHUB_REF#refs/tags/}}"
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+          echo "IMAGE_MINOR_TAG=$(echo "$TAG" | cut -d. -f-2)" >> $GITHUB_ENV
+          echo "IMAGE_MAJOR_TAG=$(echo "$TAG" | cut -d. -f-1)" >> $GITHUB_ENV
+          echo "MILESTONE_OR_RC_SUFFIX=$(echo "$TAG" | cut -d- -f2)" >> $GITHUB_ENV
       -
         name: Building Docker images for tag
         run: |
@@ -70,11 +88,34 @@ jobs:
           echo "Major version: $IMAGE_MAJOR_TAG"
           echo "Milestone or RC suffix: $MILESTONE_OR_RC_SUFFIX"
       -
+        name: Set up JDK 25
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          cache: 'maven'
+      -
+        name: Build allinone jars from sources
+        # The *-allinone.jar artifacts are no longer published to a Maven repository (they
+        # exceed the repo.eclipse.org upload size limit). Build them here from the tagged
+        # sources so the Docker image build can consume them from the local context.
+        run: |
+          mvn clean install -T4 --batch-mode --errors -DskipTests -Dmaven.javadoc.skip=true \
+            -Drevision=$IMAGE_TAG \
+            -pl policies/service,things/service,gateway/service,connectivity/service,thingsearch/service -am
+      -
+        name: Stage allinone jars for the Docker build context
+        run: |
+          mkdir -p docker-libs
+          find . -path '*/service/target/*-allinone.jar' -exec cp -v {} docker-libs/ \;
+          echo "Staged allinone jars:"
+          ls -lh docker-libs
+      -
         name: Build and push ditto-policies
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -93,7 +134,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -112,7 +153,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -131,7 +172,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -150,7 +191,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX == env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -198,7 +239,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -214,7 +255,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -230,7 +271,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -246,7 +287,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -262,7 +303,7 @@ jobs:
         if: env.MILESTONE_OR_RC_SUFFIX != env.IMAGE_TAG
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/dockerfile-release
+++ b/dockerfile-release
@@ -27,7 +27,6 @@ RUN set -x \
     && chown -R ditto:ditto $DITTO_LOGS \
     && rm -rf /var/lib/apt/lists/*
 
-ARG MAVEN_REPO=https://repo.eclipse.org/repository/ditto-maven2-releases/org/eclipse/ditto
 ARG SERVICE_STARTER
 ARG SERVICE_VERSION
 ARG JVM_CMD_ARGS=""
@@ -39,10 +38,10 @@ ENV HTTP_PORT=8080 \
     MAIN_CLASS_ENV=${MAIN_CLASS} \
     CLASSPATH=/opt/ditto/*:/opt/ditto/extensions/*
 
-RUN set -x \
-    && cd $DITTO_HOME \
-    && curl -o ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar "${MAVEN_REPO}/${SERVICE_STARTER}/${SERVICE_VERSION}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar" \
-    && chown -R ditto:ditto $DITTO_HOME
+# The *-allinone.jar is built from the tagged sources by the GitHub Actions "push-dockerhub"
+# workflow and provided in the build context. It is intentionally no longer published to a
+# Maven repository (it exceeds the repo.eclipse.org upload size limit).
+COPY --chown=ditto:ditto ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME/
 
 USER ditto
 WORKDIR $DITTO_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,11 @@
 
         <!-- Phase for the maven-shade-plugin executions in the service modules.
              Default `package` builds and attaches the *-allinone.jar as a Maven artifact.
-             Overridden to `none` in the `publishToMavenCentral` profile so the (very large)
-             allinone jars are NOT uploaded to Maven Central — they're only needed in the
-             Eclipse Maven repo (consumed by the Docker image build). -->
+             This default is used by the GitHub Actions "push-dockerhub" workflow, which
+             builds the allinone jars from the tagged sources solely to assemble the Docker
+             images. It is overridden to `none` in BOTH the `publishToMavenCentral` and the
+             `publishToEclipseMavenRepo` profiles so the (very large) allinone jars are never
+             staged/uploaded to a Maven repository (they exceed repo.eclipse.org size limits). -->
         <shade.phase>package</shade.phase>
 
         <!-- globally set version for checking binary compatibility against -->
@@ -836,6 +838,14 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <!-- Skip the maven-shade-plugin executions so the *-allinone.jar is NOT
+                     attached and therefore not staged/uploaded to repo.eclipse.org. The
+                     allinone jars exceed the Eclipse Maven repo upload size limit; they are
+                     instead built on demand by the GitHub Actions "push-dockerhub" workflow
+                     and consumed directly by the Docker image build. -->
+                <shade.phase>none</shade.phase>
+            </properties>
             <distributionManagement>
                 <repository>
                     <id>repo.eclipse.org</id>
@@ -861,8 +871,9 @@
             <properties>
                 <!-- Skip the maven-shade-plugin executions so the *-allinone.jar is NOT
                      attached and therefore not staged/uploaded to Maven Central.
-                     The allinone is still produced in the `publishToEclipseMavenRepo`
-                     run, which uploads it to repo.eclipse.org for the Docker build. -->
+                     The allinone jars are built on demand by the GitHub Actions
+                     "push-dockerhub" workflow and consumed directly by the Docker image
+                     build; they are never published to a Maven repository. -->
                 <shade.phase>none</shade.phase>
             </properties>
             <distributionManagement>


### PR DESCRIPTION
## Problem

The `*-allinone.jar` shaded fat-jars (~90 MB each) exist only to assemble the Docker images, yet the release build uploaded them to `repo.eclipse.org`, where they hit the repository's upload size limit. Maven Central never hosts them (only the ~600 KB thin service jars).

Concretely, for 3.9.5 the Eclipse artifact upload failed (nothing on `repo.eclipse.org`) while Maven Central succeeded — leaving the Docker image build, which `curl`s the allinone jars from `repo.eclipse.org`, with nothing to fetch.

## Change

Stop publishing the allinone jars to any Maven repository and build them from the tagged sources inside the image workflow instead.

- **`pom.xml`** — set `shade.phase=none` in the `publishToEclipseMavenRepo` profile so the allinone jars are no longer staged/uploaded to `repo.eclipse.org` (thin jars still publish there). This removes the size-limit failure at its root.
- **`dockerfile-release`** — `COPY` the locally built `*-allinone.jar` from the build context instead of `curl`ing it from `repo.eclipse.org`. Mirrors the existing `dockerfile-snapshot` pattern; the now-unused `MAVEN_REPO` arg is dropped.
- **`push-dockerhub.yml`** — add a `workflow_dispatch` trigger with an optional `dittoVersion` input (to recover a failed release); check out the matching tag; build the five service allinone jars via `mvn clean install -DskipTests -Drevision=$IMAGE_TAG -pl <services> -am`; stage them into `docker-libs/`; point the image builds at that context.
- **`push-dockerhub-on-demand.yml`** — build the selected service's allinone jar from its tag's sources for the same reason.

## Recovering a failed release (e.g. 3.9.5)

Once merged to `master`, run **push-dockerhub** via *Run workflow* on `master` with `dittoVersion = 3.9.5`. It checks out the `3.9.5` tag, builds the allinone jars from those sources, and pushes all images to Docker Hub — independent of the failed Eclipse upload.