### PR TITLE
Compute IndexLengthRestrictionEnforcer pointer byte-length without allocating

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/IndexLengthRestrictionEnforcer.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/IndexLengthRestrictionEnforcer.java
@@ -20,6 +20,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.CoderResult;
 import java.util.Optional;
 
+import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 
@@ -111,8 +112,55 @@ public final class IndexLengthRestrictionEnforcer {
         return thingId.length() + namespaceLength + authSubjectOverhead;
     }
 
-    private static int jsonPointerBytes(final JsonPointer jsonPointer) {
-        return jsonPointer.toString().getBytes(UTF_8).length;
+    // Package-private for the equivalence test in IndexLengthRestrictionEnforcerTest. Computes the exact byte
+    // length of the pointer's UTF-8 string representation (as produced by JsonPointer.toString()) without
+    // materialising that String or an intermediate byte[]. This runs per leaf field of every indexed thing, so
+    // avoiding the two throwaway allocations meaningfully cuts CPU and allocation churn on the search-write path.
+    static int jsonPointerBytes(final JsonPointer jsonPointer) {
+        final int levelCount = jsonPointer.getLevelCount();
+        if (levelCount == 0) {
+            // JsonPointer.toString() renders the empty pointer as a single "/".
+            return 1;
+        }
+        // One '/' byte per key: the leading slash plus a separator before each subsequent key.
+        int bytes = levelCount;
+        for (final JsonKey key : jsonPointer) {
+            bytes += escapedUtf8ByteLength(key.toString());
+        }
+        return bytes;
+    }
+
+    /**
+     * Byte length of a single pointer segment as {@link JsonPointer#toString()} would render it: UTF-8 encoded,
+     * with each {@code ~} escaped to {@code ~0} (RFC 6901, matching {@code ImmutableJsonPointer.escapeTilde};
+     * {@code /} is not escaped there). Mirrors {@code String.getBytes(UTF_8)} exactly, including the single
+     * {@code ?} replacement byte that encoder emits for an unpaired surrogate.
+     */
+    private static int escapedUtf8ByteLength(final String segment) {
+        int bytes = 0;
+        final int length = segment.length();
+        for (int i = 0; i < length; i++) {
+            final char c = segment.charAt(i);
+            if (c == '~') {
+                bytes += 2; // escaped to "~0": '~' and '0' are each one ASCII byte
+            } else if (c < 0x80) {
+                bytes += 1;
+            } else if (c < 0x800) {
+                bytes += 2;
+            } else if (Character.isHighSurrogate(c)) {
+                if (i + 1 < length && Character.isLowSurrogate(segment.charAt(i + 1))) {
+                    bytes += 4; // valid surrogate pair encodes one supplementary code point
+                    i++;        // consume the paired low surrogate
+                } else {
+                    bytes += 1; // unpaired high surrogate -> single '?' replacement byte
+                }
+            } else if (Character.isLowSurrogate(c)) {
+                bytes += 1;     // unpaired low surrogate -> single '?' replacement byte
+            } else {
+                bytes += 3;     // remaining BMP code points (0x800..0xFFFF)
+            }
+        }
+        return bytes;
     }
 
     private static void checkThingId(final String thingId) {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/IndexLengthRestrictionEnforcerTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/IndexLengthRestrictionEnforcerTest.java
@@ -17,8 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.thingsearch.service.persistence.write.IndexLengthRestrictionEnforcer.MAX_INDEX_CONTENT_LENGTH;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
 
 import org.assertj.core.data.Offset;
+import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.thingsearch.service.persistence.util.TestStringGenerator;
@@ -96,6 +98,100 @@ public final class IndexLengthRestrictionEnforcerTest {
         final String key = baseKey + TestStringGenerator.createStringOfBytes(maxAllowed + 1);
         assertThat(indexLengthRestrictionEnforcer.enforce(JsonPointer.of(key), JsonValue.of(value)))
                 .isEmpty();
+    }
+
+    // --- jsonPointerBytes: allocation-free byte length must equal toString().getBytes(UTF_8).length ---
+
+    @Test
+    public void jsonPointerBytesMatchesToStringForRootAndSimplePointers() {
+        assertPointerBytesMatchesToString(JsonPointer.empty());
+        assertPointerBytesMatchesToString(JsonPointer.of("/"));
+        assertPointerBytesMatchesToString(JsonPointer.of("/attributes"));
+        assertPointerBytesMatchesToString(JsonPointer.of("/attributes/location/latitude"));
+        assertPointerBytesMatchesToString(JsonPointer.of("/features/lamp/properties/on/deep/nested/path"));
+        assertPointerBytesMatchesToString(pointerOfKeys("123", "456"));
+    }
+
+    @Test
+    public void jsonPointerBytesMatchesToStringForTildeEscaping() {
+        assertPointerBytesMatchesToString(pointerOfKeys("~"));
+        assertPointerBytesMatchesToString(pointerOfKeys("a~b"));
+        assertPointerBytesMatchesToString(pointerOfKeys("~~"));
+        assertPointerBytesMatchesToString(pointerOfKeys("~0", "~1"));
+        assertPointerBytesMatchesToString(pointerOfKeys("~leading", "trailing~", "mid~dle"));
+        assertPointerBytesMatchesToString(pointerOfKeys("a~b", "c~~d", "~"));
+    }
+
+    @Test
+    public void jsonPointerBytesMatchesToStringForMultiByteUnicode() {
+        assertPointerBytesMatchesToString(pointerOfKeys("café"));       // e-acute = 2-byte
+        assertPointerBytesMatchesToString(pointerOfKeys("price€"));     // euro sign = 3-byte
+        assertPointerBytesMatchesToString(pointerOfKeys("emoji😀")); // grinning face = 4-byte pair
+        assertPointerBytesMatchesToString(pointerOfKeys("mixé€😀~end"));
+        assertPointerBytesMatchesToString(pointerOfKeys("é", "€", "😀"));
+    }
+
+    @Test
+    public void jsonPointerBytesMatchesToStringForUnpairedSurrogates() {
+        assertPointerBytesMatchesToString(pointerOfKeys("\uD83D"));          // lone high surrogate
+        assertPointerBytesMatchesToString(pointerOfKeys("\uDE00"));          // lone low surrogate
+        assertPointerBytesMatchesToString(pointerOfKeys("a\uD83Db"));        // high surrogate followed by non-low
+        assertPointerBytesMatchesToString(pointerOfKeys("\uD83D\uD83D"));    // two high surrogates
+        assertPointerBytesMatchesToString(pointerOfKeys("\uDE00\uD83D"));    // low then high
+    }
+
+    @Test
+    public void jsonPointerBytesMatchesToStringForRandomKeys() {
+        final Random random = new Random(20260731L);
+        for (int iteration = 0; iteration < 5000; iteration++) {
+            final int levels = 1 + random.nextInt(6);
+            final String[] keys = new String[levels];
+            for (int level = 0; level < levels; level++) {
+                keys[level] = randomKey(random);
+            }
+            assertPointerBytesMatchesToString(pointerOfKeys(keys));
+        }
+    }
+
+    private static void assertPointerBytesMatchesToString(final JsonPointer pointer) {
+        final int expected = pointer.toString().getBytes(StandardCharsets.UTF_8).length;
+        assertThat(IndexLengthRestrictionEnforcer.jsonPointerBytes(pointer))
+                .as("byte length of pointer <%s>", pointer)
+                .isEqualTo(expected);
+    }
+
+    private static JsonPointer pointerOfKeys(final String... keys) {
+        JsonPointer pointer = JsonPointer.empty();
+        for (final String key : keys) {
+            pointer = pointer.addLeaf(JsonKey.of(key));
+        }
+        return pointer;
+    }
+
+    private static String randomKey(final Random random) {
+        final int targetLength = 1 + random.nextInt(12);
+        final StringBuilder sb = new StringBuilder(targetLength);
+        while (sb.length() < targetLength) {
+            final int pick = random.nextInt(100);
+            if (pick < 55) {
+                sb.append((char) ('a' + random.nextInt(26)));            // ascii letters
+            } else if (pick < 65) {
+                sb.append((char) ('0' + random.nextInt(10)));            // digits
+            } else if (pick < 75) {
+                sb.append('~');                                          // tilde -> escaped to "~0"
+            } else if (pick < 85) {
+                sb.append((char) (0x80 + random.nextInt(0x780)));        // 2-byte code points (0x80..0x7FF)
+            } else if (pick < 93) {
+                int cp = 0x800 + random.nextInt(0xF800);                 // 3-byte BMP code points
+                if (cp >= 0xD800 && cp <= 0xDFFF) {
+                    cp = 0x800 + (cp - 0xD800);                          // skip the surrogate range
+                }
+                sb.append((char) cp);
+            } else {
+                sb.appendCodePoint(0x10000 + random.nextInt(0x100000));  // supplementary -> surrogate pair
+            }
+        }
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
## What

`IndexLengthRestrictionEnforcer.jsonPointerBytes(...)` computed the pointer's UTF-8 byte length via `jsonPointer.toString().getBytes(UTF_8).length`. This runs **per string/number leaf of every indexed thing** on the search-write path, and each call allocates two throwaway objects:

- a full pointer `String` (level join + per-level `escapeTilde`), and
- a `byte[]` from the UTF-8 encoder — created solely to read `.length`, then discarded.

A production JFR profile showed this as a notable thingssearch CPU and allocation hotspot.

## Change

Replace it with a direct, allocation-free scan over the pointer's `JsonKey`s that sums the UTF-8 byte length of each escaped segment plus the `/` separators — no intermediate `String`, no `byte[]`.

The computed count is **byte-for-byte identical** to `toString().getBytes(UTF_8).length`:
- RFC 6901 escaping of `~` → `~0` (mirroring `ImmutableJsonPointer.escapeTilde`, which does not escape `/`), and
- the single `?` replacement byte the UTF-8 encoder emits for an unpaired surrogate.

The change is contained to `IndexLengthRestrictionEnforcer`; the `json` module is untouched.

## Correctness

An equivalence test asserts the new computation equals `pointer.toString().getBytes(UTF_8).length` for root/empty, deep, tilde-escaped (`~`, `~~`, `~0`/`~1`, leading/trailing), multi-byte unicode (2-byte é, 3-byte €, 4-byte 😀) and unpaired-surrogate pointers, plus a 5000-iteration seeded randomized property check over random BMP and supplementary code points. Index-length enforcement behaviour is unchanged. `IndexLengthRestrictionEnforcerTest` passes (10 tests).
