### PR TITLE
Make operator metrics MongoDB read preference and concern configurable

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.6.0  # chart version is effectively set by release-job
+version: 4.6.1  # chart version is effectively set by release-job
 appVersion: 3.9.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/service-config/search-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/search-extension.conf.tpl
@@ -146,6 +146,28 @@ ditto {
         }
         {{- end }}
       }
+
+      {{- with .Values.thingsSearch.config.operatorMetrics.customMetricsPersistence }}
+      {{- if .readPreference }}
+      custom-metrics-persistence {
+        readPreference = "{{ .readPreference }}"
+        {{- if .readConcern }}
+        readConcern = "{{ .readConcern }}"
+        {{- end }}
+      }
+      {{- end }}
+      {{- end }}
+
+      {{- with .Values.thingsSearch.config.operatorMetrics.customAggregationMetricsPersistence }}
+      {{- if .readPreference }}
+      custom-aggregation-metrics-persistence {
+        readPreference = "{{ .readPreference }}"
+        {{- if .readConcern }}
+        readConcern = "{{ .readConcern }}"
+        {{- end }}
+      }
+      {{- end }}
+      {{- end }}
     }
   }
 }

--- a/deployment/helm/ditto/service-config/search-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/search-extension.conf.tpl
@@ -148,9 +148,11 @@ ditto {
       }
 
       {{- with .Values.thingsSearch.config.operatorMetrics.customMetricsPersistence }}
-      {{- if .readPreference }}
+      {{- if or .readPreference .readConcern }}
       custom-metrics-persistence {
+        {{- if .readPreference }}
         readPreference = "{{ .readPreference }}"
+        {{- end }}
         {{- if .readConcern }}
         readConcern = "{{ .readConcern }}"
         {{- end }}
@@ -159,9 +161,11 @@ ditto {
       {{- end }}
 
       {{- with .Values.thingsSearch.config.operatorMetrics.customAggregationMetricsPersistence }}
-      {{- if .readPreference }}
+      {{- if or .readPreference .readConcern }}
       custom-aggregation-metrics-persistence {
+        {{- if .readPreference }}
         readPreference = "{{ .readPreference }}"
+        {{- end }}
         {{- if .readConcern }}
         readConcern = "{{ .readConcern }}"
         {{- end }}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1729,6 +1729,19 @@ thingsSearch:
       #   # or as index key spec:
       #   # indexHint:
       #   #   "t.attributes.location": 1
+      # customMetricsPersistence optionally overrides the MongoDB read preference / read concern used for the
+      # count based "customMetrics" queries above. When unset (the default), the general query.persistence
+      # settings are used - so this can offload the periodic operator metric counts to a secondary node without
+      # affecting user-facing search/count requests.
+      # customMetricsPersistence:
+      #   readPreference: secondaryPreferred
+      #   readConcern: default
+      # customAggregationMetricsPersistence optionally overrides the MongoDB read preference / read concern used
+      # for the "customAggregationMetrics" ($group) queries above. When unset (the default), the general
+      # query.persistence settings are used. Can be configured independently from customMetricsPersistence.
+      # customAggregationMetricsPersistence:
+      #   readPreference: secondaryPreferred
+      #   readConcern: default
     # dispatchers contains tuning for the things-search service's Pekko dispatchers.
     # Defaults below match the in-jar HOCON defaults and only need overriding under sustained load.
     dispatchers:

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1730,18 +1730,19 @@ thingsSearch:
       #   # indexHint:
       #   #   "t.attributes.location": 1
       # customMetricsPersistence optionally overrides the MongoDB read preference / read concern used for the
-      # count based "customMetrics" queries above. When unset (the default), the general query.persistence
-      # settings are used - so this can offload the periodic operator metric counts to a secondary node without
-      # affecting user-facing search/count requests.
+      # count based "customMetrics" queries above - e.g. to offload the periodic operator metric counts to a
+      # secondary node without affecting user-facing search/count requests.
+      # Each setting is inherited from the general query.persistence config when it is not set here, so either
+      # key can be configured on its own: setting only readConcern keeps the query.persistence readPreference.
       # customMetricsPersistence:
       #   readPreference: secondaryPreferred
-      #   readConcern: default
+      #   readConcern: local
       # customAggregationMetricsPersistence optionally overrides the MongoDB read preference / read concern used
-      # for the "customAggregationMetrics" ($group) queries above. When unset (the default), the general
-      # query.persistence settings are used. Can be configured independently from customMetricsPersistence.
+      # for the "customAggregationMetrics" ($group) queries above, with the same per-setting inheritance from
+      # query.persistence. Can be configured independently from customMetricsPersistence.
       # customAggregationMetricsPersistence:
       #   readPreference: secondaryPreferred
-      #   readConcern: default
+      #   readConcern: local
     # dispatchers contains tuning for the things-search service's Pekko dispatchers.
     # Defaults below match the in-jar HOCON defaults and only need overriding under sustained load.
     dispatchers:

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadConcern.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadConcern.java
@@ -43,6 +43,16 @@ public enum ReadConcern {
     }
 
     /**
+     * Returns the config string value of this read concern (e.g. {@code "local"}).
+     *
+     * @return the read concern config string.
+     * @since 3.9.7
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * Tries to create a ReadConcern from the given read concern string.
      *
      * @param readConcern the string value of read concern.

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadPreference.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadPreference.java
@@ -41,6 +41,16 @@ public enum ReadPreference {
     }
 
     /**
+     * Returns the config string value of this read preference (e.g. {@code "secondaryPreferred"}).
+     *
+     * @return the read preference config string.
+     * @since 3.9.7
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
      * Tries to create a ReadPreference from the given read preference string.
      *
      * @param readPreference the string value of read preference.

--- a/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
+++ b/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThings.java
@@ -73,6 +73,14 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
             JsonFactory.newJsonValueFieldDefinition("indexHint", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
 
+    static final JsonFieldDefinition<String> JSON_READ_PREFERENCE =
+            JsonFactory.newStringFieldDefinition("readPreference", FieldType.REGULAR,
+                    JsonSchemaVersion.V_2);
+
+    static final JsonFieldDefinition<String> JSON_READ_CONCERN =
+            JsonFactory.newStringFieldDefinition("readConcern", FieldType.REGULAR,
+                    JsonSchemaVersion.V_2);
+
     @Nullable
     private final String filter;
 
@@ -82,8 +90,15 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
     @Nullable
     private final JsonValue indexHint;
 
+    @Nullable
+    private final String readPreference;
+
+    @Nullable
+    private final String readConcern;
+
     private SudoCountThings(final DittoHeaders dittoHeaders, @Nullable final String filter,
-            @Nullable final Collection<String> namespaces, @Nullable final JsonValue indexHint) {
+            @Nullable final Collection<String> namespaces, @Nullable final JsonValue indexHint,
+            @Nullable final String readPreference, @Nullable final String readConcern) {
         super(TYPE, dittoHeaders);
         this.filter = filter;
         if (namespaces != null) {
@@ -92,6 +107,8 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
             this.namespaces = null;
         }
         this.indexHint = indexHint;
+        this.readPreference = readPreference;
+        this.readConcern = readConcern;
     }
 
     /**
@@ -103,7 +120,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
      */
     public static SudoCountThings of(@Nullable final String filter, final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, filter, null, null);
+        return new SudoCountThings(dittoHeaders, filter, null, null, null, null);
     }
 
     /**
@@ -117,7 +134,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      */
     public static SudoCountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
             final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, filter, namespaces, null);
+        return new SudoCountThings(dittoHeaders, filter, namespaces, null, null, null);
     }
 
     /**
@@ -132,7 +149,47 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      */
     public static SudoCountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
             @Nullable final JsonValue indexHint, final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint);
