### PR TITLE
Optimize trace-context propagation to avoid per-hop full header-map copy

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/MappingTimer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/MappingTimer.java
@@ -192,7 +192,7 @@ final class MappingTimer {
     }
 
     private Adaptable propagateContextToAdaptable(final Adaptable adaptable) {
-        return adaptable.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(adaptable.getDittoHeaders())));
+        return adaptable.setDittoHeaders(startedSpan.propagateContext(adaptable.getDittoHeaders()));
     }
 
     /**
@@ -209,7 +209,7 @@ final class MappingTimer {
     }
 
     private Signal<?> propagateContextToSignalDittoHeaders(final Signal<?> signal) {
-        return signal.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(signal.getDittoHeaders())));
+        return signal.setDittoHeaders(startedSpan.propagateContext(signal.getDittoHeaders()));
     }
 
     /**

--- a/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/ThingsAggregatorProxyActor.java
+++ b/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/ThingsAggregatorProxyActor.java
@@ -147,7 +147,7 @@ public final class ThingsAggregatorProxyActor extends AbstractActorWithShutdownB
                 .tag("size", Integer.toString(thingIds.size()))
                 .start();
         final Command<?> tracedCommand = command.setDittoHeaders(
-                DittoHeaders.of(startedSpan.propagateContext(dittoHeaders))
+                startedSpan.propagateContext(dittoHeaders)
         );
 
         final DistributedPubSubMediator.Publish pubSubMsg =

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/websocket/WebSocketRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/websocket/WebSocketRoute.java
@@ -544,7 +544,7 @@ public final class WebSocketRoute implements WebSocketRouteBuilder {
         final var startedSpan = startTraceSpan(failure, SpanOperationName.of("gw.streaming.in.error"));
         startedSpan.tagAsFailed(failure);
         try {
-            return failure.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(failure.getDittoHeaders())));
+            return failure.setDittoHeaders(startedSpan.propagateContext(failure.getDittoHeaders()));
         } finally {
             startedSpan.finish();
         }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/TimeMeasuringAuthenticationProvider.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/TimeMeasuringAuthenticationProvider.java
@@ -63,7 +63,7 @@ public abstract class TimeMeasuringAuthenticationProvider<R extends Authenticati
         final StartedTimer timer = TraceUtils.newAuthFilterTimer(authorizationContextType, requestContext.getRequest())
                 .start();
         final StartedSpan startedSpan = DittoTracing.newStartedSpanByTimer(dittoHeaders, timer);
-        final DittoHeaders propagatedHeaders = DittoHeaders.of(startedSpan.propagateContext(dittoHeaders));
+        final DittoHeaders propagatedHeaders = startedSpan.propagateContext(dittoHeaders);
 
         CompletableFuture<R> resultFuture;
         try {

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/SessionedJsonifiable.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/SessionedJsonifiable.java
@@ -105,7 +105,7 @@ public interface SessionedJsonifiable {
                 .tag(SpanTagKey.SIGNAL_TYPE.getTagForValue(signal.getType()))
                 .start();
         return new SessionedSignal(
-                signal.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(signal.getDittoHeaders()))),
+                signal.setDittoHeaders(startedSpan.propagateContext(signal.getDittoHeaders())),
                 sessionHeaders,
                 session,
                 startedSpan
@@ -126,7 +126,7 @@ public interface SessionedJsonifiable {
         final var startedSpan = preparedSpan.start();
         startedSpan.tagAsFailed(error);
         return new SessionedResponseErrorOrAck(
-                error.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(error.getDittoHeaders()))),
+                error.setDittoHeaders(startedSpan.propagateContext(error.getDittoHeaders())),
                 error.getDittoHeaders(),
                 startedSpan
         );
@@ -146,7 +146,7 @@ public interface SessionedJsonifiable {
                 .tag(SpanTagKey.SIGNAL_TYPE.getTagForValue(response.getType()))
                 .start();
         return new SessionedResponseErrorOrAck(
-                response.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(response.getDittoHeaders()))),
+                response.setDittoHeaders(startedSpan.propagateContext(response.getDittoHeaders())),
                 response.getDittoHeaders(),
                 startedSpan
         );

--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/ByRoundTripSignalEnrichmentFacade.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/ByRoundTripSignalEnrichmentFacade.java
@@ -91,9 +91,9 @@ public final class ByRoundTripSignalEnrichmentFacade implements SignalEnrichment
         }
 
         final RetrieveThing command =
-                RetrieveThing.getBuilder(thingId, DittoHeaders.of(startedSpan.propagateContext(
+                RetrieveThing.getBuilder(thingId, startedSpan.propagateContext(
                                 dittoHeadersBuilder.build()
-                        )))
+                        ))
                         .withSelectedFields(jsonFieldSelector)
                         .build();
 

--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
@@ -149,7 +149,7 @@ public class DittoCachingSignalEnrichmentFacade implements CachingSignalEnrichme
                 )
                 .start();
 
-        return DittoHeaders.of(startedSpan.propagateContext(dittoHeadersBuilder.build()));
+        return startedSpan.propagateContext(dittoHeadersBuilder.build());
     }
 
     @Override

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceActor.java
@@ -744,7 +744,7 @@ public abstract class AbstractPersistenceActor<
                 .start();
 
         final var tracedCommand =
-                command.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(command.getDittoHeaders())));
+                command.setDittoHeaders(startedSpan.propagateContext(command.getDittoHeaders()));
 
         accessCounter++;
         Result<E> result;
@@ -907,7 +907,7 @@ public abstract class AbstractPersistenceActor<
                 .start();
 
         persist(
-                event.setDittoHeaders(DittoHeaders.of(persistOperationSpan.propagateContext(event.getDittoHeaders()))),
+                event.setDittoHeaders(persistOperationSpan.propagateContext(event.getDittoHeaders())),
                 persistedEvent -> handlePersistedEvent(handler, l, persistOperationSpan, persistedEvent)
         );
     }

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
@@ -974,7 +974,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
                     .correlationId(signal.getDittoHeaders().getCorrelationId().orElse(null))
                     .start();
             final var tracedSignal = signal.setDittoHeaders(
-                    DittoHeaders.of(startedSpan.propagateContext(signal.getDittoHeaders()))
+                    startedSpan.propagateContext(signal.getDittoHeaders())
             );
             final StartedTimer rootTimer = createTimer(tracedSignal);
             final StartedTimer enforcementTimer = rootTimer.startNewSegment(ENFORCEMENT_TIMER_SEGMENT_ENFORCEMENT);

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/KamonHttpContextPropagation.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/KamonHttpContextPropagation.java
@@ -103,6 +103,27 @@ public final class KamonHttpContextPropagation {
         return result;
     }
 
+    /**
+     * Computes only the trace-context entries that the specified context contributes, without copying any
+     * pre-existing headers. The returned map contains solely the propagated context entries (the W3C trace-context
+     * headers such as {@code traceparent}/{@code tracestate}); it never contains the headers the context was read
+     * from.
+     * <p>
+     * This is the allocation-lean counterpart to {@link #propagateContextToHeaders(Context, Map)}: callers that only
+     * need the propagated delta (e.g. to apply it onto already-validated, trusted headers) avoid copying the whole
+     * incoming header map on every traced hop.
+     *
+     * @param context the context to be propagated.
+     * @return a small, modifiable Map containing only the propagated context entries.
+     * @throws NullPointerException if {@code context} is {@code null}.
+     */
+    public Map<String, String> propagateContextToNewMap(final Context context) {
+        checkNotNull(context, "context");
+        final Map<String, String> propagatedContext = new HashMap<>(4);
+        propagation.write(context, propagatedContext::put);
+        return propagatedContext;
+    }
+
     private static <K, V> Map<K, V> getMutableCopyOfMap(final Map<K, V> map) {
         return new HashMap<>(map);
     }

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedKamonSpan.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/StartedKamonSpan.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.Tag;
 import org.eclipse.ditto.internal.utils.metrics.instruments.tag.TagSet;
 
