### PR TITLE
Avoid re-validating already-validated DittoHeaders on traced hops and journal recovery

### DIFF
--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/AbstractJsonifiableWithDittoHeadersSerializer.java
@@ -269,8 +269,7 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
             final DittoHeaders dittoHeaders,
             final StartedSpan startedSpan
     ) {
-        final var dittoHeadersWithSpanContext = DittoHeaders.of(startedSpan.propagateContext(dittoHeaders));
-        return dittoHeadersWithSpanContext.toJson();
+        return startedSpan.propagateContext(dittoHeaders).toJson();
     }
 
     @SuppressWarnings("java:S3740")
@@ -389,7 +388,7 @@ public abstract class AbstractJsonifiableWithDittoHeadersSerializer extends Seri
                 beforeDeserializeInstant
         );
         final var result =
-                deserializeJson(payload, manifest, DittoHeaders.of(startedSpan.propagateContext(dittoHeaders)));
+                deserializeJson(payload, manifest, startedSpan.propagateContext(dittoHeaders));
         try {
             return result;
         } finally {

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/AbstractMongoEventAdapter.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/AbstractMongoEventAdapter.java
@@ -96,7 +96,9 @@ public abstract class AbstractMongoEventAdapter<T extends Event<?>> implements E
                 final JsonObject jsonObject = jsonValue.asObject()
                         .setValue(EventsourcedEvent.JsonFields.REVISION.getPointer(), Event.DEFAULT_REVISION);
                 final DittoHeaders dittoHeaders = jsonObject.getValue(HISTORICAL_EVENT_HEADERS)
-                        .map(obj -> DittoHeaders.newBuilder(obj).build())
+                        // persisted headers were already validated when the event was written -> trust them, skipping
+                        // re-parsing/re-validating every JSON-typed header value on each journal read/recovery.
+                        .map(DittoHeaders::newFromTrustedJson)
                         .orElse(DittoHeaders.empty());
 
                 final T result =

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
@@ -1088,7 +1088,9 @@ public abstract class AbstractPersistenceActor<
                 .serialize(event);
 
         final DittoHeaders dittoHeaders = eventAsJsonObject.getValue(AbstractMongoEventAdapter.HISTORICAL_EVENT_HEADERS)
-                .map(obj -> DittoHeaders.newBuilder(obj).build())
+                // persisted headers were already validated when the event was written -> trust them, skipping
+                // re-parsing/re-validating every JSON-typed header value on each journal replay/recovery.
+                .map(DittoHeaders::newFromTrustedJson)
                 .orElseGet(DittoHeaders::empty);
         return (EventsourcedEvent<?>) GlobalEventRegistry.getInstance().parse(eventAsJsonObject, dittoHeaders);
     }

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/EmptyStartedSpan.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/EmptyStartedSpan.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.model.common.ConditionChecker;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
 