+        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint, null, null);
+    }
+
+    /**
+     * Returns a new instance of {@code SudoCountThings}.
+     *
+     * @param filter the optional filter string.
+     * @param namespaces the namespaces to perform the count in.
+     * @param indexHint the optional index hint for the MongoDB query.
+     * @param readPreference the optional MongoDB read preference to use for this count query (e.g.
+     * {@code "secondaryPreferred"}); when {@code null} the persistence default read preference is used.
+     * @param dittoHeaders the headers of the command.
+     * @return a new command for counting Things.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     * @since 3.9.7
+     */
+    public static SudoCountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
+            @Nullable final JsonValue indexHint, @Nullable final String readPreference,
+            final DittoHeaders dittoHeaders) {
+        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint, readPreference, null);
+    }
+
+    /**
+     * Returns a new instance of {@code SudoCountThings}.
+     *
+     * @param filter the optional filter string.
+     * @param namespaces the namespaces to perform the count in.
+     * @param indexHint the optional index hint for the MongoDB query.
+     * @param readPreference the optional MongoDB read preference to use for this count query (e.g.
+     * {@code "secondaryPreferred"}); when {@code null} the persistence default read preference is used.
+     * @param readConcern the optional MongoDB read concern to use for this count query (e.g. {@code "local"});
+     * when {@code null} the persistence default read concern is used.
+     * @param dittoHeaders the headers of the command.
+     * @return a new command for counting Things.
+     * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     * @since 3.9.7
+     */
+    public static SudoCountThings of(@Nullable final String filter, @Nullable final Collection<String> namespaces,
+            @Nullable final JsonValue indexHint, @Nullable final String readPreference,
+            @Nullable final String readConcern, final DittoHeaders dittoHeaders) {
+        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint, readPreference, readConcern);
     }
 
     /**
@@ -143,7 +200,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static SudoCountThings of(final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, null, null, null);
+        return new SudoCountThings(dittoHeaders, null, null, null, null, null);
     }
 
     /**
@@ -186,7 +243,12 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
 
             final JsonValue extractedIndexHint = jsonObject.getValue(JSON_INDEX_HINT).orElse(null);
 
-            return new SudoCountThings(dittoHeaders, extractedFilter, extractedNamespaces, extractedIndexHint);
+            final String extractedReadPreference = jsonObject.getValue(JSON_READ_PREFERENCE).orElse(null);
+
+            final String extractedReadConcern = jsonObject.getValue(JSON_READ_CONCERN).orElse(null);
+
+            return new SudoCountThings(dittoHeaders, extractedFilter, extractedNamespaces, extractedIndexHint,
+                    extractedReadPreference, extractedReadConcern);
         });
     }
 
@@ -217,6 +279,26 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
         return Optional.ofNullable(indexHint);
     }
 
+    /**
+     * Get the optional MongoDB read preference override for this count query.
+     *
+     * @return the optional read preference (e.g. {@code "secondaryPreferred"}).
+     * @since 3.9.7
+     */
+    public Optional<String> getReadPreference() {
+        return Optional.ofNullable(readPreference);
+    }
+
+    /**
+     * Get the optional MongoDB read concern override for this count query.
+     *
+     * @return the optional read concern (e.g. {@code "local"}).
+     * @since 3.9.7
+     */
+    public Optional<String> getReadConcern() {
+        return Optional.ofNullable(readConcern);
+    }
+
     @Override
     protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
             final Predicate<JsonField> thePredicate) {
@@ -227,6 +309,8 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
                 .map(JsonValue::of)
                 .collect(JsonCollectors.valuesToArray()), predicate));
         getIndexHint().ifPresent(hint -> jsonObjectBuilder.set(JSON_INDEX_HINT, hint, predicate));
+        getReadPreference().ifPresent(rp -> jsonObjectBuilder.set(JSON_READ_PREFERENCE, rp, predicate));
+        getReadConcern().ifPresent(rc -> jsonObjectBuilder.set(JSON_READ_CONCERN, rc, predicate));
     }
 
     @Override
@@ -236,7 +320,7 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
 
     @Override
     public SudoCountThings setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint);
+        return new SudoCountThings(dittoHeaders, filter, namespaces, indexHint, readPreference, readConcern);
     }
 
     @Override
@@ -250,12 +334,14 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
         final SudoCountThings that = (SudoCountThings) o;
         return Objects.equals(filter, that.filter) &&
                 Objects.equals(namespaces, that.namespaces) &&
-                Objects.equals(indexHint, that.indexHint);
+                Objects.equals(indexHint, that.indexHint) &&
+                Objects.equals(readPreference, that.readPreference) &&
+                Objects.equals(readConcern, that.readConcern);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filter, namespaces, indexHint);
+        return Objects.hash(super.hashCode(), filter, namespaces, indexHint, readPreference, readConcern);
     }
 
     @Override
@@ -264,6 +350,8 @@ public final class SudoCountThings extends AbstractCommand<SudoCountThings>
                 "filter='" + filter + "'" +
                 ", namespaces=" + namespaces +
                 ", indexHint=" + indexHint +
+                ", readPreference=" + readPreference +
+                ", readConcern=" + readConcern +
                 "]";
     }
 

--- a/thingsearch/api/src/test/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThingsTest.java
+++ b/thingsearch/api/src/test/java/org/eclipse/ditto/thingsearch/api/commands/sudo/SudoCountThingsTest.java
@@ -135,4 +135,42 @@ public final class SudoCountThingsTest {
         assertThat(withNewHeaders.getIndexHint()).contains(JsonValue.of("my_index"));
     }
 