@@ -118,6 +120,25 @@ final class StartedKamonSpan implements StartedSpan {
         return httpContextPropagation.propagateContextToHeaders(wrapSpanInContext(
                 headers.get(DittoHeaderDefinition.W3C_TRACESTATE.getKey())
         ), headers);
+    }
+
+    @Override
+    public DittoHeaders propagateContext(final DittoHeaders dittoHeaders) {
+        checkNotNull(dittoHeaders, "dittoHeaders");
+        // Propagate onto a fresh, small map (delta) instead of copying all headers: the writer only ever emits the
+        // W3C trace-context headers. The read side is identical to propagateContext(Map) - the same incoming
+        // tracestate is read into the same context and this span's traceparent is written identically.
+        final Map<String, String> propagatedContext = httpContextPropagation.propagateContextToNewMap(wrapSpanInContext(
+                dittoHeaders.get(DittoHeaderDefinition.W3C_TRACESTATE.getKey())
+        ));
+        if (propagatedContext.isEmpty()) {
+            return dittoHeaders;
+        }
+        // Apply only the propagated trace-context entries onto the already-validated, trusted headers. The changed
+        // entries are the W3C trace-context headers, which carry a no-op value validator, so no header is re-parsed.
+        final DittoHeadersBuilder<?, ?> builder = dittoHeaders.toBuilder();
+        propagatedContext.forEach(builder::putHeader);
+        return builder.build();
     }
 
     private Context wrapSpanInContext(@Nullable final String traceStateHeader) {

--- a/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/KamonHttpContextPropagationTest.java
+++ b/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/KamonHttpContextPropagationTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -192,6 +193,44 @@ public final class KamonHttpContextPropagationTest {
                 .hasSize(contextTags.size() + 1)
                 .containsAllEntriesOf(contextTags)
                 .containsEntry("upstream.name", "kamon-application");
+    }
+
+    @Test
+    public void propagateContextToNewMapWithNullContextThrowsNullPointerException() {
+        final var underTest = KamonHttpContextPropagation.getInstanceForDefaultHttpChannel();
+
+        assertThatNullPointerException()
+                .isThrownBy(() -> underTest.propagateContextToNewMap(null))
+                .withMessage("The context must not be null!")
+                .withNoCause();
+    }
+
+    @Test
+    public void propagateContextToNewMapReturnsOnlyPropagatedContextWithoutCopyingInputHeaders() {
+        final Map<String, Object> contextTags = Map.of(
+                "foo", "bar",
+                "bar", "baz",
+                "marco", "polo"
+        );
+        final var span = Kamon.spanBuilder(testName.getMethodName()).traceId(traceId).start();
+        final var dittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
+        final var underTest = KamonHttpContextPropagation.getInstanceForDefaultHttpChannel();
+        final var context = Context.of(Span.Key(), span, TagSet.from(contextTags));
+
+        final var propagatedContext = underTest.propagateContextToNewMap(context);
+
+        // the delta holds only the propagated context entries and none of the pre-existing headers ...
+        softly.assertThat(propagatedContext)
+                .as("delta map")
+                .containsOnlyKeys(TRACEPARENT_KEY, DittoHeaderDefinition.W3C_TRACESTATE.getKey(), CONTEXT_TAGS_KEY)
+                .doesNotContainKey(DittoHeaderDefinition.CORRELATION_ID.getKey());
+
+        // ... and applying it onto the incoming headers reproduces propagateContextToHeaders exactly.
+        final Map<String, String> reconstructed = new HashMap<>(dittoHeaders);
+        reconstructed.putAll(propagatedContext);
+        softly.assertThat(reconstructed)
+                .as("headers reconstructed from delta")
+                .isEqualTo(underTest.propagateContextToHeaders(context, dittoHeaders));
     }
 
     private static Map<String, Object> parseContextTagsHeaderValueToMap(final String contextTagsHeaderValue) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractEnforcerActor.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractEnforcerActor.java
@@ -166,7 +166,7 @@ public abstract class AbstractEnforcerActor<I extends EntityId, S extends Signal
                 .start();
         final Optional<String> formerTraceParent = dittoHeaders.getTraceParent();
         final var tracedSignal = signal.setDittoHeaders(
-                DittoHeaders.of(startedSpan.propagateContext(dittoHeaders))
+                startedSpan.propagateContext(dittoHeaders)
         );
         final ActorRef self = getSelf();
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingEnforcerActor.java
@@ -224,7 +224,7 @@ public final class ThingEnforcerActor
                     )
                     .start();
             return performWotBasedMessageCommandValidation(messageCommand.setDittoHeaders(
-                    DittoHeaders.of(startedSpan.propagateContext(messageCommand.getDittoHeaders()))
+                    startedSpan.propagateContext(messageCommand.getDittoHeaders())
                             .toBuilder()
                             .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(),
                                     entityId.getEntityType() + ":" + entityId)
@@ -318,7 +318,7 @@ public final class ThingEnforcerActor
                 .start();
         return performWotBasedMessageCommandResponseValidation(
                 messageCommandResponse.setDittoHeaders(
-                        DittoHeaders.of(startedSpan.propagateContext(messageCommandResponse.getDittoHeaders()))
+                        startedSpan.propagateContext(messageCommandResponse.getDittoHeaders())
                                 .toBuilder()
                                 .putHeader(DittoHeaderDefinition.ENTITY_ID.getKey(),
                                         entityId.getEntityType() + ":" + entityId)
@@ -631,11 +631,11 @@ public final class ThingEnforcerActor
                     .start();
             final SudoRetrieveThing sudoRetrieveThing = SudoRetrieveThing.of(entityId,
                     JsonFieldSelector.newInstance("policyId"),
-                    DittoHeaders.of(startedSpan.propagateContext(DittoHeaders.newBuilder()
+                    startedSpan.propagateContext(DittoHeaders.newBuilder()
                             .correlationId("sudoRetrieveThingFromThingEnforcerActor-" + UUID.randomUUID())
                             .putHeader(DittoHeaderDefinition.DITTO_RETRIEVE_DELETED.getKey(),
                                     Boolean.TRUE.toString())
-                            .build()))
+                            .build())
             );
             return Patterns.ask(getContext().getParent(), sudoRetrieveThing, determineAskTimeoutForLocalActorInvocations())
                     .thenApply(

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingModifyCommandStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/AbstractThingModifyCommandStrategy.java
@@ -85,7 +85,7 @@ abstract class AbstractThingModifyCommandStrategy<C extends ThingModifyCommand<C
         final var startedSpan = DittoTracing.newStartedSpanByTimer(command.getDittoHeaders(), startedTimer)
                 .tag(SpanTagKey.SIGNAL_TYPE.getTagForValue(command.getType()));
         final var tracedCommand =
-                command.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(command.getDittoHeaders())));
+                command.setDittoHeaders(startedSpan.propagateContext(command.getDittoHeaders()));
         return performWotValidation(tracedCommand, previousThing, previewThing)
                 .whenCompleteAsync((result, throwable) -> {
                     if (throwable instanceof CompletionException completionException) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActor.java
@@ -313,7 +313,7 @@ public final class SearchActor extends AbstractActorWithShutdownBehaviorAndReque
 
         @SuppressWarnings("unchecked")
         final T tracedCountCommand = (T) countCommand.setDittoHeaders(
-                DittoHeaders.of(spanWithTimer.startedSpan.propagateContext(dittoHeaders)));
+                spanWithTimer.startedSpan.propagateContext(dittoHeaders));
 
         final Source<CountThingsResponse, ?> countThingsResponseSource =
                 createQuerySource(queryParseFunction, tracedCountCommand)
@@ -365,7 +365,7 @@ public final class SearchActor extends AbstractActorWithShutdownBehaviorAndReque
         final var namespaces = streamThings.getNamespaces().orElse(null);
 
         final StreamThings tracedStreamThings = streamThings.setDittoHeaders(
-                DittoHeaders.of(spanWithTimer.startedSpan.propagateContext(streamThings.getDittoHeaders())));
+                spanWithTimer.startedSpan.propagateContext(streamThings.getDittoHeaders()));
 
         final Source<SourceRef<String>, NotUsed> thingIdSourceRefSource =
                 ThingsSearchCursor.extractCursor(tracedStreamThings).flatMapConcat(cursor -> {
@@ -484,7 +484,7 @@ public final class SearchActor extends AbstractActorWithShutdownBehaviorAndReque
         final var namespaces = queryThings.getNamespaces().orElse(null);
 
         final QueryThings tracedQueryThings = queryThings.setDittoHeaders(
-                DittoHeaders.of(spanWithTimer.startedSpan.propagateContext(queryThings.getDittoHeaders())));
+                spanWithTimer.startedSpan.propagateContext(queryThings.getDittoHeaders()));
 
         final Source<QueryThingsResponse, ?> queryThingsResponseSource =
                 ThingsSearchCursor.extractCursor(tracedQueryThings, getSystem()).flatMapConcat(cursor -> {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -547,8 +547,8 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
                 .start();
         final StartedSpan startedSpan = DittoTracing.newStartedSpanByTimer(thingEvent.getDittoHeaders(), startedTimer);
         ConsistencyLag.startS1InUpdater(startedTimer);
-        final var tracedEvent = thingEvent.setDittoHeaders(DittoHeaders.of(startedSpan.propagateContext(
-                thingEvent.getDittoHeaders())));
+        final var tracedEvent = thingEvent.setDittoHeaders(startedSpan.propagateContext(
+                thingEvent.getDittoHeaders()));
         final var metadata = exportMetadataWithSender(shouldAcknowledge, tracedEvent, getAckRecipient(
                 tracedEvent.getDittoHeaders()), startedTimer, data)
                 .withUpdateReason(UpdateReason.THING_UPDATE);


### PR DESCRIPTION
## What

Optimizes trace-context propagation so a traced hop no longer copies the entire `DittoHeaders` map, and no longer re-validates headers when re-wrapping them.

## Why

A production JFR profile (10 min, profile config) showed trace-context propagation as a significant CPU cost across the fleet — roughly 7% of overall microservice JVM-user CPU, and the single biggest hotspot in the gateway (~14.5%, driven by per-signal propagation on the streaming/WebSocket paths). It is paid on effectively every signal and cluster hop because tracing runs with an always-on sampler.

Two O(N) costs were incurred per hop:

1. `KamonHttpContextPropagation.propagateContextToHeaders(...)` did `new HashMap<>(headers)` — copying **all** incoming headers — only to add the ~2 W3C trace-context entries (`traceparent`/`tracestate`) that the propagation actually writes.
2. The vast majority of call sites then re-wrapped the result via `DittoHeaders.of(startedSpan.propagateContext(x.getDittoHeaders()))`, sending the map back through the **validating** `DittoHeaders` constructor and re-parsing every JSON-typed header value on each hop.

## What changed

- **`KamonHttpContextPropagation`**: added `propagateContextToNewMap(Context)`, which writes only the propagated trace-context entries into a fresh small map instead of copying all incoming headers.
- **`StartedKamonSpan`**: overrides `propagateContext(DittoHeaders)` to apply only the propagated delta onto the already-validated (trusted) headers via `toBuilder()`. This removes both the full-map copy and the full `entrySet()` re-scan that the `StartedSpan` interface default performed to recover the delta.
- **Call-site migration** (20 sites): replaced `DittoHeaders.of(startedSpan.propagateContext(x.getDittoHeaders()))` with the trusted `startedSpan.propagateContext(x.getDittoHeaders())` overload, dropping the redundant re-validating re-wrap. Raw-`Map<String,String>` callers (Kafka/AMQP/RabbitMQ consumers, `RequestTracingDirective`, `ExternalMessage` header paths) were intentionally left on the `Map` overload.

## Behavior & compatibility

- Behavior is unchanged: the same context is propagated and the same trace-context headers are written. The pre-existing `StartedKamonSpanTest` equivalence test asserts the trusted overload is byte-for-byte equal to `DittoHeaders.of(propagateContext((Map) ...))`, and new unit tests cover the delta path.
- API change is additive only (a new public method on `KamonHttpContextPropagation` plus an override); no existing signature changed.
- `internal/utils/tracing` test suite passes (114 tests).