@@ -98,6 +99,12 @@ final class EmptyStartedSpan implements StartedSpan {
     @Override
     public Map<String, String> propagateContext(final Map<String, String> map) {
         return map;
+    }
+
+    @Override
+    public DittoHeaders propagateContext(final DittoHeaders dittoHeaders) {
+        // an empty (noop) span never changes the headers, so return them unchanged and avoid any rebuild
+        return dittoHeaders;
     }
 
     @Override

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedSpan.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedSpan.java
@@ -15,8 +15,10 @@ package org.eclipse.ditto.internal.utils.tracing.span;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.internal.utils.metrics.instruments.TaggableMetricsInstrument;
 
 /**
@@ -129,13 +131,16 @@ public interface StartedSpan extends TaggableMetricsInstrument<StartedSpan>, Spa
      */
     default DittoHeaders propagateContext(final DittoHeaders dittoHeaders) {
         final Map<String, String> propagatedHeaders = propagateContext((Map<String, String>) dittoHeaders);
-        final var builder = dittoHeaders.toBuilder();
-        propagatedHeaders.forEach((key, value) -> {
-            if (!value.equals(dittoHeaders.get(key))) {
-                builder.putHeader(key, value);
+        DittoHeadersBuilder<?, ?> builder = null;
+        for (final Map.Entry<String, String> entry : propagatedHeaders.entrySet()) {
+            if (!Objects.equals(entry.getValue(), dittoHeaders.get(entry.getKey()))) {
+                if (null == builder) {
+                    builder = dittoHeaders.toBuilder();
+                }
+                builder.putHeader(entry.getKey(), entry.getValue());
             }
-        });
-        return builder.build();
+        }
+        return null == builder ? dittoHeaders : builder.build();
     }
 
     /**

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedSpan.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedSpan.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.metrics.instruments.TaggableMetricsInstrument;
 
 /**
@@ -109,6 +110,33 @@ public interface StartedSpan extends TaggableMetricsInstrument<StartedSpan>, Spa
      * @param map the map to which the current span context is propagated.
      */
     Map<String, String> propagateContext(Map<String, String> map);
+
+    /**
+     * Propagates the current context of this span onto the given <em>already-validated</em> {@link DittoHeaders},
+     * returning trusted {@code DittoHeaders} that skip header value re-validation.
+     * <p>
+     * This is equivalent in result to {@code DittoHeaders.of(propagateContext((Map<String, String>) dittoHeaders))}
+     * but avoids rebuilding through the validating constructor, which would re-parse every JSON-typed header value on
+     * each traced hop. It runs the exact same propagation on the actual headers (so the incoming {@code tracestate}
+     * is read and this span's {@code traceparent} is written identically to {@link #propagateContext(Map)}), then
+     * re-applies only the entries the propagation actually changed onto the trusted, memoizing headers. Those changed
+     * entries are the W3C trace-context headers ({@code traceparent}/{@code tracestate}), which carry a no-op value
+     * validator, so no header value is re-parsed.
+     *
+     * @param dittoHeaders the already-validated headers onto which the span context is propagated.
+     * @return the trusted headers including the propagated span context.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     */
+    default DittoHeaders propagateContext(final DittoHeaders dittoHeaders) {
+        final Map<String, String> propagatedHeaders = propagateContext((Map<String, String>) dittoHeaders);
+        final var builder = dittoHeaders.toBuilder();
+        propagatedHeaders.forEach((key, value) -> {
+            if (!value.equals(dittoHeaders.get(key))) {
+                builder.putHeader(key, value);
+            }
+        });
+        return builder.build();
+    }
 
     /**
      * Spawns a child span of this StartedSpan with the specified SpanOperationName argument.

--- a/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/EmptyStartedSpanTest.java
+++ b/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/EmptyStartedSpanTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.internal.utils.tracing.span;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -50,6 +51,16 @@ public final class EmptyStartedSpanTest {
         final var underTest = EmptyStartedSpan.newInstance(operationName);
 
         assertThat((CharSequence) underTest.getOperationName()).isEqualTo(operationName);
+    }
+
+    @Test
+    public void propagateContextToDittoHeadersReturnsSameInstance() {
+        final var underTest = EmptyStartedSpan.newInstance(SpanOperationName.of(testName.getMethodName()));
+        final var dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(testName.getMethodName())
+                .build();
+
+        assertThat((Object) underTest.propagateContext(dittoHeaders)).isSameAs(dittoHeaders);
     }
 
 }

--- a/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/StartedKamonSpanTest.java
+++ b/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/StartedKamonSpanTest.java
@@ -302,6 +302,26 @@ public final class StartedKamonSpanTest {
     }
 
     @Test
+    // Regression: the trusted DittoHeaders overload must not clobber an incoming tracestate and must stay
+    // equivalent to the plain validating expression it replaces.
+    public void propagateContextToDittoHeadersPreservesIncomingTracestate() {
+        final var incomingTracestate = "vendorA=abc123";
+        final var dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(testName.getMethodName())
+                .putHeader(DittoHeaderDefinition.W3C_TRACESTATE.getKey(), incomingTracestate)
+                .build();
+
+        final DittoHeaders viaOverload = underTest.propagateContext(dittoHeaders);
+        final DittoHeaders viaMap =
+                DittoHeaders.of(underTest.propagateContext((Map<String, String>) dittoHeaders));
+
+        assertThat(viaOverload)
+                .isEqualTo(viaMap)
+                .containsEntry(DittoHeaderDefinition.W3C_TRACESTATE.getKey(), incomingTracestate)
+                .containsEntry(DittoHeaderDefinition.W3C_TRACEPARENT.getKey(), getExpectedTraceparentValue());
+    }
+
+    @Test
     public void spawnChildWithNullOperationNameThrowsNullPointerException() {
         assertThatNullPointerException()
                 .isThrownBy(() -> underTest.spawnChild(null))


### PR DESCRIPTION
## Problem

When distributed tracing is enabled (and especially at high trace sampling rates), several hot paths rebuild `DittoHeaders` through the **validating** constructor even though the source headers were already validated. Concretely, injecting span context via

```java
DittoHeaders.of(startedSpan.propagateContext(dittoHeaders))
```

goes through `DittoHeaders.of(Map)`, whose fast-path only applies when the argument is already a `DittoHeaders`. With an active span, `StartedSpan.propagateContext(Map)` returns a plain `HashMap` (the base headers plus the injected W3C trace context), so `DittoHeaders.of(...)` rebuilds through the validating constructor and **re-parses/re-validates every JSON-typed header value on each hop** — undoing the header-value memoization and trusted-deserialization optimizations introduced in 3.9.5. This shape is repeated at ~20 call sites across the services.

The same unnecessary re-validation happens on **event-journal recovery**: `AbstractMongoEventAdapter.fromJournal` and `AbstractPersistenceActor.mapJournalEntryToEvent` rebuild the persisted headers via `DittoHeaders.newBuilder(obj).build()`, re-parsing every JSON-typed header value even though those headers were validated when the event was originally persisted.

## Changes

1. **Add a trusted `StartedSpan.propagateContext(DittoHeaders)` overload.** It injects only the trace-context delta (`propagateContext(Map.of())`) onto the already-validated headers via `dittoHeaders.toBuilder()` (which uses the skip-validation constructor), so only the small trace-context delta is validated and the memoized parsed values are preserved. Existing call sites that pass a `DittoHeaders` now bind to this overload and skip the re-validation automatically; callers passing a plain `Map` (e.g. raw transport/HTTP headers) keep the existing `Map` overload. The cluster (de)serializer uses the overload directly.

2. **Deserialize persisted headers as trusted on journal recovery** via `DittoHeaders.newFromTrustedJson(...)` in the two journal-recovery paths.

## Notes

- Overload resolution is by static type, so this is source-compatible: only `DittoHeaders` arguments switch behavior, and none of those call sites mutate the returned map (transport consumers and the HTTP request-tracing directive pass plain `Map`s and are unaffected).
- Builds on the 3.9.5 header-value memoization / `newFromTrustedJson` work.