+    @Test
+    public void toJsonWithReadPreferenceAndReadConcern() {
+        final SudoCountThings command = SudoCountThings.of(
+                KNOWN_FILTER_STR, List.of("ns1"), JsonValue.of("my_index"), "secondaryPreferred", "local",
+                DittoHeaders.empty());
+
+        final String json = command.toJsonString();
+        final SudoCountThings deserialized = SudoCountThings.fromJson(json, DittoHeaders.empty());
+
+        assertThat(deserialized.getFilter()).contains(KNOWN_FILTER_STR);
+        assertThat(deserialized.getIndexHint()).contains(JsonValue.of("my_index"));
+        assertThat(deserialized.getReadPreference()).contains("secondaryPreferred");
+        assertThat(deserialized.getReadConcern()).contains("local");
+    }
+
+    @Test
+    public void toJsonWithoutReadPreferenceOrReadConcern() {
+        final SudoCountThings command = SudoCountThings.of(KNOWN_FILTER_STR, DittoHeaders.empty());
+
+        final String json = command.toJsonString();
+        final SudoCountThings deserialized = SudoCountThings.fromJson(json, DittoHeaders.empty());
+
+        assertThat(deserialized.getReadPreference()).isEmpty();
+        assertThat(deserialized.getReadConcern()).isEmpty();
+    }
+
+    @Test
+    public void setDittoHeadersPreservesReadPreferenceAndReadConcern() {
+        final SudoCountThings command = SudoCountThings.of(
+                KNOWN_FILTER_STR, null, null, "secondaryPreferred", "local", DittoHeaders.empty());
+
+        final SudoCountThings withNewHeaders = command.setDittoHeaders(
+                DittoHeaders.newBuilder().correlationId("test").build());
+
+        assertThat(withNewHeaders.getReadPreference()).contains("secondaryPreferred");
+        assertThat(withNewHeaders.getReadConcern()).contains("local");
+    }
+
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
@@ -32,6 +32,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -66,33 +67,70 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
     @Nullable private final SearchPersistenceConfig customMetricsPersistenceConfig;
     @Nullable private final SearchPersistenceConfig customAggregationMetricsPersistenceConfig;
 
-    private DefaultOperatorMetricsConfig(final ConfigWithFallback updaterScopedConfig) {
+    private DefaultOperatorMetricsConfig(final ConfigWithFallback updaterScopedConfig,
+            final SearchPersistenceConfig queryPersistenceConfig) {
         enabled = updaterScopedConfig.getBoolean(OperatorMetricsConfigValue.ENABLED.getConfigPath());
         scrapeInterval = updaterScopedConfig.getNonNegativeDurationOrThrow(OperatorMetricsConfigValue.SCRAPE_INTERVAL);
         customMetricConfigurations = loadCustomMetricConfigurations(updaterScopedConfig,
                 OperatorMetricsConfigValue.CUSTOM_METRICS);
         customAggregationMetricConfigs = loadCustomAggregatedMetricConfigurations(updaterScopedConfig,
                 OperatorMetricsConfigValue.CUSTOM_AGGREGATION_METRIC);
-        customMetricsPersistenceConfig = updaterScopedConfig.hasPath(CUSTOM_METRICS_PERSISTENCE_PATH)
-                ? DefaultSearchPersistenceConfig.of(updaterScopedConfig, CUSTOM_METRICS_PERSISTENCE_PATH)
-                : null;
-        customAggregationMetricsPersistenceConfig =
-                updaterScopedConfig.hasPath(CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH)
-                        ? DefaultSearchPersistenceConfig.of(updaterScopedConfig,
-                        CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH)
-                        : null;
+        customMetricsPersistenceConfig = loadPersistenceConfig(updaterScopedConfig,
+                CUSTOM_METRICS_PERSISTENCE_PATH, queryPersistenceConfig);
+        customAggregationMetricsPersistenceConfig = loadPersistenceConfig(updaterScopedConfig,
+                CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH, queryPersistenceConfig);
     }
 
     /**
-     * Returns an instance of DefaultOperatorMetricsConfig based on the settings of the specified Config.
+     * Returns an instance of DefaultOperatorMetricsConfig based on the settings of the specified Config, using the
+     * {@code SearchPersistenceConfig} defaults as fallback for partially configured persistence blocks.
      *
      * @param config is supposed to provide the settings of the updater config at {@value #CONFIG_PATH}.
      * @return the instance.
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultOperatorMetricsConfig of(final Config config) {
+        return of(config, DefaultSearchPersistenceConfig.of(ConfigFactory.empty()));
+    }
+
+    /**
+     * Returns an instance of DefaultOperatorMetricsConfig based on the settings of the specified Config, inheriting
+     * read settings which the optional persistence blocks leave out from the passed {@code queryPersistenceConfig}.
+     *
+     * @param config is supposed to provide the settings of the updater config at {@value #CONFIG_PATH}.
+     * @param queryPersistenceConfig the general {@code query.persistence} config which individual read settings are
+     * inherited from when a configured persistence block does not specify them.
+     * @return the instance.
+     * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
+     * @since 3.9.7
+     */
+    public static DefaultOperatorMetricsConfig of(final Config config,
+            final SearchPersistenceConfig queryPersistenceConfig) {
         return new DefaultOperatorMetricsConfig(
-                ConfigWithFallback.newInstance(config, CONFIG_PATH, OperatorMetricsConfigValue.values()));
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, OperatorMetricsConfigValue.values()),
+                queryPersistenceConfig);
+    }
+
+    @Nullable
+    private static SearchPersistenceConfig loadPersistenceConfig(final ConfigWithFallback updaterScopedConfig,
+            final String configPath, final SearchPersistenceConfig queryPersistenceConfig) {
+
+        if (!updaterScopedConfig.hasPath(configPath)) {
+            return null;
+        }
+        // read settings the block does not specify are inherited from "query.persistence" instead of falling back to
+        // the SearchPersistenceConfig defaults, so a partially configured block only overrides what it names:
+        final Config blockConfig = updaterScopedConfig.getConfig(configPath)
+                .withFallback(asConfig(queryPersistenceConfig));
+        return DefaultSearchPersistenceConfig.ofScopedConfig(blockConfig);
+    }
+
+    private static Config asConfig(final SearchPersistenceConfig persistenceConfig) {
+        return ConfigFactory.parseMap(Map.of(
+                MongoDbConfig.OptionsConfig.OptionsConfigValue.READ_PREFERENCE.getConfigPath(),
+                persistenceConfig.readPreference().getName(),
+                MongoDbConfig.OptionsConfig.OptionsConfigValue.READ_CONCERN.getConfigPath(),
+                persistenceConfig.readConcern().getName()));
     }
 
     private static Map<String, CustomMetricConfig> loadCustomMetricConfigurations(final ConfigWithFallback config,

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfig.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -26,6 +27,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
@@ -47,10 +49,22 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
      */
     static final String CONFIG_PATH = "operator-metrics";
 
+    /**
+     * Path of the optional persistence config block used for the count based {@code custom-metrics} queries.
+     */
+    static final String CUSTOM_METRICS_PERSISTENCE_PATH = "custom-metrics-persistence";
+
+    /**
+     * Path of the optional persistence config block used for the {@code custom-aggregation-metrics} queries.
+     */
+    static final String CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH = "custom-aggregation-metrics-persistence";
+
     private final boolean enabled;
     private final Duration scrapeInterval;
     private final Map<String, CustomMetricConfig> customMetricConfigurations;
     private final Map<String, CustomAggregationMetricConfig> customAggregationMetricConfigs;
+    @Nullable private final SearchPersistenceConfig customMetricsPersistenceConfig;
+    @Nullable private final SearchPersistenceConfig customAggregationMetricsPersistenceConfig;
 
     private DefaultOperatorMetricsConfig(final ConfigWithFallback updaterScopedConfig) {
         enabled = updaterScopedConfig.getBoolean(OperatorMetricsConfigValue.ENABLED.getConfigPath());
@@ -59,6 +73,14 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
                 OperatorMetricsConfigValue.CUSTOM_METRICS);
         customAggregationMetricConfigs = loadCustomAggregatedMetricConfigurations(updaterScopedConfig,
                 OperatorMetricsConfigValue.CUSTOM_AGGREGATION_METRIC);
+        customMetricsPersistenceConfig = updaterScopedConfig.hasPath(CUSTOM_METRICS_PERSISTENCE_PATH)
+                ? DefaultSearchPersistenceConfig.of(updaterScopedConfig, CUSTOM_METRICS_PERSISTENCE_PATH)
+                : null;
+        customAggregationMetricsPersistenceConfig =
+                updaterScopedConfig.hasPath(CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH)
+                        ? DefaultSearchPersistenceConfig.of(updaterScopedConfig,
+                        CUSTOM_AGGREGATION_METRICS_PERSISTENCE_PATH)
+                        : null;
     }
 
     /**
@@ -99,12 +121,18 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
         }
         final DefaultOperatorMetricsConfig that = (DefaultOperatorMetricsConfig) o;
         return enabled == that.enabled &&
-                Objects.equals(scrapeInterval, that.scrapeInterval);
+                Objects.equals(scrapeInterval, that.scrapeInterval) &&
+                Objects.equals(customMetricConfigurations, that.customMetricConfigurations) &&
+                Objects.equals(customAggregationMetricConfigs, that.customAggregationMetricConfigs) &&
+                Objects.equals(customMetricsPersistenceConfig, that.customMetricsPersistenceConfig) &&
+                Objects.equals(customAggregationMetricsPersistenceConfig,
+                        that.customAggregationMetricsPersistenceConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, scrapeInterval, customMetricConfigurations);
+        return Objects.hash(enabled, scrapeInterval, customMetricConfigurations, customAggregationMetricConfigs,
+                customMetricsPersistenceConfig, customAggregationMetricsPersistenceConfig);
     }
 
     @Override
@@ -113,6 +141,9 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
                 "enabled=" + enabled +
                 ", scrapeInterval=" + scrapeInterval +
                 ", customMetricConfigurations=" + customMetricConfigurations +
+                ", customAggregationMetricConfigs=" + customAggregationMetricConfigs +
+                ", customMetricsPersistenceConfig=" + customMetricsPersistenceConfig +
+                ", customAggregationMetricsPersistenceConfig=" + customAggregationMetricsPersistenceConfig +
                 "]";
     }
 
@@ -134,6 +165,16 @@ public final class DefaultOperatorMetricsConfig implements OperatorMetricsConfig
     @Override
     public Map<String, CustomAggregationMetricConfig> getCustomAggregationMetricConfigs() {
         return customAggregationMetricConfigs;
+    }
+
+    @Override
+    public Optional<SearchPersistenceConfig> getCustomMetricsPersistenceConfig() {
+        return Optional.ofNullable(customMetricsPersistenceConfig);
+    }
+
+    @Override
+    public Optional<SearchPersistenceConfig> getCustomAggregationMetricsPersistenceConfig() {
+        return Optional.ofNullable(customAggregationMetricsPersistenceConfig);
     }
 
     private static class CustomMetricConfigCollector

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfig.java
@@ -69,22 +69,24 @@ public final class DefaultSearchPersistenceConfig implements SearchPersistenceCo
      * @throws DittoConfigError if {@code config} is invalid.
      */
     public static DefaultSearchPersistenceConfig of(final Config config) {
-        return of(config, CONFIG_PATH);
+        return new DefaultSearchPersistenceConfig(
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValue.values()));
     }
 
     /**
-     * Returns an instance of DefaultSearchPersistenceConfig based on the settings of the specified Config at the
-     * given {@code configPath}.
+     * Returns an instance of DefaultSearchPersistenceConfig based on the settings of the specified already scoped
+     * Config, i.e. a Config directly providing the persistence settings instead of nesting them at
+     * {@value CONFIG_PATH}. Settings absent from {@code scopedConfig} are taken from the {@code ConfigValue}
+     * defaults, so a caller wanting different fallbacks has to merge them into {@code scopedConfig} beforehand.
      *
-     * @param config the Config which provides the persistence settings at {@code configPath}.
-     * @param configPath the path under {@code config} at which the persistence settings are expected.
+     * @param scopedConfig the Config directly providing the persistence settings.
      * @return the instance.
-     * @throws DittoConfigError if {@code config} is invalid.
+     * @throws DittoConfigError if {@code scopedConfig} is invalid.
      * @since 3.9.7
      */
