### PR TITLE
Memoize authorization verdicts in TreeBasedPolicyEnforcer

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.6.0  # chart version is effectively set by release-job
+version: 4.6.1  # chart version is effectively set by release-job
 appVersion: 3.9.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.6.1  # chart version is effectively set by release-job
+version: 4.6.2  # chart version is effectively set by release-job
 appVersion: 3.9.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -318,6 +318,8 @@ spec:
               value: "{{ .Values.connectivity.config.policiesEnforcer.cache.namespaceFilteredMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_READ_CLASSIFICATION_MAX_SIZE
               value: "{{ .Values.connectivity.config.policiesEnforcer.cache.readClassificationMaxSize }}"
+            - name: DITTO_POLICIES_ENFORCER_AUTHORIZATION_MEMO_MAX_SIZE
+              value: "{{ .Values.connectivity.config.policiesEnforcer.cache.authorizationMemoMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_WRITE
               value: "{{ .Values.connectivity.config.policiesEnforcer.cache.expireAfterWrite }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_ACCESS

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -322,6 +322,8 @@ spec:
               value: "{{ .Values.policies.config.policiesEnforcer.cache.namespaceFilteredMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_READ_CLASSIFICATION_MAX_SIZE
               value: "{{ .Values.policies.config.policiesEnforcer.cache.readClassificationMaxSize }}"
+            - name: DITTO_POLICIES_ENFORCER_AUTHORIZATION_MEMO_MAX_SIZE
+              value: "{{ .Values.policies.config.policiesEnforcer.cache.authorizationMemoMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_WRITE
               value: "{{ .Values.policies.config.policiesEnforcer.cache.expireAfterWrite }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_ACCESS

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -320,6 +320,8 @@ spec:
               value: "{{ .Values.things.config.policiesEnforcer.cache.namespaceFilteredMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_READ_CLASSIFICATION_MAX_SIZE
               value: "{{ .Values.things.config.policiesEnforcer.cache.readClassificationMaxSize }}"
+            - name: DITTO_POLICIES_ENFORCER_AUTHORIZATION_MEMO_MAX_SIZE
+              value: "{{ .Values.things.config.policiesEnforcer.cache.authorizationMemoMaxSize }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_WRITE
               value: "{{ .Values.things.config.policiesEnforcer.cache.expireAfterWrite }}"
             - name: DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_ACCESS

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -866,6 +866,11 @@ policies:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration
@@ -1241,6 +1246,11 @@ things:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration
@@ -1970,6 +1980,11 @@ connectivity:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -866,6 +866,11 @@ policies:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration
@@ -1241,6 +1246,11 @@ things:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration
@@ -1956,6 +1966,11 @@ connectivity:
         # avoiding re-walking the policy tree per emitted ThingEvent for per-event read-authorization and
         # read-grant collection; caps distinct resource paths cached per policy
         readClassificationMaxSize: 1000