-    public static DefaultSearchPersistenceConfig of(final Config config, final String configPath) {
+    public static DefaultSearchPersistenceConfig ofScopedConfig(final Config scopedConfig) {
         return new DefaultSearchPersistenceConfig(
-                ConfigWithFallback.newInstance(config, configPath, ConfigValue.values()));
+                ConfigWithFallback.newInstance(scopedConfig, ConfigValue.values()));
     }
 
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfig.java
@@ -69,7 +69,22 @@ public final class DefaultSearchPersistenceConfig implements SearchPersistenceCo
      * @throws DittoConfigError if {@code config} is invalid.
      */
     public static DefaultSearchPersistenceConfig of(final Config config) {
-        return new DefaultSearchPersistenceConfig(ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValue.values()));
+        return of(config, CONFIG_PATH);
+    }
+
+    /**
+     * Returns an instance of DefaultSearchPersistenceConfig based on the settings of the specified Config at the
+     * given {@code configPath}.
+     *
+     * @param config the Config which provides the persistence settings at {@code configPath}.
+     * @param configPath the path under {@code config} at which the persistence settings are expected.
+     * @return the instance.
+     * @throws DittoConfigError if {@code config} is invalid.
+     * @since 3.9.7
+     */
+    public static DefaultSearchPersistenceConfig of(final Config config, final String configPath) {
+        return new DefaultSearchPersistenceConfig(
+                ConfigWithFallback.newInstance(config, configPath, ConfigValue.values()));
     }
 
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
@@ -107,7 +107,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
         simpleFieldMappings =
                 convertToMap(configWithFallback.getConfig(SearchConfigValue.SIMPLE_FIELD_MAPPINGS.getConfigPath()));
         namespaceIndexedFields = loadNamespaceSearchIndexList(configWithFallback);