+        # authorizationMemoMaxSize bounds the per-enforcer memo of authorization verdicts (permission checks and
+        # subject collection), replacing the full policy-tree walk per authorization with a hash lookup; caps
+        # distinct (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable it
+        # entirely - then no maps are allocated and every check walks the tree directly.
+        authorizationMemoMaxSize: 10000
         # expireAfterWrite the maximum duration of inconsistency after losing a cache invalidation
         expireAfterWrite: 4h
         # expireAfterAccess prolonged on each cache access by that duration

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -95,6 +95,13 @@ public final class PolicyEnforcer {
     // the things-service hot path calls classifyReadSubjects on the namespace-filtered child, so its cache
     // must be bounded too (unlike the child's namespace cache, which stays empty).
     private final long readClassificationCacheMaxSize;
+    // The operator-configured authorization-verdict memo bound (reference.conf
+    // 'authorization-memo-cache-max-size'), kept for the same reason as readClassificationCacheMaxSize above:
+    // forNamespace children must inherit it. The things-service hot path enforces against the
+    // namespace-filtered child, so a configured bound - 0 in particular, the documented "disable the memo"
+    // escape hatch - has to reach the child's enforcer, not just this instance's. null means no configuration
+    // was supplied (transient of/embed instances), in which case PolicyEnforcers' own default applies.
+    @Nullable private final Integer authorizationMemoMaxSize;
 
     /**
      * Creates an instance with an <em>unbounded</em> namespace-filtered-enforcer cache. Used for transient
@@ -104,7 +111,7 @@ public final class PolicyEnforcer {
      * instances need a bound.
      */
     private PolicyEnforcer(@Nullable final Policy policy, final Enforcer enforcer) {
-        this(policy, enforcer, Caffeine.newBuilder().build(), 0L);
+        this(policy, enforcer, Caffeine.newBuilder().build(), 0L, null);
     }
 
     /**
@@ -114,19 +121,22 @@ public final class PolicyEnforcer {
      * (operator-configurable) cap distinct namespaces / resource paths per policy.
      */
     private PolicyEnforcer(@Nullable final Policy policy, final Enforcer enforcer,
-            final long namespaceEnforcerCacheMaxSize, final long readClassificationCacheMaxSize) {
+            final long namespaceEnforcerCacheMaxSize, final long readClassificationCacheMaxSize,
+            @Nullable final Integer authorizationMemoMaxSize) {
         this(policy, enforcer,
                 Caffeine.newBuilder().maximumSize(namespaceEnforcerCacheMaxSize).build(),
-                readClassificationCacheMaxSize);
+                readClassificationCacheMaxSize, authorizationMemoMaxSize);
     }
 
     private PolicyEnforcer(@Nullable final Policy policy, final Enforcer enforcer,
             final Cache<String, PolicyEnforcer> namespaceEnforcerCache,
-            final long readClassificationCacheMaxSize) {
+            final long readClassificationCacheMaxSize,
+            @Nullable final Integer authorizationMemoMaxSize) {
         this.policy = policy;
         this.enforcer = enforcer;
         this.namespaceEnforcerCache = namespaceEnforcerCache;
         this.readClassificationCacheMaxSize = readClassificationCacheMaxSize;
+        this.authorizationMemoMaxSize = authorizationMemoMaxSize;
         // <= 0 means unbounded (of/embed/transient instances); provider-cached and forNamespace children
         // inherit the operator-configured bound.
         this.readClassificationCache = readClassificationCacheMaxSize > 0
@@ -260,7 +270,7 @@ public final class PolicyEnforcer {
         return resolveImportsAndNamespacePolicies(policy, policyResolver, namespacePoliciesConfig)
                 .thenApply(finalPolicy ->
                         new PolicyEnforcer(finalPolicy, PolicyEnforcers.defaultEvaluator(finalPolicy),
-                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
+                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize, null));
     }
 
     /**
@@ -275,7 +285,9 @@ public final class PolicyEnforcer {
      * @param namespaceEnforcerCacheMaxSize the maximum size of the per-instance namespace-filtered-enforcer cache.
      * @param readClassificationCacheMaxSize the maximum size of the per-instance read-classification cache.
      * @param authorizationMemoMaxSize the per-memo upper bound for the enforcer's authorization-verdict memos;
-     * a value {@code <= 0} disables those memos (no maps allocated).
+     * a value {@code <= 0} disables those memos (no maps allocated), and values above {@link Integer#MAX_VALUE}
+     * saturate rather than wrap. The bound is retained on the returned instance so the namespace-filtered
+     * children handed out by {@link #forNamespace(String)} inherit it.
      * @return a completion stage with the fully resolved PolicyEnforcer.
      * @since 3.9.7
      */
@@ -287,11 +299,40 @@ public final class PolicyEnforcer {
             final long readClassificationCacheMaxSize,
             final long authorizationMemoMaxSize) {
 
+        final int memoMaxSize = clampAuthorizationMemoMaxSize(authorizationMemoMaxSize);
         return resolveImportsAndNamespacePolicies(policy, policyResolver, namespacePoliciesConfig)
                 .thenApply(finalPolicy ->
                         new PolicyEnforcer(finalPolicy,
-                                PolicyEnforcers.defaultEvaluator(finalPolicy, (int) authorizationMemoMaxSize),
-                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
+                                PolicyEnforcers.defaultEvaluator(finalPolicy, memoMaxSize),
+                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize, memoMaxSize));
+    }
+
+    /**
+     * Package-private test hook: the operator-configured authorization-verdict memo bound this instance was
+     * built with, or {@code null} if none was configured (in which case {@code PolicyEnforcers}' own default
+     * applies). Namespace-filtered children must inherit it.
+     *
+     * @return the configured bound, or {@code null}.
+     */
+    @Nullable
+    Integer getAuthorizationMemoMaxSize() {
+        return authorizationMemoMaxSize;
+    }
+
+    /**
+     * Narrows a configured authorization-memo bound to the {@code int} the enforcer factory takes. A plain cast
+     * would wrap for values above {@link Integer#MAX_VALUE} and could land on a negative number, silently
+     * <em>disabling</em> the memo when the operator asked for a very large one; saturate instead. Values
+     * {@code <= 0} keep their meaning: memoization off.
+     *
+     * @param authorizationMemoMaxSize the configured bound.
+     * @return the bound clamped to {@code [0, Integer.MAX_VALUE]}.
+     */
+    private static int clampAuthorizationMemoMaxSize(final long authorizationMemoMaxSize) {
+        if (authorizationMemoMaxSize <= 0L) {
+            return 0;
+        }
+        return (int) Math.min(authorizationMemoMaxSize, Integer.MAX_VALUE);
     }
 
     private static CompletionStage<Policy> resolveImportsAndNamespacePolicies(
@@ -400,7 +441,7 @@ public final class PolicyEnforcer {
     public static PolicyEnforcer of(final Policy policy, final long namespaceEnforcerCacheMaxSize,
             final long readClassificationCacheMaxSize) {
         return new PolicyEnforcer(policy, PolicyEnforcers.defaultEvaluator(policy),
-                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize);
+                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize, null);
     }
 
     /**
@@ -585,12 +626,18 @@ public final class PolicyEnforcer {
         if (!anyFiltered) {
             return this;
         }
-        final Enforcer filteredEnforcer = PolicyEnforcers.defaultEvaluator(filteredEntries);
         // The filtered child is the instance the things-service hot path enforces against, so it must inherit
-        // the parent's read-classification bound (classifyReadSubjects is called on it per signal). Its own
-        // namespace cache stays empty (forNamespace is never called on the child), so leave that unbounded.
+        // both of the parent's operator-configured bounds: the read-classification one (classifyReadSubjects is
+        // called on it per signal) and the authorization-verdict memo one (every permission check runs against
+        // this enforcer). Without the latter, 'authorization-memo-cache-max-size' - including 0 to disable -
+        // would not reach the very instance an operator is most likely tuning.
+        final Enforcer filteredEnforcer = authorizationMemoMaxSize == null
+                ? PolicyEnforcers.defaultEvaluator(filteredEntries)
+                : PolicyEnforcers.defaultEvaluator(filteredEntries, authorizationMemoMaxSize);
+        // The child's own namespace cache stays empty (forNamespace is never called on the child), so leave
+        // that unbounded.
         return new PolicyEnforcer(policy, filteredEnforcer, Caffeine.newBuilder().build(),
-                readClassificationCacheMaxSize);
+                readClassificationCacheMaxSize, authorizationMemoMaxSize);
     }
 
 }

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -263,6 +263,37 @@ public final class PolicyEnforcer {
                                 namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
     }
 
+    /**
+     * Same as {@link #withResolvedImportsAndNamespacePolicies(Policy, Function, NamespacePoliciesConfig, long, long)}
+     * but additionally bounds the bare enforcer's authorization-verdict memos (see
+     * {@link org.eclipse.ditto.policies.model.enforcers.tree.TreeBasedPolicyEnforcer}). Used by the enforcer cache
+     * loader with the operator-configured value.
+     *
+     * @param policy the policy to build an enforcer for.
+     * @param policyResolver resolves imported policies by ID.
+     * @param namespacePoliciesConfig the static namespace policies configuration.
+     * @param namespaceEnforcerCacheMaxSize the maximum size of the per-instance namespace-filtered-enforcer cache.
+     * @param readClassificationCacheMaxSize the maximum size of the per-instance read-classification cache.
+     * @param authorizationMemoMaxSize the per-memo upper bound for the enforcer's authorization-verdict memos;
+     * a value {@code <= 0} disables those memos (no maps allocated).
+     * @return a completion stage with the fully resolved PolicyEnforcer.
+     * @since 3.9.7
+     */
+    public static CompletionStage<PolicyEnforcer> withResolvedImportsAndNamespacePolicies(
+            final Policy policy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
+            final long namespaceEnforcerCacheMaxSize,
+            final long readClassificationCacheMaxSize,
+            final long authorizationMemoMaxSize) {
+
+        return resolveImportsAndNamespacePolicies(policy, policyResolver, namespacePoliciesConfig)
+                .thenApply(finalPolicy ->
+                        new PolicyEnforcer(finalPolicy,
+                                PolicyEnforcers.defaultEvaluator(finalPolicy, (int) authorizationMemoMaxSize),
+                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
+    }
+
     private static CompletionStage<Policy> resolveImportsAndNamespacePolicies(
             final Policy policy,
             final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -243,6 +243,37 @@ public final class PolicyEnforcer {
                                 namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
     }
 
+    /**
+     * Same as {@link #withResolvedImportsAndNamespacePolicies(Policy, Function, NamespacePoliciesConfig, long, long)}
+     * but additionally bounds the bare enforcer's authorization-verdict memos (see
+     * {@link org.eclipse.ditto.policies.model.enforcers.tree.TreeBasedPolicyEnforcer}). Used by the enforcer cache
+     * loader with the operator-configured value.
+     *
+     * @param policy the policy to build an enforcer for.
+     * @param policyResolver resolves imported policies by ID.
+     * @param namespacePoliciesConfig the static namespace policies configuration.
+     * @param namespaceEnforcerCacheMaxSize the maximum size of the per-instance namespace-filtered-enforcer cache.
+     * @param readClassificationCacheMaxSize the maximum size of the per-instance read-classification cache.
+     * @param authorizationMemoMaxSize the per-memo upper bound for the enforcer's authorization-verdict memos;
+     * a value {@code <= 0} disables those memos (no maps allocated).
+     * @return a completion stage with the fully resolved PolicyEnforcer.
+     * @since 3.9.7
+     */
+    public static CompletionStage<PolicyEnforcer> withResolvedImportsAndNamespacePolicies(
+            final Policy policy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
+            final long namespaceEnforcerCacheMaxSize,
+            final long readClassificationCacheMaxSize,
+            final long authorizationMemoMaxSize) {
+
+        return resolveImportsAndNamespacePolicies(policy, policyResolver, namespacePoliciesConfig)
+                .thenApply(finalPolicy ->
+                        new PolicyEnforcer(finalPolicy,
+                                PolicyEnforcers.defaultEvaluator(finalPolicy, (int) authorizationMemoMaxSize),
+                                namespaceEnforcerCacheMaxSize, readClassificationCacheMaxSize));
+    }
+
     private static CompletionStage<Policy> resolveImportsAndNamespacePolicies(
             final Policy policy,
             final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
@@ -44,11 +44,16 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
      * read-classification cache size; default provided by reference.conf. */
     private static final String READ_CLASSIFICATION_MAX_SIZE_KEY = "read-classification-cache-max-size";
 
+    /** Config key (relative to {@link PolicyEnforcerProvider#ENFORCER_CACHE_CONFIG_KEY}) for the per-enforcer
+     * authorization-verdict memo size; {@code 0} disables the memo (no maps allocated). Default in reference.conf. */
+    private static final String AUTHORIZATION_MEMO_MAX_SIZE_KEY = "authorization-memo-cache-max-size";
+
     private final PolicyCacheLoader delegate;
     private final Executor enforcementCacheExecutor;
     private final NamespacePoliciesConfig namespacePoliciesConfig;
     private final long namespaceFilteredEnforcerCacheMaxSize;
     private final long readClassificationCacheMaxSize;
+    private final long authorizationMemoMaxSize;
     @Nullable
     private final CompletableFuture<Cache<PolicyId, Entry<PolicyEnforcer>>> cacheFuture;
 
@@ -91,6 +96,9 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
         this.readClassificationCacheMaxSize = actorSystem.settings().config()
                 .getLong(PolicyEnforcerProvider.ENFORCER_CACHE_CONFIG_KEY + "." +
                         READ_CLASSIFICATION_MAX_SIZE_KEY);
+        this.authorizationMemoMaxSize = actorSystem.settings().config()
+                .getLong(PolicyEnforcerProvider.ENFORCER_CACHE_CONFIG_KEY + "." +
+                        AUTHORIZATION_MEMO_MAX_SIZE_KEY);
         this.cacheFuture = cacheFuture;
     }
 
@@ -123,7 +131,7 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
             final var policy = entry.getValueOrThrow();
             return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(policy, policyResolver,
                             namespacePoliciesConfig, namespaceFilteredEnforcerCacheMaxSize,
-                            readClassificationCacheMaxSize)
+                            readClassificationCacheMaxSize, authorizationMemoMaxSize)
                     .thenApply(enforcer -> Entry.of(revision, enforcer));
         } else {
             return CompletableFuture.completedFuture(Entry.nonexistent());

--- a/policies/enforcement/src/main/resources/reference.conf
+++ b/policies/enforcement/src/main/resources/reference.conf
@@ -59,6 +59,13 @@ ditto.policies-enforcer-cache {
   read-classification-cache-max-size = 1000
   read-classification-cache-max-size = ${?DITTO_POLICIES_ENFORCER_READ_CLASSIFICATION_MAX_SIZE}
 
+  # per-enforcer memo of authorization verdicts (hasUnrestricted/hasPartialPermissions, getSubjectsWith*Permission):
+  # a hash lookup replaces the full policy-tree walk per authorization; bounds the number of distinct
+  # (resource, caller-subjects, permission) tuples cached per policy. Set to 0 to disable entirely - then no
+  # ConcurrentHashMaps are allocated and every check walks the tree directly.
+  authorization-memo-cache-max-size = 10000
+  authorization-memo-cache-max-size = ${?DITTO_POLICIES_ENFORCER_AUTHORIZATION_MEMO_MAX_SIZE}
+
   # maximum duration of inconsistency after losing a cache invalidation
   expire-after-write = 1h
   expire-after-write = ${?DITTO_POLICIES_ENFORCER_CACHE_EXPIRE_AFTER_WRITE}

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerTest.java
@@ -13,16 +13,21 @@
 package org.eclipse.ditto.policies.enforcement;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.Permission;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.AllowedAddition;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.ImportableType;
@@ -38,6 +43,7 @@ import org.eclipse.ditto.policies.model.enforcers.SubjectClassification;
 import org.junit.Test;
 
 public final class PolicyEnforcerTest {
+
 
     @Test
     public void forNamespaceFiltersRestrictedEntriesButKeepsGlobalEntries() {
@@ -288,6 +294,74 @@ public final class PolicyEnforcerTest {
                 .setGrantedPermissionsFor("bob", ResourceKey.newInstance("thing", "/attributes/x"), Permission.READ)
                 .setSubjectFor("carol", Subject.newInstance(SubjectId.newInstance("user:carol")))
                 .setGrantedPermissionsFor("carol", ResourceKey.newInstance("thing", "/attributes/y"), Permission.READ)
+                .build();
+    }
+
+    @Test
+    public void forNamespaceChildInheritsConfiguredAuthorizationMemoBound() {
+        final PolicyEnforcer parent = providerStyleEnforcer(10_000L);
+
+        // The namespace-filtered child - the instance the things-service hot path enforces against - is built
+        // by a separate defaultEvaluator call, so it has to be handed the configured bound explicitly.
+        assertThat(parent.getAuthorizationMemoMaxSize()).isEqualTo(10_000);
+        assertThat(namespaceFilteredChild(parent).getAuthorizationMemoMaxSize()).isEqualTo(10_000);
+    }
+
+    @Test
+    public void forNamespaceChildInheritsDisabledAuthorizationMemo() {
+        final PolicyEnforcer parent = providerStyleEnforcer(0L);
+
+        // 0 is the documented escape hatch for disabling the memo entirely; it must reach the child too,
+        // otherwise an operator disabling it still gets a memoizing enforcer on the hot path.
+        assertThat(namespaceFilteredChild(parent).getAuthorizationMemoMaxSize()).isEqualTo(0);
+    }
+
+    @Test
+    public void configuredAuthorizationMemoBoundAboveIntMaxSaturatesInsteadOfWrapping() {
+        final PolicyEnforcer parent = providerStyleEnforcer(3_000_000_000L);
+
+        // A plain (int) cast wraps this to a negative number, which reads as "disabled" - the opposite of what
+        // an operator configuring a very large bound asked for. Saturate at Integer.MAX_VALUE instead.
+        assertThat(parent.getAuthorizationMemoMaxSize()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(namespaceFilteredChild(parent).getAuthorizationMemoMaxSize()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void transientEnforcerHasNoConfiguredAuthorizationMemoBound() {
+        // of/embed instances carry no operator configuration, so children fall back to the library default.
+        assertThat(PolicyEnforcer.of(namespaceScopedPolicy()).getAuthorizationMemoMaxSize()).isNull();
+    }
+
+    /**
+     * Builds a {@code PolicyEnforcer} the way {@code PolicyEnforcerCacheLoader} does, i.e. through the
+     * config-carrying factory, with the given authorization-memo bound.
+     */
+    private static PolicyEnforcer providerStyleEnforcer(final long authorizationMemoMaxSize) {
+        final NamespacePoliciesConfig emptyNamespacePolicies = mock(NamespacePoliciesConfig.class);
+        when(emptyNamespacePolicies.isEmpty()).thenReturn(true);
+
+        return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(namespaceScopedPolicy(),
+                        policyId -> CompletableFuture.completedFuture(Optional.empty()), emptyNamespacePolicies,
+                        100L, 100L, authorizationMemoMaxSize)
+                .toCompletableFuture()
+                .join();
+    }
+
+    /**
+     * Returns the namespace-filtered child for a namespace that excludes the scoped entry, so
+     * {@code forNamespace} genuinely builds a new child enforcer rather than returning the parent.
+     */
+    private static PolicyEnforcer namespaceFilteredChild(final PolicyEnforcer parent) {
+        final PolicyEnforcer child = parent.forNamespace("org.example");
+        assertThat(child).isNotSameAs(parent);
+        return child;
+    }
+
+    private static Policy namespaceScopedPolicy() {
+        return PoliciesModelFactory.newPolicyBuilder(PolicyId.of("test:policy"))
+                .set(newScopedEntry("restricted", "google:tenant-user",
+                        Arrays.asList("com.acme", "com.acme.*")))
+                .set(newScopedEntry("global", "google:global-user", Collections.emptyList()))
                 .build();
     }
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/PolicyEnforcers.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/PolicyEnforcers.java
@@ -41,18 +41,41 @@ public final class PolicyEnforcers {
      * @throws NullPointerException if {@code policyEntries} is {@code null}.
      */
     public static Enforcer defaultEvaluator(final Iterable<PolicyEntry> policyEntries) {
-        // Skip entries that cannot contribute to access decisions: entries without subjects
-        // can't authorize anyone, entries without resources can't grant or revoke anything.
-        // This filtering is applied after all import and references resolution is complete.
-        final Iterable<PolicyEntry> effectiveEntries = StreamSupport
-                .stream(policyEntries.spliterator(), false)
-                .filter(entry -> !entry.getSubjects().isEmpty() && !entry.getResources().isEmpty())
-                .collect(Collectors.toList());
+        final Iterable<PolicyEntry> effectiveEntries = effectiveEntries(policyEntries);
         if (FeatureToggle.isPolicyEnforcementUseThroughputOptimizedEvaluatorEnabled()) {
             return throughputOptimizedEvaluator(effectiveEntries);
         } else {
             return memoryOptimizedEvaluator(effectiveEntries);
         }
+    }
+
+    /**
+     * Same as {@link #defaultEvaluator(Iterable)} but bounds the memory-optimized enforcer's authorization-verdict
+     * memos at {@code maxMemoSize} entries (a value {@code <= 0} disables memoization; see
+     * {@link TreeBasedPolicyEnforcer#createInstance(Iterable, int)}). The bound only applies to the memory-optimized
+     * evaluator; the throughput-optimized (trie-based) evaluator does not memoize and ignores it.
+     *
+     * @param policyEntries the Policy entries to initialize the evaluator with.
+     * @param maxMemoSize the per-memo best-effort upper bound; {@code <= 0} disables memoization.
+     * @return the initialized general purpose Enforcer.
+     * @throws NullPointerException if {@code policyEntries} is {@code null}.
+     */
+    public static Enforcer defaultEvaluator(final Iterable<PolicyEntry> policyEntries, final int maxMemoSize) {
+        final Iterable<PolicyEntry> effectiveEntries = effectiveEntries(policyEntries);
+        if (FeatureToggle.isPolicyEnforcementUseThroughputOptimizedEvaluatorEnabled()) {
+            return throughputOptimizedEvaluator(effectiveEntries);
+        } else {
+            return memoryOptimizedEvaluator(effectiveEntries, maxMemoSize);
+        }
+    }
+
+    // Skip entries that cannot contribute to access decisions: entries without subjects can't authorize anyone,
+    // entries without resources can't grant or revoke anything. Applied after import/reference resolution.
+    private static Iterable<PolicyEntry> effectiveEntries(final Iterable<PolicyEntry> policyEntries) {
+        return StreamSupport
+                .stream(policyEntries.spliterator(), false)
+                .filter(entry -> !entry.getSubjects().isEmpty() && !entry.getResources().isEmpty())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -79,6 +102,19 @@ public final class PolicyEnforcers {
      */
     public static Enforcer memoryOptimizedEvaluator(final Iterable<PolicyEntry> policyEntries) {
         return TreeBasedPolicyEnforcer.createInstance(policyEntries);
+    }
+
+    /**
+     * Same as {@link #memoryOptimizedEvaluator(Iterable)} but bounds each authorization-verdict memo at
+     * {@code maxMemoSize} entries; a value {@code <= 0} disables memoization entirely (no maps are allocated).
+     *
+     * @param policyEntries the Policy entries to initialize the evaluator with.
+     * @param maxMemoSize the per-memo best-effort upper bound; {@code <= 0} disables memoization.
+     * @return the initialized memory optimized Enforcer.
+     * @throws NullPointerException if {@code policyEntries} is {@code null}.
+     */
+    public static Enforcer memoryOptimizedEvaluator(final Iterable<PolicyEntry> policyEntries, final int maxMemoSize) {
+        return TreeBasedPolicyEnforcer.createInstance(policyEntries, maxMemoSize);
     }
 
 }

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -60,10 +62,31 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     private static final JsonPointer ROOT_RESOURCE_POINTER = JsonFactory.newPointer(ROOT_RESOURCE);
 
     /**
+     * Best-effort upper bound on each authorization-verdict memo (see below). Keeps memory bounded should a
+     * caller ever produce pathologically many distinct keys (e.g. huge numbers of distinct resources or
+     * subject-sets). Above the cap, verdicts are computed without being cached — correctness is unaffected,
+     * only the fast path is skipped. Mirrors the bounded best-effort caches used by {@code PolicyEnforcer}.
+     */
+    private static final int MAX_MEMO_SIZE = 10_000;
+
+    /**
      * Maps subject ID to {@link org.eclipse.ditto.policies.model.enforcers.tree.SubjectNode} whose children are {@link org.eclipse.ditto.policies.model.enforcers.tree.ResourceNode} for which the subject is granted
      * or revoked access. The child-set of each {@link org.eclipse.ditto.policies.model.enforcers.tree.SubjectNode} is effectively a map from resources to permissions.
      */
     private final Map<String, PolicyTreeNode> tree;
+
+    // Per-instance memos of authorization verdicts. TreeBasedPolicyEnforcer is effectively immutable after
+    // createInstance: the tree is built once during construction and only ever read (never mutated) by
+    // visitTree afterwards. A policy change produces a brand-new instance via
+    // PolicyEnforcers.defaultEvaluator, so - exactly like the classifySubjects(resource, READ) memo on
+    // PolicyEnforcer - each memo's lifetime equals the instance's and needs no explicit invalidation.
+    // Every memoized method walks the whole policy tree per call (visitTree), which production JFR showed to
+    // be a dominant things-service CPU hotspot; the (resource, subjects, permissions) tuples recur heavily,
+    // so a hash lookup replaces the repeated full-tree traversal. ConcurrentHashMap because enforcer
+    // instances are shared and hit from multiple threads concurrently.
+    private final Map<PermissionCheckKey, Boolean> permissionCheckMemo = new ConcurrentHashMap<>();
+    private final Map<SubjectsKey, EffectedSubjects> effectedSubjectsMemo = new ConcurrentHashMap<>();
+    private final Map<SubjectsKey, Set<AuthorizationSubject>> partialSubjectsMemo = new ConcurrentHashMap<>();
 
     private TreeBasedPolicyEnforcer(final Map<String, PolicyTreeNode> tree) {
         this.tree = tree;
@@ -160,9 +183,13 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
             final AuthorizationContext authorizationContext, final Permissions permissions) {
 
         checkPermissions(permissions);
+        // resourcePointer/authSubjectIds are computed eagerly (cheap, and preserving the original
+        // null-argument check ordering); only the expensive visitTree call is deferred into the memo supplier.
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
-        final Collection<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
-        return visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+        final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
+        return memoize(permissionCheckMemo,
+                new PermissionCheckKey(resourceKey, authSubjectIds, permissions, false),
+                () -> visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));
     }
 
     private static void checkPermissions(final Permissions permissions) {
@@ -173,7 +200,7 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         return JsonFactory.newPointer(resourceKey.getResourceType()).append(resourceKey.getResourcePath());
     }
 
-    private static Collection<String> getAuthorizationSubjectIds(final AuthorizationContext authorizationContext) {
+    private static Set<String> getAuthorizationSubjectIds(final AuthorizationContext authorizationContext) {
         checkNotNull(authorizationContext, "Authorization Context");
 
         return authorizationContext.stream()
@@ -186,12 +213,33 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         return visitor.get();
     }
 
+    /**
+     * Returns the memoized value for {@code key}, computing and caching it (best-effort, up to
+     * {@link #MAX_MEMO_SIZE} entries) on a miss. All memoized suppliers return non-null values, so a
+     * {@code null} lookup reliably means "absent". Thread-safe: {@code memo} is a {@link ConcurrentHashMap}
+     * and the supplier only reads the immutable policy tree, never re-entering the memo.
+     */
+    private static <K, V> V memoize(final Map<K, V> memo, final K key, final Supplier<V> valueSupplier) {
+        final V cached = memo.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        final V computed = valueSupplier.get();
+        if (memo.size() < MAX_MEMO_SIZE) {
+            memo.putIfAbsent(key, computed);
+        }
+        return computed;
+    }
+
     @Override
     public EffectedSubjects getSubjectsWithPermission(final ResourceKey resourceKey, final Permissions permissions) {
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
-        return visitTree(new CollectEffectedSubjectsVisitor(resourcePointer, permissions));
+        // EffectedSubjects (DefaultEffectedSubjects) is @Immutable with unmodifiable internal sets, so the
+        // cached instance can be shared across callers directly.
+        return memoize(effectedSubjectsMemo, new SubjectsKey(resourceKey, permissions),
+                () -> visitTree(new CollectEffectedSubjectsVisitor(resourcePointer, permissions)));
     }
 
     private static void checkResourceKey(final ResourceKey resourceKey) {
@@ -205,7 +253,13 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
-        return visitTree(new CollectPartialGrantedSubjectsVisitor(resourcePointer, permissions));
+        // The visitor returns a fresh mutable HashSet; memoize an immutable snapshot but hand each caller a
+        // fresh mutable copy, preserving the original contract (callers receive a private, mutable set).
+        final Set<AuthorizationSubject> cached = memoize(partialSubjectsMemo,
+                new SubjectsKey(resourceKey, permissions),
+                () -> Collections.unmodifiableSet(new HashSet<>(
+                        visitTree(new CollectPartialGrantedSubjectsVisitor(resourcePointer, permissions)))));
+        return new HashSet<>(cached);
     }
 
     @Override
@@ -214,9 +268,11 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
 
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
-        final Collection<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
+        final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
-        return visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+        return memoize(permissionCheckMemo,
+                new PermissionCheckKey(resourceKey, authSubjectIds, permissions, true),
+                () -> visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));
     }
 
     @Override
@@ -737,6 +793,83 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         PointerAndPermission(final JsonPointer pointer, final String permission) {
             this.pointer = pointer;
             this.permission = permission;
+        }
+    }
+
+    /**
+     * Memo key for the two permission-check methods. {@code authorizationSubjectIds} is a {@link Set} so its
+     * equality is order-independent; {@code partial} distinguishes {@code hasUnrestrictedPermissions}
+     * ({@code false}) from {@code hasPartialPermissions} ({@code true}), letting both share a single map. All
+     * components are immutable value types with stable {@code equals}/{@code hashCode}. Plain class (not a
+     * record) because this module still targets Java 8.
+     */
+    @Immutable
+    private static final class PermissionCheckKey {
+
+        private final ResourceKey resourceKey;
+        private final Set<String> authorizationSubjectIds;
+        private final Permissions permissions;
+        private final boolean partial;
+
+        private PermissionCheckKey(final ResourceKey resourceKey, final Set<String> authorizationSubjectIds,
+                final Permissions permissions, final boolean partial) {
+            this.resourceKey = resourceKey;
+            this.authorizationSubjectIds = authorizationSubjectIds;
+            this.permissions = permissions;
+            this.partial = partial;
+        }
+
+        @Override
+        public boolean equals(@Nullable final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final PermissionCheckKey that = (PermissionCheckKey) o;
+            return partial == that.partial
+                    && Objects.equals(resourceKey, that.resourceKey)
+                    && Objects.equals(authorizationSubjectIds, that.authorizationSubjectIds)
+                    && Objects.equals(permissions, that.permissions);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(resourceKey, authorizationSubjectIds, permissions, partial);
+        }
+    }
+
+    /**
+     * Memo key for the subject-collection methods, which classify <em>all</em> subjects and therefore depend
+     * only on the resource and permissions. Plain class (not a record) because this module still targets Java 8.
+     */
+    @Immutable
+    private static final class SubjectsKey {
+
+        private final ResourceKey resourceKey;
+        private final Permissions permissions;
+
+        private SubjectsKey(final ResourceKey resourceKey, final Permissions permissions) {
+            this.resourceKey = resourceKey;
+            this.permissions = permissions;
+        }
+
+        @Override
+        public boolean equals(@Nullable final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final SubjectsKey that = (SubjectsKey) o;
+            return Objects.equals(resourceKey, that.resourceKey) && Objects.equals(permissions, that.permissions);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(resourceKey, permissions);
         }
     }
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
@@ -62,12 +62,15 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     private static final JsonPointer ROOT_RESOURCE_POINTER = JsonFactory.newPointer(ROOT_RESOURCE);
 
     /**
-     * Best-effort upper bound on each authorization-verdict memo (see below). Keeps memory bounded should a
-     * caller ever produce pathologically many distinct keys (e.g. huge numbers of distinct resources or
-     * subject-sets). Above the cap, verdicts are computed without being cached — correctness is unaffected,
-     * only the fast path is skipped. Mirrors the bounded best-effort caches used by {@code PolicyEnforcer}.
+     * Default best-effort upper bound on each authorization-verdict memo (see below), used by the no-size
+     * {@link #createInstance(Iterable)} factory. Operators can override it (see
+     * {@link #createInstance(Iterable, int)}); a value {@code <= 0} disables memoization entirely (no maps are
+     * allocated). Keeps memory bounded should a caller ever produce pathologically many distinct keys (e.g.
+     * huge numbers of distinct resources or subject-sets). Above the cap, verdicts are computed without being
+     * cached — correctness is unaffected, only the fast path is skipped. Mirrors the bounded best-effort caches
+     * used by {@code PolicyEnforcer}.
      */
-    private static final int MAX_MEMO_SIZE = 10_000;
+    private static final int DEFAULT_MAX_MEMO_SIZE = 10_000;
 
     /**
      * Maps subject ID to {@link org.eclipse.ditto.policies.model.enforcers.tree.SubjectNode} whose children are {@link org.eclipse.ditto.policies.model.enforcers.tree.ResourceNode} for which the subject is granted
@@ -84,22 +87,56 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     // be a dominant things-service CPU hotspot; the (resource, subjects, permissions) tuples recur heavily,
     // so a hash lookup replaces the repeated full-tree traversal. ConcurrentHashMap because enforcer
     // instances are shared and hit from multiple threads concurrently.
-    private final Map<PermissionCheckKey, Boolean> permissionCheckMemo = new ConcurrentHashMap<>();
-    private final Map<SubjectsKey, EffectedSubjects> effectedSubjectsMemo = new ConcurrentHashMap<>();
-    private final Map<SubjectsKey, Set<AuthorizationSubject>> partialSubjectsMemo = new ConcurrentHashMap<>();
+    // When memoization is disabled (maxMemoSize <= 0) these are left null and NOT allocated: every method then
+    // takes the direct visitTree path, behaving exactly like a non-memoizing enforcer with zero extra memory.
+    private final int maxMemoSize;
+    private final boolean memoizationEnabled;
+    @Nullable
+    private final Map<PermissionCheckKey, Boolean> permissionCheckMemo;
+    @Nullable
+    private final Map<SubjectsKey, EffectedSubjects> effectedSubjectsMemo;
+    @Nullable
+    private final Map<SubjectsKey, Set<AuthorizationSubject>> partialSubjectsMemo;
 
-    private TreeBasedPolicyEnforcer(final Map<String, PolicyTreeNode> tree) {
+    private TreeBasedPolicyEnforcer(final Map<String, PolicyTreeNode> tree, final int maxMemoSize) {
         this.tree = tree;
+        this.maxMemoSize = maxMemoSize;
+        this.memoizationEnabled = maxMemoSize > 0;
+        if (memoizationEnabled) {
+            permissionCheckMemo = new ConcurrentHashMap<>();
+            effectedSubjectsMemo = new ConcurrentHashMap<>();
+            partialSubjectsMemo = new ConcurrentHashMap<>();
+        } else {
+            permissionCheckMemo = null;
+            effectedSubjectsMemo = null;
+            partialSubjectsMemo = null;
+        }
     }
 
     /**
-     * Creates a new policy tree for execution of policy checks.
+     * Creates a new policy tree for execution of policy checks, using the {@link #DEFAULT_MAX_MEMO_SIZE default}
+     * authorization-verdict memo bound.
      *
      * @param policyEntries the policy entries to create a tree for
      * @return the generated {@code TreeBasedPolicyEnforcer}
      * @throws NullPointerException if {@code policyEntries} is {@code null}.
      */
     public static TreeBasedPolicyEnforcer createInstance(final Iterable<PolicyEntry> policyEntries) {
+        return createInstance(policyEntries, DEFAULT_MAX_MEMO_SIZE);
+    }
+
+    /**
+     * Creates a new policy tree for execution of policy checks, bounding each authorization-verdict memo at
+     * {@code maxMemoSize} entries.
+     *
+     * @param policyEntries the policy entries to create a tree for
+     * @param maxMemoSize the per-memo best-effort upper bound; a value {@code <= 0} disables memoization
+     * entirely (no {@link ConcurrentHashMap}s are allocated and every check takes the direct tree-walk path).
+     * @return the generated {@code TreeBasedPolicyEnforcer}
+     * @throws NullPointerException if {@code policyEntries} is {@code null}.
+     */
+    public static TreeBasedPolicyEnforcer createInstance(final Iterable<PolicyEntry> policyEntries,
+            final int maxMemoSize) {
         checkNotNull(policyEntries, "policyEntries");
         final Map<String, PolicyTreeNode> tree = new HashMap<>();
 
@@ -122,7 +159,7 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
             });
         });
 
-        return new TreeBasedPolicyEnforcer(tree);
+        return new TreeBasedPolicyEnforcer(tree, maxMemoSize);
     }
 
     private static void addResourceSubTree(final ResourceNode parentNode, final Resource resource,
@@ -187,6 +224,9 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         // null-argument check ordering); only the expensive visitTree call is deferred into the memo supplier.
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
         final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
+        if (!memoizationEnabled) {
+            return visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+        }
         return memoize(permissionCheckMemo,
                 new PermissionCheckKey(resourceKey, authSubjectIds, permissions, false),
                 () -> visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));
@@ -215,20 +255,36 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
 
     /**
      * Returns the memoized value for {@code key}, computing and caching it (best-effort, up to
-     * {@link #MAX_MEMO_SIZE} entries) on a miss. All memoized suppliers return non-null values, so a
+     * {@link #maxMemoSize} entries) on a miss. All memoized suppliers return non-null values, so a
      * {@code null} lookup reliably means "absent". Thread-safe: {@code memo} is a {@link ConcurrentHashMap}
-     * and the supplier only reads the immutable policy tree, never re-entering the memo.
+     * and the supplier only reads the immutable policy tree, never re-entering the memo. Defensively
+     * short-circuits to the supplier if {@code memo} is {@code null} (memoization disabled); callers already
+     * guard on {@link #memoizationEnabled}, so this is belt-and-suspenders.
      */
-    private static <K, V> V memoize(final Map<K, V> memo, final K key, final Supplier<V> valueSupplier) {
+    private <K, V> V memoize(@Nullable final Map<K, V> memo, final K key, final Supplier<V> valueSupplier) {
+        if (memo == null) {
+            return valueSupplier.get();
+        }
         final V cached = memo.get(key);
         if (cached != null) {
             return cached;
         }
         final V computed = valueSupplier.get();
-        if (memo.size() < MAX_MEMO_SIZE) {
+        if (memo.size() < maxMemoSize) {
             memo.putIfAbsent(key, computed);
         }
         return computed;
+    }
+
+    /**
+     * Package-private test hook: whether this instance memoizes authorization verdicts. {@code false} means the
+     * verdict memos were not allocated (constructed with {@code maxMemoSize <= 0}) and every check walks the
+     * tree directly.
+     *
+     * @return {@code true} if memoization is enabled.
+     */
+    boolean isMemoizationEnabled() {
+        return memoizationEnabled;
     }
 
     @Override
@@ -236,6 +292,9 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        if (!memoizationEnabled) {
+            return visitTree(new CollectEffectedSubjectsVisitor(resourcePointer, permissions));
+        }
         // EffectedSubjects (DefaultEffectedSubjects) is @Immutable with unmodifiable internal sets, so the
         // cached instance can be shared across callers directly.
         return memoize(effectedSubjectsMemo, new SubjectsKey(resourceKey, permissions),
@@ -253,6 +312,9 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        if (!memoizationEnabled) {
+            return visitTree(new CollectPartialGrantedSubjectsVisitor(resourcePointer, permissions));
+        }
         // The visitor returns a fresh mutable HashSet; memoize an immutable snapshot but hand each caller a
         // fresh mutable copy, preserving the original contract (callers receive a private, mutable set).
         final Set<AuthorizationSubject> cached = memoize(partialSubjectsMemo,
@@ -270,6 +332,9 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         checkPermissions(permissions);
         final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        if (!memoizationEnabled) {
+            return visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+        }
         return memoize(permissionCheckMemo,
                 new PermissionCheckKey(resourceKey, authSubjectIds, permissions, true),
                 () -> visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
@@ -220,16 +220,24 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
             final AuthorizationContext authorizationContext, final Permissions permissions) {
 
         checkPermissions(permissions);
-        // resourcePointer/authSubjectIds are computed eagerly (cheap, and preserving the original
-        // null-argument check ordering); only the expensive visitTree call is deferred into the memo supplier.
-        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
-        final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
+        // Checked eagerly so a null context still fails with the documented message rather than a bare NPE
+        // from the memo-key construction below.
+        checkNotNull(authorizationContext, "Authorization Context");
+        // ImmutableAuthorizationContext memoizes this list, so obtaining it is a field read rather than a
+        // stream-and-collect; it doubles as the memo key.
+        final List<String> authorizationSubjectIds = authorizationContext.getAuthorizationSubjectIds();
         if (!memoizationEnabled) {
-            return visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+            return visitTree(new CheckUnrestrictedPermissionsVisitor(createAbsoluteResourcePointer(resourceKey),
+                    toSubjectIdSet(authorizationSubjectIds), permissions));
         }
+        // The resource pointer and the subject-ID Set are built inside the supplier, so they are paid only on a
+        // miss: neither is part of the key, and on a hit they were what the memo was meant to skip. The Set is
+        // still required on the miss path - CheckPermissionsVisitor probes it with contains() once per subject
+        // node, so handing the visitor the List would make the walk O(policy subjects x caller subjects).
         return memoize(permissionCheckMemo,
-                new PermissionCheckKey(resourceKey, authSubjectIds, permissions, false),
-                () -> visitTree(new CheckUnrestrictedPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));
+                new PermissionCheckKey(resourceKey, authorizationSubjectIds, permissions, false),
+                () -> visitTree(new CheckUnrestrictedPermissionsVisitor(createAbsoluteResourcePointer(resourceKey),
+                        toSubjectIdSet(authorizationSubjectIds), permissions)));
     }
 
     private static void checkPermissions(final Permissions permissions) {
@@ -243,9 +251,16 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     private static Set<String> getAuthorizationSubjectIds(final AuthorizationContext authorizationContext) {
         checkNotNull(authorizationContext, "Authorization Context");
 
-        return authorizationContext.stream()
-                .map(AuthorizationSubject::getId)
-                .collect(Collectors.toSet());
+        return toSubjectIdSet(authorizationContext.getAuthorizationSubjectIds());
+    }
+
+    /**
+     * Copies the authorization subject IDs into a {@link Set}. The permission-check visitors probe the IDs with
+     * {@link Set#contains(Object)} once per subject node of the policy tree, so the hash-based lookup is what
+     * keeps the tree walk linear in the number of policy subjects.
+     */
+    private static Set<String> toSubjectIdSet(final List<String> authorizationSubjectIds) {
+        return new HashSet<>(authorizationSubjectIds);
     }
 
     private <T> T visitTree(final Visitor<T> visitor) {
@@ -291,14 +306,16 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     public EffectedSubjects getSubjectsWithPermission(final ResourceKey resourceKey, final Permissions permissions) {
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
-        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
         if (!memoizationEnabled) {
-            return visitTree(new CollectEffectedSubjectsVisitor(resourcePointer, permissions));
+            return visitTree(new CollectEffectedSubjectsVisitor(createAbsoluteResourcePointer(resourceKey),
+                    permissions));
         }
         // EffectedSubjects (DefaultEffectedSubjects) is @Immutable with unmodifiable internal sets, so the
-        // cached instance can be shared across callers directly.
+        // cached instance can be shared across callers directly. The resource pointer is built inside the
+        // supplier: it is not part of the key and is unused on a hit.
         return memoize(effectedSubjectsMemo, new SubjectsKey(resourceKey, permissions),
-                () -> visitTree(new CollectEffectedSubjectsVisitor(resourcePointer, permissions)));
+                () -> visitTree(new CollectEffectedSubjectsVisitor(createAbsoluteResourcePointer(resourceKey),
+                        permissions)));
     }
 
     private static void checkResourceKey(final ResourceKey resourceKey) {
@@ -311,16 +328,18 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
 
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
-        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
         if (!memoizationEnabled) {
-            return visitTree(new CollectPartialGrantedSubjectsVisitor(resourcePointer, permissions));
+            return visitTree(new CollectPartialGrantedSubjectsVisitor(createAbsoluteResourcePointer(resourceKey),
+                    permissions));
         }
         // The visitor returns a fresh mutable HashSet; memoize an immutable snapshot but hand each caller a
-        // fresh mutable copy, preserving the original contract (callers receive a private, mutable set).
+        // fresh mutable copy, preserving the original contract (callers receive a private, mutable set). The
+        // resource pointer is built inside the supplier: not part of the key, unused on a hit.
         final Set<AuthorizationSubject> cached = memoize(partialSubjectsMemo,
                 new SubjectsKey(resourceKey, permissions),
-                () -> Collections.unmodifiableSet(new HashSet<>(
-                        visitTree(new CollectPartialGrantedSubjectsVisitor(resourcePointer, permissions)))));
+                () -> Collections.unmodifiableSet(new HashSet<>(visitTree(
+                        new CollectPartialGrantedSubjectsVisitor(createAbsoluteResourcePointer(resourceKey),
+                                permissions)))));
         return new HashSet<>(cached);
     }
 
@@ -330,14 +349,17 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
 
         checkResourceKey(resourceKey);
         checkPermissions(permissions);
-        final Set<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
-        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        checkNotNull(authorizationContext, "Authorization Context");
+        final List<String> authorizationSubjectIds = authorizationContext.getAuthorizationSubjectIds();
         if (!memoizationEnabled) {
-            return visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+            return visitTree(new CheckPartialPermissionsVisitor(createAbsoluteResourcePointer(resourceKey),
+                    toSubjectIdSet(authorizationSubjectIds), permissions));
         }
+        // Pointer and Set built inside the supplier - see hasUnrestrictedPermissions.
         return memoize(permissionCheckMemo,
-                new PermissionCheckKey(resourceKey, authSubjectIds, permissions, true),
-                () -> visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions)));
+                new PermissionCheckKey(resourceKey, authorizationSubjectIds, permissions, true),
+                () -> visitTree(new CheckPartialPermissionsVisitor(createAbsoluteResourcePointer(resourceKey),
+                        toSubjectIdSet(authorizationSubjectIds), permissions)));
     }
 
     @Override
@@ -862,21 +884,27 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     }
 
     /**
-     * Memo key for the two permission-check methods. {@code authorizationSubjectIds} is a {@link Set} so its
-     * equality is order-independent; {@code partial} distinguishes {@code hasUnrestrictedPermissions}
-     * ({@code false}) from {@code hasPartialPermissions} ({@code true}), letting both share a single map. All
-     * components are immutable value types with stable {@code equals}/{@code hashCode}. Plain class (not a
-     * record) because this module still targets Java 8.
+     * Memo key for the two permission-check methods. {@code authorizationSubjectIds} is the
+     * {@link AuthorizationContext}'s own memoized ID {@link List}, so building the key allocates nothing; note
+     * that list equality makes the key order-<em>dependent</em>, so two contexts holding the same subjects in a
+     * different order occupy separate entries. That only costs a duplicate entry - each entry's verdict is
+     * computed from its own subject IDs and is correct either way - and in practice the order is stable per
+     * caller. The list is the context's own unmodifiable, lazily-cached one, so the key stays a stable value
+     * even though it is not a private copy. {@code partial} distinguishes
+     * {@code hasUnrestrictedPermissions} ({@code false}) from
+     * {@code hasPartialPermissions} ({@code true}), letting both share a single map. All components are
+     * immutable value types with stable {@code equals}/{@code hashCode}. Plain class (not a record) because
+     * this module still targets Java 8.
      */
     @Immutable
     private static final class PermissionCheckKey {
 
         private final ResourceKey resourceKey;
-        private final Set<String> authorizationSubjectIds;
+        private final List<String> authorizationSubjectIds;
         private final Permissions permissions;
         private final boolean partial;
 
-        private PermissionCheckKey(final ResourceKey resourceKey, final Set<String> authorizationSubjectIds,
+        private PermissionCheckKey(final ResourceKey resourceKey, final List<String> authorizationSubjectIds,
                 final Permissions permissions, final boolean partial) {
             this.resourceKey = resourceKey;
             this.authorizationSubjectIds = authorizationSubjectIds;

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.enforcers.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.enforcers.EffectedSubjects;
+import org.junit.Test;
+
+/**
+ * Verifies the per-instance authorization-verdict memoization on {@link TreeBasedPolicyEnforcer}: repeat
+ * calls return results identical to a fresh (cold) enforcer, and distinct
+ * (resource, subjects, permissions, check-kind) inputs are never conflated by the shared caches.
+ */
+public final class TreeBasedPolicyEnforcerMemoTest {
+
+    private static final Permissions READ = Permissions.newInstance("READ");
+    private static final Permissions WRITE = Permissions.newInstance("WRITE");
+    private static final ResourceKey THING_ROOT = ResourceKey.newInstance("thing", "/");
+
+    // fullSubject: unrestricted READ+WRITE on thing:/ .
+    private static final AuthorizationSubject FULL = AuthorizationSubject.newInstance("test:full");
+    // readOnlySubject: unrestricted READ only on thing:/ (used to prove READ vs WRITE keys don't conflate).
+    private static final AuthorizationSubject READ_ONLY = AuthorizationSubject.newInstance("test:read-only");
+    // partialSubject: granted READ on thing:/ but READ revoked on a child -> partial, not unrestricted.
+    private static final AuthorizationSubject PARTIAL = AuthorizationSubject.newInstance("test:partial");
+    // strangerSubject: has no grants at all.
+    private static final AuthorizationSubject STRANGER = AuthorizationSubject.newInstance("test:stranger");
+
+    private static Policy policy() {
+        return Policy.newBuilder(PolicyId.of("namespace", "id"))
+                .forLabel("full")
+                .setSubject(FULL.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permissions.newInstance("READ", "WRITE"))
+                .forLabel("read-only")
+                .setSubject(READ_ONLY.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("partial")
+                .setSubject(PARTIAL.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .setRevokedPermissions(PoliciesResourceType.thingResource("/features/secret"), READ)
+                .build();
+    }
+
+    private static AuthorizationContext ctx(final AuthorizationSubject subject) {
+        return AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED, subject);
+    }
+
+    @Test
+    public void hasUnrestrictedPermissionsIsConsistentAcrossRepeatedCalls() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        // first call populates the memo, second call hits it: both must equal the cold oracle.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ));
+    }
+
+    @Test
+    public void distinctSubjectSetsAreNotConflated() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        // Same resource + permission, different subject -> different verdict; the subject set is part of the key.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(STRANGER), READ)).isFalse();
+        // re-query the first one to ensure the second did not overwrite it.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+    }
+
+    @Test
+    public void distinctPermissionsAreNotConflated() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        // read-only subject: READ granted (unrestricted) but WRITE not -> permissions must be part of the key.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(READ_ONLY), READ)).isTrue();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(READ_ONLY), WRITE)).isFalse();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(READ_ONLY), READ)).isTrue();
+    }
+
+    @Test
+    public void unrestrictedAndPartialChecksShareNoKey() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        // The partial subject has a revoke below root: NOT unrestricted on root, but partially permitted.
+        // If the two checks shared a cache key (missing the 'partial' discriminator), one would poison the other.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(PARTIAL), READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, ctx(PARTIAL), READ))
+                .isFalse();
+        assertThat(underTest.hasPartialPermissions(THING_ROOT, ctx(PARTIAL), READ))
+                .isEqualTo(cold.hasPartialPermissions(THING_ROOT, ctx(PARTIAL), READ))
+                .isTrue();
+        // and again in the reverse order after both are cached:
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, ctx(PARTIAL), READ)).isFalse();
+        assertThat(underTest.hasPartialPermissions(THING_ROOT, ctx(PARTIAL), READ)).isTrue();
+    }
+
+    @Test
+    public void getSubjectsWithPermissionReturnsCachedImmutableInstanceEqualToColdEnforcer() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        final EffectedSubjects first = underTest.getSubjectsWithPermission(THING_ROOT, READ);
+        final EffectedSubjects second = underTest.getSubjectsWithPermission(THING_ROOT, READ);
+
+        assertThat(first).isEqualTo(cold.getSubjectsWithPermission(THING_ROOT, READ));
+        // EffectedSubjects is immutable, so a cache hit returns the very same instance (proves memoization is live).
+        assertThat(second).isSameAs(first);
+        assertThat(first.getGranted()).contains(FULL, READ_ONLY, PARTIAL);
+    }
+
+    @Test
+    public void getSubjectsWithPartialPermissionReturnsFreshMutableCopyOnEachCall() {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        final Set<AuthorizationSubject> first = underTest.getSubjectsWithPartialPermission(THING_ROOT, READ);
+        assertThat(first).isEqualTo(cold.getSubjectsWithPartialPermission(THING_ROOT, READ));
+
+        // The contract returns a private, mutable set; mutating it must NOT corrupt the memoized snapshot.
+        final Set<AuthorizationSubject> snapshotBeforeMutation = new HashSet<>(first);
+        first.clear();
+        first.add(AuthorizationSubject.newInstance("test:injected"));
+
+        final Set<AuthorizationSubject> second = underTest.getSubjectsWithPartialPermission(THING_ROOT, READ);
+        assertThat(second).isEqualTo(snapshotBeforeMutation);
+        assertThat(second).isNotSameAs(first);
+    }
+}

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.ditto.base.model.auth.AuthorizationContext;
@@ -196,6 +197,32 @@ public final class TreeBasedPolicyEnforcerMemoTest {
         // The genuinely-permitted subjects still resolve correctly after the cap was hit.
         assertThat(bounded.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
         assertThat(bounded.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+    }
+
+    @Test
+    public void differentSubjectOrderingsStayCorrectDespiteOrderDependentKeys() throws Exception {
+        final TreeBasedPolicyEnforcer underTest = TreeBasedPolicyEnforcer.createInstance(policy());
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        // The memo keys on the AuthorizationContext's own memoized ID *list*, so key equality is
+        // order-dependent and these two contexts occupy separate entries. Each entry's verdict is computed
+        // from its own IDs, so both orderings must still agree with a cold enforcer.
+        final AuthorizationContext strangerFirst = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, STRANGER, FULL);
+        final AuthorizationContext fullFirst = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, FULL, STRANGER);
+
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, strangerFirst, READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, strangerFirst, READ)).isTrue();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, fullFirst, READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, fullFirst, READ)).isTrue();
+
+        // Repeat calls are memo hits now; neither ordering may have been contaminated by the other.
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, strangerFirst, READ)).isTrue();
+        assertThat(underTest.hasUnrestrictedPermissions(THING_ROOT, fullFirst, READ)).isTrue();
+
+        // Documented consequence of the list-based key: one entry per ordering, not one shared entry.
+        assertThat((Map<?, ?>) memoField(underTest, "permissionCheckMemo")).hasSize(2);
     }
 
     private static Object memoField(final TreeBasedPolicyEnforcer enforcer, final String fieldName)

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcerMemoTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.policies.model.enforcers.tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -148,5 +149,59 @@ public final class TreeBasedPolicyEnforcerMemoTest {
         final Set<AuthorizationSubject> second = underTest.getSubjectsWithPartialPermission(THING_ROOT, READ);
         assertThat(second).isEqualTo(snapshotBeforeMutation);
         assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    public void memoizationDisabledAllocatesNoMemosAndStaysCorrect() throws Exception {
+        final TreeBasedPolicyEnforcer disabled = TreeBasedPolicyEnforcer.createInstance(policy(), 0);
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        assertThat(disabled.isMemoizationEnabled()).isFalse();
+        // No ConcurrentHashMaps are allocated when disabled: the three memo fields must be null.
+        assertThat(memoField(disabled, "permissionCheckMemo")).isNull();
+        assertThat(memoField(disabled, "effectedSubjectsMemo")).isNull();
+        assertThat(memoField(disabled, "partialSubjectsMemo")).isNull();
+
+        // All four memoized methods must still return results identical to a cold (memoizing) enforcer.
+        assertThat(disabled.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+        assertThat(disabled.hasUnrestrictedPermissions(THING_ROOT, ctx(STRANGER), READ))
+                .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, ctx(STRANGER), READ)).isFalse();
+        assertThat(disabled.hasPartialPermissions(THING_ROOT, ctx(PARTIAL), READ))
+                .isEqualTo(cold.hasPartialPermissions(THING_ROOT, ctx(PARTIAL), READ)).isTrue();
+        assertThat(disabled.getSubjectsWithPermission(THING_ROOT, READ))
+                .isEqualTo(cold.getSubjectsWithPermission(THING_ROOT, READ));
+        assertThat(disabled.getSubjectsWithPartialPermission(THING_ROOT, READ))
+                .isEqualTo(cold.getSubjectsWithPartialPermission(THING_ROOT, READ));
+
+        // With no cache, repeated getSubjectsWithPermission recomputes -> not the same instance (proves no memo).
+        assertThat(disabled.getSubjectsWithPermission(THING_ROOT, READ))
+                .isNotSameAs(disabled.getSubjectsWithPermission(THING_ROOT, READ));
+    }
+
+    @Test
+    public void smallCapStaysCorrectEvenWhenExceeded() {
+        final TreeBasedPolicyEnforcer bounded = TreeBasedPolicyEnforcer.createInstance(policy(), 4);
+        final TreeBasedPolicyEnforcer cold = TreeBasedPolicyEnforcer.createInstance(policy());
+
+        assertThat(bounded.isMemoizationEnabled()).isTrue();
+        // Push well past the cap of 4 with distinct subject-sets: above the cap, verdicts are computed uncached,
+        // but must remain correct for every distinct key (cached or not).
+        for (int i = 0; i < 20; i++) {
+            final AuthorizationContext stranger =
+                    ctx(AuthorizationSubject.newInstance("test:stranger-" + i));
+            assertThat(bounded.hasUnrestrictedPermissions(THING_ROOT, stranger, READ))
+                    .isEqualTo(cold.hasUnrestrictedPermissions(THING_ROOT, stranger, READ)).isFalse();
+        }
+        // The genuinely-permitted subjects still resolve correctly after the cap was hit.
+        assertThat(bounded.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+        assertThat(bounded.hasUnrestrictedPermissions(THING_ROOT, ctx(FULL), READ)).isTrue();
+    }
+
+    private static Object memoField(final TreeBasedPolicyEnforcer enforcer, final String fieldName)
+            throws Exception {
+        final Field field = TreeBasedPolicyEnforcer.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(enforcer);
     }
 }

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/AuthorizationVerdictMemoBenchmark.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/AuthorizationVerdictMemoBenchmark.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.enforcement;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.policies.api.Permission;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyBuilder;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.enforcers.tree.TreeBasedPolicyEnforcer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH micro-benchmark for the per-instance authorization-verdict memo on {@link TreeBasedPolicyEnforcer}: the
+ * policy-tree walk ({@code visitTree}) that every authorization check performed on each call, which production
+ * JFR showed as a dominant things-service CPU hotspot.
+ * <p>
+ * Run with {@code -prof gc} to also get the allocation figures — the memo-hit path is allocation-dominated, so
+ * {@code gc.alloc.rate.norm} (B/op) is the more stable signal of the two:
+ * <pre>
+ * mvn install -DskipTests -pl policies/model,policies/enforcement,things/service -am
+ * mvn exec:exec -pl things/service -Dexec.classpathScope=test -Dexec.executable=java \
+ *   -Dexec.args="-classpath %classpath \
+ *     org.eclipse.ditto.things.service.enforcement.AuthorizationVerdictMemoBenchmark -prof gc"
+ * </pre>
+ * Use {@code exec:exec} rather than {@code exec:java}: the latter runs in-process, so JMH's forked VM does not
+ * inherit the classpath and every benchmark fails with {@code ClassNotFoundException: ForkedMain}. The
+ * {@code install} step matters too — {@code -pl things/service} alone resolves {@code ditto-policies-model}
+ * from the local repository, which will not have this branch's enforcer.
+ * Benchmarks, all against the <em>same</em> policy and resource (the production shape: the same subjects
+ * repeatedly accessing the same resources):
+ * <ul>
+ *   <li>{@code hasUnrestrictedPermissionsMemoHit} / {@code getSubjectsWithPermissionMemoHit}: warm enforcer,
+ *       every call a memo hit — the fast path.</li>
+ *   <li>{@code hasUnrestrictedPermissionsNoMemo} / {@code getSubjectsWithPermissionNoMemo}: enforcer built with
+ *       {@code maxMemoSize = 0}, so no memo is allocated and every call walks the whole tree — the baseline the
+ *       memo removes.</li>
+ *   <li>{@code hasUnrestrictedPermissionsMemoMiss} vs {@code hasUnrestrictedPermissionsNoMemoSameKeys}: a tiny
+ *       cap plus a pool of distinct resource keys, so (almost) every call misses. Both cycle the <em>same</em>
+ *       key pool, so the pair is directly comparable and shows the memo adds no measurable overhead on the
+ *       pathological no-repeat workload.</li>
+ *   <li>{@code formerlyEagerPerHitWork}: the work a memo <em>hit</em> used to pay before it consulted the map —
+ *       building the absolute resource pointer and rebuilding the caller subject-id {@link Set} by streaming
+ *       the {@link AuthorizationContext}. Neither is part of the memo key and neither is used on a hit, so both
+ *       now happen inside the memo supplier (miss-only). Keeping this measurable guards against reintroducing
+ *       eager work on the hit path: {@code hasUnrestrictedPermissionsMemoHit} must stay well below
+ *       {@code hasUnrestrictedPermissionsMemoHit + formerlyEagerPerHitWork}.</li>
+ * </ul>
+ * Expectations: {@code memoHit} &lll; {@code noMemo} (the win), {@code memoMiss} ≈ {@code noMemoSameKeys}
+ * within noise (no regression), and {@code formerlyEagerPerHitWork} costing several times {@code memoHit}
+ * itself in allocation — which is why paying it eagerly, before the map lookup, dominated the hit path.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 3, time = 2)
+@Fork(1)
+@Threads(1)
+public class AuthorizationVerdictMemoBenchmark {
+
+    private static final PolicyId POLICY_ID = PolicyId.of("bench:policy");
+    private static final Permissions READ = Permissions.newInstance(Permission.READ);
+    private static final ResourceKey THING_ROOT = ResourceKey.newInstance("thing", "/");
+    private static final String CALLER = "user:caller-0";
+
+    /** Distinct resource keys, far more than {@link #BOUNDED_MAX}, so cycling them (almost) always misses. */
+    private static final int MISS_POOL = 64;
+    private static final int BOUNDED_MAX = 4;
+    private static final ResourceKey[] MISS_KEYS = new ResourceKey[MISS_POOL];
+
+    static {
+        for (int i = 0; i < MISS_POOL; i++) {
+            MISS_KEYS[i] = ResourceKey.newInstance("thing", "/features/feature" + i);
+        }
+    }
+
+    /** Number of policy labels, i.e. how much tree there is to walk on a miss. */
+    @Param({"10", "100"})
+    public String policyLabels;
+
+    /** Number of subjects in the calling AuthorizationContext. */
+    @Param({"1", "5"})
+    public String callerSubjects;
+
+    private TreeBasedPolicyEnforcer warmEnforcer;
+    private TreeBasedPolicyEnforcer noMemoEnforcer;
+    private TreeBasedPolicyEnforcer boundedEnforcer;
+    private AuthorizationContext callerContext;
+    private int missIdx;
+
+    @Setup
+    public void setup() {
+        final Policy policy = buildPolicy(Integer.parseInt(policyLabels));
+        warmEnforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        noMemoEnforcer = TreeBasedPolicyEnforcer.createInstance(policy, 0);
+        boundedEnforcer = TreeBasedPolicyEnforcer.createInstance(policy, BOUNDED_MAX);
+
+        callerContext = context(Integer.parseInt(callerSubjects));
+        // Prime the warm enforcer so every measured hit-path call really is a hit.
+        warmEnforcer.hasUnrestrictedPermissions(THING_ROOT, callerContext, READ);
+        warmEnforcer.getSubjectsWithPermission(THING_ROOT, READ);
+
+    }
+
+    @Benchmark
+    public void hasUnrestrictedPermissionsMemoHit(final Blackhole bh) {
+        bh.consume(warmEnforcer.hasUnrestrictedPermissions(THING_ROOT, callerContext, READ));
+    }
+
+    @Benchmark
+    public void hasUnrestrictedPermissionsNoMemo(final Blackhole bh) {
+        bh.consume(noMemoEnforcer.hasUnrestrictedPermissions(THING_ROOT, callerContext, READ));
+    }
+
+    @Benchmark
+    public void hasUnrestrictedPermissionsMemoMiss(final Blackhole bh) {
+        missIdx = (missIdx + 1) % MISS_POOL;
+        bh.consume(boundedEnforcer.hasUnrestrictedPermissions(MISS_KEYS[missIdx], callerContext, READ));
+    }
+
+    /** Baseline for {@link #hasUnrestrictedPermissionsMemoMiss}: same key pool, no memo at all. */
+    @Benchmark
+    public void hasUnrestrictedPermissionsNoMemoSameKeys(final Blackhole bh) {
+        missIdx = (missIdx + 1) % MISS_POOL;
+        bh.consume(noMemoEnforcer.hasUnrestrictedPermissions(MISS_KEYS[missIdx], callerContext, READ));
+    }
+
+    @Benchmark
+    public void getSubjectsWithPermissionMemoHit(final Blackhole bh) {
+        bh.consume(warmEnforcer.getSubjectsWithPermission(THING_ROOT, READ));
+    }
+
+    @Benchmark
+    public void getSubjectsWithPermissionNoMemo(final Blackhole bh) {
+        bh.consume(noMemoEnforcer.getSubjectsWithPermission(THING_ROOT, READ));
+    }
+
+    @Benchmark
+    public void formerlyEagerPerHitWork(final Blackhole bh) {
+        // Mirrors what hasUnrestrictedPermissions used to do before consulting the memo.
+        bh.consume(JsonFactory.newPointer(THING_ROOT.getResourceType()).append(THING_ROOT.getResourcePath()));
+        bh.consume(callerContext.stream()
+                .map(AuthorizationSubject::getId)
+                .collect(Collectors.toSet()));
+    }
+
+    private static Policy buildPolicy(final int labels) {
+        // The caller is granted unrestricted READ on thing:/ ; the filler labels grant READ on distinct
+        // features, giving the tree walk realistic width without changing the caller's verdict.
+        final PolicyBuilder builder = Policy.newBuilder(POLICY_ID)
+                .setRevision(1L)
+                .setSubjectFor("caller", subject(CALLER))
+                .setGrantedPermissionsFor("caller", THING_ROOT, Permission.READ);
+        for (int i = 0; i < labels; i++) {
+            builder.setSubjectFor("filler-" + i, subject("user:filler-" + i))
+                    .setGrantedPermissionsFor("filler-" + i,
+                            ResourceKey.newInstance("thing", "/features/feature" + i), Permission.READ);
+        }
+        return builder.build();
+    }
+
+    private static AuthorizationContext context(final int subjects) {
+        // The granted CALLER is always the primary subject; the extras have no grants and only widen the
+        // subject-id set the visitor probes per tree node.
+        final AuthorizationSubject[] additional = new AuthorizationSubject[subjects - 1];
+        for (int i = 1; i < subjects; i++) {
+            additional[i - 1] = AuthorizationSubject.newInstance("user:extra-" + i);
+        }
+        return AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
+                AuthorizationSubject.newInstance(CALLER), additional);
+    }
+
+    private static Subject subject(final String id) {
+        return Subject.newInstance(SubjectId.newInstance(id), SubjectType.GENERATED);
+    }
+
+    public static void main(final String[] args) throws RunnerException, CommandLineOptionException, IOException {
+        // Command-line arguments are honoured (so e.g. "-prof gc" works) but the include pattern is fixed.
+        final Options opt = new OptionsBuilder()
+                .parent(new CommandLineOptions(args))
+                .include(AuthorizationVerdictMemoBenchmark.class.getSimpleName())
+                .shouldFailOnError(true)
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## What

Memoizes the per-command policy-tree walk in `TreeBasedPolicyEnforcer` so recurring authorization decisions become a hash lookup instead of a full tree traversal.

## Why

A production JFR profile showed the policy-tree walk (`visitTree`) as a dominant things-service CPU hotspot — roughly 10–12% of things-service CPU and ~5.6% of overall Ditto-microservice fleet CPU. Every authorization check (`hasUnrestrictedPermissions`, `hasPartialPermissions`, `getSubjectsWithPermission`, `getSubjectsWithPartialPermission`) walks the entire policy tree on each call, and the `(resource, subjects, permissions)` tuples recur heavily across signals (the same subjects repeatedly access the same resources).

This mirrors the existing `classifySubjects(resource, READ)` memoization on `PolicyEnforcer`: `TreeBasedPolicyEnforcer` is effectively immutable after `createInstance` (its `tree` is built once and only read afterwards), and a policy change produces a brand-new instance via `PolicyEnforcers.defaultEvaluator`. So the cache lifetime equals the instance lifetime and needs no explicit invalidation.

## What changed

Added per-instance `ConcurrentHashMap` memos inside `TreeBasedPolicyEnforcer`:

- Boolean permission checks share one map keyed by `(ResourceKey, subject-id Set, Permissions, partial-flag)` — the partial flag keeps unrestricted and partial checks distinct.
- Subject-collection results are keyed by `(ResourceKey, Permissions)`. The immutable `EffectedSubjects` instance is shared directly; `getSubjectsWithPartialPermission` caches an immutable snapshot and returns a fresh mutable copy per call to preserve its original contract.
- The authorization-subject-id `Set` is computed once and reused as the memo key, avoiding the previous per-call `HashSet` rebuild on cache hits.
- Each memo is best-effort bounded (`MAX_MEMO_SIZE`) to stay memory-safe under pathological key diversity; above the cap, results are computed uncached.

Placing the memo on the enforcer itself (rather than the `PolicyEnforcer` wrapper) transparently benefits every caller across things, policies and gateway, all of which invoke these checks on the bare `Enforcer`.

## Behavior & compatibility

- Verdicts are byte-for-byte identical to the non-memoized path.
- Thread-safe: `ConcurrentHashMap` with a get→compute→`putIfAbsent` helper; the computation only reads the immutable tree and never re-enters the map.
- Only private members and private nested value classes are added — no public API change (japicmp passes). Java-8 compatible (plain value classes; no records / `Set.copyOf`).
- Adds `TreeBasedPolicyEnforcerMemoTest` proving repeat calls match a cold enforcer and that distinct subjects / permissions / resources / check-kinds are never conflated. The full `policies/model` suite (1055 tests) passes.