-        operatorMetricsConfig = DefaultOperatorMetricsConfig.of(configWithFallback);
+        operatorMetricsConfig = DefaultOperatorMetricsConfig.of(configWithFallback, queryPersistenceConfig);
         customIndexes = loadCustomIndexes(configWithFallback);
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
@@ -57,7 +57,9 @@ public interface OperatorMetricsConfig {
 
     /**
      * Returns the optional persistence (read preference / read concern) configuration to use for the count based
-     * {@code custom-metrics} queries. When empty, the general {@code query.persistence} configuration is used.
+     * {@code custom-metrics} queries. When empty, i.e. when the {@code custom-metrics-persistence} block is absent,
+     * the general {@code query.persistence} configuration is used. A configured block only overrides the read
+     * settings it actually specifies; the others are inherited from {@code query.persistence} as well.
      *
      * @return the optional persistence configuration for count based custom metrics.
      * @since 3.9.7
@@ -66,8 +68,10 @@ public interface OperatorMetricsConfig {
 
     /**
      * Returns the optional persistence (read preference / read concern) configuration to use for the
-     * {@code custom-aggregation-metrics} ({@code $group}) queries. When empty, the general {@code query.persistence}
-     * configuration is used.
+     * {@code custom-aggregation-metrics} ({@code $group}) queries. When empty, i.e. when the
+     * {@code custom-aggregation-metrics-persistence} block is absent, the general {@code query.persistence}
+     * configuration is used. A configured block only overrides the read settings it actually specifies; the others
+     * are inherited from {@code query.persistence} as well.
      *
      * @return the optional persistence configuration for custom aggregation metrics.
      * @since 3.9.7

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/OperatorMetricsConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.thingsearch.service.common.config;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -53,6 +54,25 @@ public interface OperatorMetricsConfig {
      * @return the registered custom aggregation metrics.
      */
     Map<String, CustomAggregationMetricConfig> getCustomAggregationMetricConfigs();
+
+    /**
+     * Returns the optional persistence (read preference / read concern) configuration to use for the count based
+     * {@code custom-metrics} queries. When empty, the general {@code query.persistence} configuration is used.
+     *
+     * @return the optional persistence configuration for count based custom metrics.
+     * @since 3.9.7
+     */
+    Optional<SearchPersistenceConfig> getCustomMetricsPersistenceConfig();
+
+    /**
+     * Returns the optional persistence (read preference / read concern) configuration to use for the
+     * {@code custom-aggregation-metrics} ({@code $group}) queries. When empty, the general {@code query.persistence}
+     * configuration is used.
+     *
+     * @return the optional persistence configuration for custom aggregation metrics.
+     * @since 3.9.7
+     */
+    Optional<SearchPersistenceConfig> getCustomAggregationMetricsPersistenceConfig();
 
     /**
      * An enumeration of the known config path expressions and their associated default values for

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsAggregationPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsAggregationPersistence.java
@@ -89,8 +89,13 @@ public final class MongoThingsAggregationPersistence implements ThingsAggregatio
 
     public static ThingsAggregationPersistence of(final DittoMongoClient mongoClient,
             final SearchConfig searchConfig, final LoggingAdapter log) {
+        // use the dedicated operator-metrics aggregation persistence config (read preference / read concern) if
+        // configured, otherwise fall back to the general query persistence config:
+        final SearchPersistenceConfig persistenceConfig = searchConfig.getOperatorMetricsConfig()
+                .getCustomAggregationMetricsPersistenceConfig()
+                .orElseGet(searchConfig::getQueryPersistenceConfig);
         return new MongoThingsAggregationPersistence(mongoClient, searchConfig.getMongoHintsByNamespace(),
-                searchConfig.getSimpleFieldMappings(), searchConfig.getQueryPersistenceConfig(), log);
+                searchConfig.getSimpleFieldMappings(), persistenceConfig, log);
     }
 
     @Override

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsAggregationPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsAggregationPersistence.java
@@ -91,9 +91,15 @@ public final class MongoThingsAggregationPersistence implements ThingsAggregatio
             final SearchConfig searchConfig, final LoggingAdapter log) {
         // use the dedicated operator-metrics aggregation persistence config (read preference / read concern) if
         // configured, otherwise fall back to the general query persistence config:
-        final SearchPersistenceConfig persistenceConfig = searchConfig.getOperatorMetricsConfig()
-                .getCustomAggregationMetricsPersistenceConfig()
-                .orElseGet(searchConfig::getQueryPersistenceConfig);
+        final Optional<SearchPersistenceConfig> dedicatedPersistenceConfig =
+                searchConfig.getOperatorMetricsConfig().getCustomAggregationMetricsPersistenceConfig();
+        final SearchPersistenceConfig persistenceConfig =
+                dedicatedPersistenceConfig.orElseGet(searchConfig::getQueryPersistenceConfig);
+        log.info("Aggregation metrics query readConcern=<{}> readPreference=<{}> (configured via <{}>)",
+                persistenceConfig.readConcern().getName(), persistenceConfig.readPreference().getName(),
+                dedicatedPersistenceConfig.isPresent()
+                        ? "operator-metrics.custom-aggregation-metrics-persistence"
+                        : "query.persistence");
         return new MongoThingsAggregationPersistence(mongoClient, searchConfig.getMongoHintsByNamespace(),
                 searchConfig.getSimpleFieldMappings(), persistenceConfig, log);
     }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
@@ -48,6 +48,8 @@ import org.eclipse.ditto.internal.utils.persistence.mongo.BsonUtil;
 import org.eclipse.ditto.internal.utils.persistence.mongo.DittoBsonJson;
 import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.IndexInitializationConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
 import org.eclipse.ditto.internal.utils.persistence.mongo.indices.Index;
 import org.eclipse.ditto.internal.utils.persistence.mongo.indices.IndexInitializer;
 import org.eclipse.ditto.json.JsonArray;
@@ -215,6 +217,13 @@ public final class MongoThingsSearchPersistence implements ThingsSearchPersisten
     @Override
     public Source<Long, NotUsed> sudoCount(final Query query, final DittoHeaders dittoHeaders,
             @Nullable final JsonValue indexHint) {
+        return sudoCount(query, dittoHeaders, indexHint, null, null);
+    }
+
+    @Override
+    public Source<Long, NotUsed> sudoCount(final Query query, final DittoHeaders dittoHeaders,
+            @Nullable final JsonValue indexHint, @Nullable final String readPreferenceOverride,
+            @Nullable final String readConcernOverride) {
 
         checkNotNull(query, "query");
 
@@ -227,9 +236,36 @@ public final class MongoThingsSearchPersistence implements ThingsSearchPersisten
                 .maxTime(maxQueryTime.getSeconds(), TimeUnit.SECONDS);
         applyHint(countOptions, indexHint);
 
-        return Source.fromPublisher(collection.countDocuments(queryFilter, countOptions))
+        return Source.fromPublisher(withReadOverrides(readPreferenceOverride, readConcernOverride, dittoHeaders)
+                        .countDocuments(queryFilter, countOptions))
                 .mapError(handleMongoExecutionTimeExceededException(dittoHeaders))
                 .log("sudoCount");
+    }
+
+    private MongoCollection<Document> withReadOverrides(@Nullable final String readPreferenceOverride,
+            @Nullable final String readConcernOverride, final DittoHeaders dittoHeaders) {
+        MongoCollection<Document> result = collection;
+        if (readPreferenceOverride != null) {
+            final Optional<ReadPreference> parsed = ReadPreference.ofReadPreference(readPreferenceOverride);
+            if (parsed.isPresent()) {
+                result = result.withReadPreference(parsed.get().getMongoReadPreference());
+            } else {
+                LOGGER.withCorrelationId(dittoHeaders)
+                        .warn("Ignoring unknown read preference override <{}> for count query.",
+                                readPreferenceOverride);
+            }
+        }
+        if (readConcernOverride != null) {
+            final Optional<ReadConcern> parsed = ReadConcern.ofReadConcern(readConcernOverride);
+            if (parsed.isPresent()) {
+                result = result.withReadConcern(parsed.get().getMongoReadConcern());
+            } else {
+                LOGGER.withCorrelationId(dittoHeaders)
+                        .warn("Ignoring unknown read concern override <{}> for count query.",
+                                readConcernOverride);
+            }
+        }
+        return result;
     }
 
     private void applyHint(final CountOptions countOptions, @Nullable final JsonValue indexHint) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/ThingsSearchPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/ThingsSearchPersistence.java
@@ -91,6 +91,27 @@ public interface ThingsSearchPersistence {
     }
 
     /**
+     * Returns the count of documents found by the given {@code query} regardless of visibility,
+     * using an optional per-query index hint and an optional per-query read preference override.
+     *
+     * @param query the query for matching.
+     * @param dittoHeaders the headers of the request.
+     * @param indexHint the optional index hint (string for index name, object for index key spec).
+     * @param readPreferenceOverride the optional MongoDB read preference to use for this query (e.g.
+     * {@code "secondaryPreferred"}); when {@code null} the persistence default read preference is used.
+     * @param readConcernOverride the optional MongoDB read concern to use for this query (e.g. {@code "local"});
+     * when {@code null} the persistence default read concern is used.
+     * @return an {@link Source} which emits the count.
+     * @throws NullPointerException if {@code query} is {@code null}.
+     * @since 3.9.7
+     */
+    default Source<Long, NotUsed> sudoCount(Query query, DittoHeaders dittoHeaders,
+            @Nullable JsonValue indexHint, @Nullable String readPreferenceOverride,
+            @Nullable String readConcernOverride) {
+        return sudoCount(query, dittoHeaders, indexHint);
+    }
+
+    /**
      * Returns the IDs for all found documents.
      *
      * @param query the query for matching.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import javax.annotation.Nullable;
+
 import org.apache.pekko.actor.AbstractActorWithTimers;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.Props;
@@ -57,12 +59,20 @@ public final class OperatorMetricsProviderActor extends AbstractActorWithTimers 
 
     private final ActorRef searchActor;
     private final Map<String, Gauge> metricsGauges;
+    @Nullable private final String readPreferenceOverride;
+    @Nullable private final String readConcernOverride;
 
     @SuppressWarnings("unused")
     private OperatorMetricsProviderActor(final OperatorMetricsConfig operatorMetricsConfig,
             final ActorRef searchActor) {
 
         this.searchActor = searchActor;
+        readPreferenceOverride = operatorMetricsConfig.getCustomMetricsPersistenceConfig()
+                .map(persistenceConfig -> persistenceConfig.readPreference().getName())
+                .orElse(null);
+        readConcernOverride = operatorMetricsConfig.getCustomMetricsPersistenceConfig()
+                .map(persistenceConfig -> persistenceConfig.readConcern().getName())
+                .orElse(null);
         metricsGauges = new HashMap<>();
         operatorMetricsConfig.getCustomMetricConfigurations().forEach((metricName, config) -> {
             if (config.isEnabled()) {
@@ -131,7 +141,7 @@ public final class OperatorMetricsProviderActor extends AbstractActorWithTimers 
                 .build();
         final SudoCountThings sudoCountThings = SudoCountThings.of(
                 filter.isEmpty() ? null : filter, namespaces.isEmpty() ? null : namespaces,
-                config.getIndexHint().orElse(null), dittoHeaders);
+                config.getIndexHint().orElse(null), readPreferenceOverride, readConcernOverride, dittoHeaders);
 
         final long startTs = System.nanoTime();
         log.withCorrelationId(dittoHeaders)

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorMetricsProviderActor.java
@@ -73,6 +73,13 @@ public final class OperatorMetricsProviderActor extends AbstractActorWithTimers 
         readConcernOverride = operatorMetricsConfig.getCustomMetricsPersistenceConfig()
                 .map(persistenceConfig -> persistenceConfig.readConcern().getName())
                 .orElse(null);
+        if (null != readPreferenceOverride || null != readConcernOverride) {
+            log.info("Custom metrics count queries readConcern=<{}> readPreference=<{}> (configured via " +
+                            "<operator-metrics.custom-metrics-persistence>)",
+                    readConcernOverride, readPreferenceOverride);
+        } else {
+            log.info("Custom metrics count queries use the read settings configured via <query.persistence>");
+        }
         metricsGauges = new HashMap<>();
         operatorMetricsConfig.getCustomMetricConfigurations().forEach((metricName, config) -> {
             if (config.isEnabled()) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
@@ -327,7 +327,9 @@ public final class SearchActor extends AbstractActorWithShutdownBehaviorAndReque
                                             (theQuery, headers) -> {
                                                 if (isSudo && tracedCountCommand instanceof SudoCountThings sudoCmd) {
                                                     return searchPersistence.sudoCount(theQuery, headers,
-                                                            sudoCmd.getIndexHint().orElse(null));
+                                                            sudoCmd.getIndexHint().orElse(null),
+                                                            sudoCmd.getReadPreference().orElse(null),
+                                                            sudoCmd.getReadConcern().orElse(null));
                                                 } else if (isSudo) {
                                                     return searchPersistence.sudoCount(theQuery, headers);
                                                 } else {

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -405,23 +405,25 @@ ditto {
 
       # Optional dedicated MongoDB read settings for the count based "custom-metrics" queries above.
       # When this block is absent (the default), the general "query.persistence" read preference / read concern
-      # is used. Configure it to e.g. offload the periodic operator metric counts to a secondary node without
-      # affecting user-facing search/count requests:
+      # is used. A setting left out of the block is inherited from "query.persistence" as well, so either key can
+      # be configured on its own. Configure it to e.g. offload the periodic operator metric counts to a secondary
+      # node, or to run them with a cheaper read concern than user-facing search/count requests:
       # custom-metrics-persistence {
       #   readPreference = "secondaryPreferred"
       #   readPreference = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_METRICS_READ_PREFERENCE}
-      #   readConcern = "default"
+      #   readConcern = "local"
       #   readConcern = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_METRICS_READ_CONCERN}
       # }
 
       # Optional dedicated MongoDB read settings for the "custom-aggregation-metrics" ($group) queries.
       # When this block is absent (the default), the general "query.persistence" read preference / read concern
-      # is used. Configure it independently from the count based "custom-metrics-persistence" above, e.g. to run
-      # the (potentially expensive) aggregation scans on a secondary node:
+      # is used, and a setting left out of the block is inherited from there as well. Configure it independently
+      # from the count based "custom-metrics-persistence" above, e.g. to run the (potentially expensive)
+      # aggregation scans on a secondary node:
       # custom-aggregation-metrics-persistence {
       #   readPreference = "secondaryPreferred"
       #   readPreference = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_AGGREGATION_METRICS_READ_PREFERENCE}
-      #   readConcern = "default"
+      #   readConcern = "local"
       #   readConcern = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_AGGREGATION_METRICS_READ_CONCERN}
       # }
     }

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -402,6 +402,28 @@ ditto {
         #   # index-hint { "t.attributes.location": 1 }
         # }
       }
+
+      # Optional dedicated MongoDB read settings for the count based "custom-metrics" queries above.
+      # When this block is absent (the default), the general "query.persistence" read preference / read concern
+      # is used. Configure it to e.g. offload the periodic operator metric counts to a secondary node without
+      # affecting user-facing search/count requests:
+      # custom-metrics-persistence {
+      #   readPreference = "secondaryPreferred"
+      #   readPreference = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_METRICS_READ_PREFERENCE}
+      #   readConcern = "default"
+      #   readConcern = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_METRICS_READ_CONCERN}
+      # }
+
+      # Optional dedicated MongoDB read settings for the "custom-aggregation-metrics" ($group) queries.
+      # When this block is absent (the default), the general "query.persistence" read preference / read concern
+      # is used. Configure it independently from the count based "custom-metrics-persistence" above, e.g. to run
+      # the (potentially expensive) aggregation scans on a secondary node:
+      # custom-aggregation-metrics-persistence {
+      #   readPreference = "secondaryPreferred"
+      #   readPreference = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_AGGREGATION_METRICS_READ_PREFERENCE}
+      #   readConcern = "default"
+      #   readConcern = ${?THINGS_SEARCH_OPERATOR_METRICS_CUSTOM_AGGREGATION_METRICS_READ_CONCERN}
+      # }
     }
   }
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfigTest.java
@@ -23,52 +23,116 @@ import com.typesafe.config.ConfigFactory;
 
 /**
  * Unit test for {@link DefaultOperatorMetricsConfig}, focusing on the optional per-metric-type persistence
- * (read preference / read concern) configuration.
+ * (read preference / read concern) configuration and its inheritance from the general {@code query.persistence}
+ * configuration.
  */
 public final class DefaultOperatorMetricsConfigTest {
 
-    @Test
-    public void persistenceConfigsAreEmptyWhenNotConfigured() {
-        final Config config = ConfigFactory.parseString(
+    /**
+     * Stands in for a deployment which configured non-default read settings for user-facing searches.
+     */
+    private static final SearchPersistenceConfig QUERY_PERSISTENCE_CONFIG =
+            DefaultSearchPersistenceConfig.of(ConfigFactory.parseString(
+                    "persistence {\n" +
+                            "  readPreference = \"secondaryPreferred\"\n" +
+                            "  readConcern = \"majority\"\n" +
+                            "}"));
+
+    private static Config operatorMetricsConfig(final String... persistenceBlocks) {
+        return ConfigFactory.parseString(
                 "operator-metrics {\n" +
                         "  enabled = true\n" +
                         "  scrape-interval = 15m\n" +
                         "  custom-metrics {}\n" +
                         "  custom-aggregation-metrics {}\n" +
+                        String.join("\n", persistenceBlocks) + "\n" +
                         "}");
+    }
 
-        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(config);
+    @Test
+    public void persistenceConfigsAreEmptyWhenNotConfigured() {
+        final DefaultOperatorMetricsConfig underTest =
+                DefaultOperatorMetricsConfig.of(operatorMetricsConfig(), QUERY_PERSISTENCE_CONFIG);
 
+        // an absent block means: use the general query.persistence config, which the callers resolve themselves:
         assertThat(underTest.getCustomMetricsPersistenceConfig()).isEmpty();
         assertThat(underTest.getCustomAggregationMetricsPersistenceConfig()).isEmpty();
     }
 
     @Test
-    public void persistenceConfigsAreParsedWhenConfigured() {
-        final Config config = ConfigFactory.parseString(
-                "operator-metrics {\n" +
-                        "  enabled = true\n" +
-                        "  scrape-interval = 15m\n" +
-                        "  custom-metrics {}\n" +
-                        "  custom-aggregation-metrics {}\n" +
-                        "  custom-metrics-persistence {\n" +
+    public void fullyConfiguredBlockOverridesQueryPersistence() {
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(operatorMetricsConfig(
+                "  custom-metrics-persistence {\n" +
                         "    readPreference = \"nearest\"\n" +
                         "    readConcern = \"local\"\n" +
-                        "  }\n" +
-                        "  custom-aggregation-metrics-persistence {\n" +
-                        "    readPreference = \"secondaryPreferred\"\n" +
-                        "  }\n" +
-                        "}");
-
-        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(config);
+                        "  }"), QUERY_PERSISTENCE_CONFIG);
 
         assertThat(underTest.getCustomMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig -> {
             assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.NEAREST);
             assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.LOCAL);
         });
-        assertThat(underTest.getCustomAggregationMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig ->
-                // read concern falls back to its own default when not explicitly configured:
-                assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.SECONDARY_PREFERRED));
+    }
+
+    @Test
+    public void blockConfiguringOnlyReadPreferenceInheritsReadConcernFromQueryPersistence() {
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(operatorMetricsConfig(
+                "  custom-metrics-persistence {\n" +
+                        "    readPreference = \"nearest\"\n" +
+                        "  }"), QUERY_PERSISTENCE_CONFIG);
+
+        assertThat(underTest.getCustomMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig -> {
+            assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.NEAREST);
+            assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.MAJORITY);
+        });
+    }
+
+    @Test
+    public void blockConfiguringOnlyReadConcernInheritsReadPreferenceFromQueryPersistence() {
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(operatorMetricsConfig(
+                "  custom-aggregation-metrics-persistence {\n" +
+                        "    readConcern = \"local\"\n" +
+                        "  }"), QUERY_PERSISTENCE_CONFIG);
+
+        assertThat(underTest.getCustomAggregationMetricsPersistenceConfig())
+                .hasValueSatisfying(persistenceConfig -> {
+                    assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.LOCAL);
+                    // must not silently fall back to the "primaryPreferred" default of SearchPersistenceConfig:
+                    assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.SECONDARY_PREFERRED);
+                });
+    }
+
+    @Test
+    public void bothBlocksAreResolvedIndependently() {
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(operatorMetricsConfig(
+                "  custom-metrics-persistence {\n" +
+                        "    readConcern = \"local\"\n" +
+                        "  }",
+                "  custom-aggregation-metrics-persistence {\n" +
+                        "    readPreference = \"secondary\"\n" +
+                        "  }"), QUERY_PERSISTENCE_CONFIG);
+
+        assertThat(underTest.getCustomMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig -> {
+            assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.SECONDARY_PREFERRED);
+            assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.LOCAL);
+        });
+        assertThat(underTest.getCustomAggregationMetricsPersistenceConfig())
+                .hasValueSatisfying(persistenceConfig -> {
+                    assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.SECONDARY);
+                    assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.MAJORITY);
+                });
+    }
+
+    @Test
+    public void configuredBlockFallsBackToDefaultsWhenNoQueryPersistenceConfigIsKnown() {
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(operatorMetricsConfig(
+                "  custom-metrics-persistence {\n" +
+                        "    readConcern = \"local\"\n" +
+                        "  }"));
+
+        assertThat(underTest.getCustomMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig -> {
+            assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.PRIMARY_PREFERRED);
+            assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.LOCAL);
+        });
     }
 
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultOperatorMetricsConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit test for {@link DefaultOperatorMetricsConfig}, focusing on the optional per-metric-type persistence
+ * (read preference / read concern) configuration.
+ */
+public final class DefaultOperatorMetricsConfigTest {
+
+    @Test
+    public void persistenceConfigsAreEmptyWhenNotConfigured() {
+        final Config config = ConfigFactory.parseString(
+                "operator-metrics {\n" +
+                        "  enabled = true\n" +
+                        "  scrape-interval = 15m\n" +
+                        "  custom-metrics {}\n" +
+                        "  custom-aggregation-metrics {}\n" +
+                        "}");
+
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(config);
+
+        assertThat(underTest.getCustomMetricsPersistenceConfig()).isEmpty();
+        assertThat(underTest.getCustomAggregationMetricsPersistenceConfig()).isEmpty();
+    }
+
+    @Test
+    public void persistenceConfigsAreParsedWhenConfigured() {
+        final Config config = ConfigFactory.parseString(
+                "operator-metrics {\n" +
+                        "  enabled = true\n" +
+                        "  scrape-interval = 15m\n" +
+                        "  custom-metrics {}\n" +
+                        "  custom-aggregation-metrics {}\n" +
+                        "  custom-metrics-persistence {\n" +
+                        "    readPreference = \"nearest\"\n" +
+                        "    readConcern = \"local\"\n" +
+                        "  }\n" +
+                        "  custom-aggregation-metrics-persistence {\n" +
+                        "    readPreference = \"secondaryPreferred\"\n" +
+                        "  }\n" +
+                        "}");
+
+        final DefaultOperatorMetricsConfig underTest = DefaultOperatorMetricsConfig.of(config);
+
+        assertThat(underTest.getCustomMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig -> {
+            assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.NEAREST);
+            assertThat(persistenceConfig.readConcern()).isEqualTo(ReadConcern.LOCAL);
+        });
+        assertThat(underTest.getCustomAggregationMetricsPersistenceConfig()).hasValueSatisfying(persistenceConfig ->
+                // read concern falls back to its own default when not explicitly configured:
+                assertThat(persistenceConfig.readPreference()).isEqualTo(ReadPreference.SECONDARY_PREFERRED));
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSearchPersistenceConfigTest.java
@@ -86,4 +86,18 @@ public final class DefaultSearchPersistenceConfigTest {
                 .isNotNull();
     }
 
+    @Test
+    public void ofScopedConfigReadsSettingsWithoutTheNestedPersistencePath() {
+        final SearchPersistenceConfig underTest = DefaultSearchPersistenceConfig.ofScopedConfig(
+                ConfigFactory.parseString("readPreference = \"nearest\""));
+
+        softly.assertThat(underTest.readPreference())
+                .as(SearchPersistenceConfig.ConfigValue.READ_PREFERENCE.getConfigPath())
+                .isEqualTo(ReadPreference.NEAREST);
+
+        softly.assertThat(underTest.readConcern())
+                .as("read concern falls back to its default")
+                .isEqualTo(ReadConcern.DEFAULT);
+    }
+
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorTest.java
@@ -122,7 +122,7 @@ public final class SearchActorTest {
 
             final var serviceRequestsDone = SearchActor.Control.SERVICE_REQUESTS_DONE;
             final var countActor = use(p -> p.count(any(), any(), any()));
-            final var sudoCountActor = use(p -> p.sudoCount(any(), any(), any()));
+            final var sudoCountActor = use(p -> p.sudoCount(any(), any(), any(), any(), any()));
             final var queryActor = use(p -> p.findAll(any(), any(), any(), any()));
             final var shutdownProbe = TestProbe.apply(actorSystemResource.getActorSystem());
 


### PR DESCRIPTION
## What

Makes the MongoDB `readPreference` and `readConcern` used by the operator metrics configurable **independently** from the read settings used for normal searches (`query.persistence`).

Two optional, independent config blocks are added under `ditto.things-search.operator-metrics`:

| Block                                     | Applies to                                     |
|-------------------------------------------|------------------------------------------------|
| `custom-metrics-persistence`              | the count based `custom-metrics`               |
| `custom-aggregation-metrics-persistence`  | the `$group` `custom-aggregation-metrics`      |

Both are optional and **fall back to the general `query.persistence` config when absent**, so existing deployments are unaffected.

## Why

Closes #2163.

The operator (aggregation) metrics so far inherited the global search `readConcern` / `readPreference`. That is unwanted when searches are configured with an expensive `readConcern` (e.g. `linearizable`) for strong consistency: the periodic operator metric queries would rather run cheaply (`readConcern = local`) and/or be offloaded to a secondary node (`readPreference = secondaryPreferred`) without weakening the user-facing search guarantees.

## How

- **Aggregation metrics** use a dedicated `MongoThingsAggregationPersistence`, so it resolves the dedicated `custom-aggregation-metrics-persistence` config (else `query.persistence`) and binds read preference + read concern at construction.
- **Count metrics** share the `SearchActor` → `MongoThingsSearchPersistence.count/sudoCount` path with user-facing counts, so `SudoCountThings` gains optional `readPreference` / `readConcern` fields (`@since 3.9.7`, mirroring the existing `indexHint`), applied per-query via `collection.withReadPreference(...).withReadConcern(...)`. Unknown values are logged and ignored, not fatal.
- Helm: both blocks are rendered only when configured; chart version bumped to `4.6.1`.

## Out of scope

The `hint` sub-point from #2163 is intentionally left out: aggregation metrics already support a per-metric `index-hint`, so hints can already differ per metric. Decoupling the shared namespace-hint fallback can be tracked separately.
