### PR TITLE
Memoize read-subject parsing and ditto-read-subjects rendering

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeaders.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeaders.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -67,6 +68,19 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
 
     private static final String REDACTED_VALUE = "***";
     private static final Set<String> REDACTED_HEADER_KEYS = loadRedactedHeaderKeys();
+
+    /*
+     * Single derivation function shared by the "ditto-read-subjects" and "ditto-read-revoked-subjects" headers, so
+     * that the untyped memo slot of Header is only ever populated with a Set<AuthorizationSubject> for those keys.
+     * Set.copyOf is required (not Collections.unmodifiableSet): only its final fields make the result safe to
+     * publish through Header's deliberately non-volatile memo field.
+     */
+    private static final Function<JsonValue, Set<AuthorizationSubject>> AUTHORIZATION_SUBJECT_SET_DERIVATION =
+            jsonValue -> Set.copyOf(jsonValue.asArray()
+                    .stream()
+                    .map(JsonValue::asString)
+                    .map(AuthorizationSubject::newInstance)
+                    .collect(Collectors.toList()));
 
     final Map<String, Header> headers;
 
@@ -214,11 +228,11 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
     }
 
     private Set<AuthorizationSubject> getAuthorizationSubjectSet(final HeaderDefinition definition) {
-        final JsonArray jsonValueArray = getJsonArrayForDefinition(definition);
-        return jsonValueArray.stream()
-                .map(JsonValue::asString)
-                .map(AuthorizationSubject::newInstance)
-                .collect(Collectors.toSet());
+        @Nullable final Header header = headers.get(definition.getKey());
+        if (null == header) {
+            return Set.of();
+        }
+        return header.getDerivedValue(AUTHORIZATION_SUBJECT_SET_DERIVATION);
     }
 
     @Override

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
@@ -16,6 +16,7 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.argumentNotEm
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotEmpty;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
+import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -348,13 +349,43 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
 
     private void putJsonValue(final HeaderDefinition definition, final JsonValue jsonValue) {
         if (!jsonValue.isNull()) {
-            putCharSequence(definition, jsonValue.isString() ? jsonValue.asString() : jsonValue.toString());
+            if (jsonValue.isString()) {
+                putCharSequence(definition, jsonValue.asString());
+            } else {
+                // Seed the Header's JSON memo with the value we just rendered: the resulting Header is fresh per
+                // built signal, so without this the next reader (e.g. the pub/sub topic extractor on the very same
+                // node) would parse the string right back into the object we already have at hand.
+                final String stringRepresentation = jsonValue.toString();
+                checkNotEmpty(stringRepresentation, definition.getKey());
+                headers.remove(definition.getKey());
+                headers.put(definition.getKey(),
+                        Header.of(definition.getKey(), stringRepresentation, jsonValue));
+            }
         }
     }
 
     @Override
     public S readGrantedSubjects(final Collection<AuthorizationSubject> readGrantedSubjects) {
         putAuthorizationSubjectCollection(readGrantedSubjects, DittoHeaderDefinition.READ_SUBJECTS);
+        return myself;
+    }
+
+    @Override
+    public S readGrantedSubjects(final JsonArray readGrantedSubjectIds) {
+        checkNotNull(readGrantedSubjectIds, DittoHeaderDefinition.READ_SUBJECTS.getKey());
+        // The array is put verbatim, bypassing the parse-based JsonArrayValueValidator; the element type check it
+        // would have done is kept, so a caller cannot smuggle in a value that later fails on read with asString().
+        for (final JsonValue jsonValue : readGrantedSubjectIds) {
+            if (!jsonValue.isString()) {
+                final String invalidHeaderKey = DittoHeaderDefinition.READ_SUBJECTS.getKey();
+                throw DittoHeaderInvalidException.newBuilder()
+                        .withInvalidHeaderKey(invalidHeaderKey)
+                        .message(MessageFormat.format("JSON array for <{0}> contained non-string values!",
+                                invalidHeaderKey))
+                        .build();
+            }
+        }
+        putJsonValue(DittoHeaderDefinition.READ_SUBJECTS, readGrantedSubjectIds);
         return myself;
     }
 

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaders.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeaders.java
@@ -173,7 +173,8 @@ public interface DittoHeaders extends Jsonifiable<JsonObject>, Map<String, Strin
     /**
      * Returns the authorization subjects with granted "READ" permissions for the key in the map defining a pointer in
      * the Thing.
-     * Changes on the returned Set are not reflected back to this headers object.
+     * The returned Set is unmodifiable and may be a memoized instance shared by repeated invocations; changes on it
+     * are neither possible nor reflected back to this headers object.
      *
      * @return the read granted subjects for pointers in the Thing.
      * @since 1.1.0
@@ -183,7 +184,8 @@ public interface DittoHeaders extends Jsonifiable<JsonObject>, Map<String, Strin
     /**
      * Returns the authorization subjects with explicitly revoked "READ" permissions for the key in the map defining a
      * pointer in the Thing.
-     * Changes on the returned Set are not reflected back to this headers object.
+     * The returned Set is unmodifiable and may be a memoized instance shared by repeated invocations; changes on it
+     * are neither possible nor reflected back to this headers object.
      *
      * @return the read revoked subjects for pointers in the Thing.
      * @since 1.1.0

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/DittoHeadersBuilder.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.base.model.headers.metadata.MetadataHeaderKey;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonValue;
 
 /**
@@ -85,6 +86,21 @@ public interface DittoHeadersBuilder<B extends DittoHeadersBuilder<B, R>, R exte
      * @since 1.1.0
      */
     B readGrantedSubjects(Collection<AuthorizationSubject> readGrantedSubjects);
+
+    /**
+     * Sets the subjects with granted READ access from an already rendered JSON array of subject IDs.
+     * Semantically equivalent to {@link #readGrantedSubjects(Collection)}, but skips re-serializing the subject IDs;
+     * intended for callers that memoize the rendered array because it only changes with the underlying policy.
+     * An empty array is set as {@code []}, exactly like an empty collection.
+     *
+     * @param readGrantedSubjectIds the rendered subject IDs to be set; every element must be a JSON string.
+     * @return this builder for Method Chaining.
+     * @throws NullPointerException if {@code readGrantedSubjectIds} is {@code null}.
+     * @throws org.eclipse.ditto.base.model.exceptions.DittoHeaderInvalidException if {@code readGrantedSubjectIds}
+     * contains an element which is not a JSON string.
+     * @since 3.9.7
+     */
+    B readGrantedSubjects(JsonArray readGrantedSubjectIds);
 
     /**
      * Sets the subjects with explicitly revoked READ access.

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.base.model.headers;
 
 import java.util.Objects;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -43,6 +44,16 @@ final class Header implements CharSequence {
      */
     @Nullable
     private JsonValue parsedValue;
+
+    /*
+     * Lazily memoized value derived from {@link #parsedValue}, for header keys whose parsed JSON is repeatedly
+     * converted into the same domain object (e.g. "ditto-read-subjects" into a Set of AuthorizationSubject).
+     * Same benign-data-race rationale as {@link #parsedValue}: the derivation is a pure function of the immutable
+     * value string, so a race can only recompute an equal result. See {@link #getDerivedValue(Function)} for the
+     * two invariants callers must uphold.
+     */
+    @Nullable
+    private Object derivedValue;
 
     private Header(final String key, final String value) {
         this.key = key;
@@ -76,6 +87,39 @@ final class Header implements CharSequence {
             parsedValue = result;
         }
         return result;
+    }
+
+    /**
+     * Returns a value derived from {@link #getParsedValue()} by the given derivation, memoizing the result for
+     * subsequent calls. Intended for header keys whose parsed JSON is converted into the same domain object on every
+     * access on a hot path.
+     * <p>
+     * Callers must uphold two invariants:
+     * <ul>
+     * <li>The derivation must return a non-{@code null}, deeply immutable value whose fields are all {@code final}
+     * (e.g. the result of {@link java.util.Set#copyOf}). The memo field is deliberately non-volatile, so only
+     * final-field freeze semantics (JLS 17.5) guarantee that another thread observing the memo cannot see a
+     * partially constructed object. A {@code Collections.unmodifiableSet(new HashSet<>(…))} would <em>not</em> be
+     * safe here.</li>
+     * <li>For any given header key, exactly one derivation function must ever be used. The memo slot is untyped, so
+     * mixing derivations of different result types for the same key would cause a {@link ClassCastException} at the
+     * call site.</li>
+     * </ul>
+     * Like {@link #parsedValue}, the memo does not participate in {@link #equals(Object)} / {@link #hashCode()} and
+     * does not affect the observable immutability of Header.
+     *
+     * @param derivation the pure function deriving the value from the parsed JSON representation.
+     * @param <T> the type of the derived value.
+     * @return the derived (and cached) value.
+     */
+    @SuppressWarnings("unchecked")
+    <T> T getDerivedValue(final Function<? super JsonValue, ? extends T> derivation) {
+        Object result = derivedValue;
+        if (null == result) {
+            result = derivation.apply(getParsedValue());
+            derivedValue = result;
+        }
+        return (T) result;
     }
 
     @Override

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/Header.java
@@ -64,6 +64,22 @@ final class Header implements CharSequence {
         return new Header(key, value);
     }
 
+    /**
+     * Creates a Header whose JSON memo is pre-seeded with the value the string representation was rendered from,
+     * so the first {@link #getParsedValue()} does not have to parse it back. The caller must guarantee that
+     * {@code value} is the string representation of {@code parsedValue}.
+     *
+     * @param key the header key in its original capitalization.
+     * @param value the string representation of {@code parsedValue}.
+     * @param parsedValue the already known JSON representation of {@code value}.
+     * @return the new Header.
+     */
+    static Header of(final String key, final String value, final JsonValue parsedValue) {
+        final Header result = new Header(key, value);
+        result.parsedValue = parsedValue;
+        return result;
+    }
+
     String getKey() {
         return key;
     }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
@@ -494,4 +494,45 @@ public final class DefaultDittoHeadersBuilderTest {
                 .withNoCause();
     }
 
+    @Test
+    public void readGrantedSubjectsFromJsonArrayIsEquivalentToCollectionVariant() {
+        final JsonArray renderedSubjectIds = READ_SUBJECTS.stream()
+                .map(AuthorizationSubject::getId)
+                .map(JsonFactory::newValue)
+                .collect(JsonCollectors.valuesToArray());
+
+        final DittoHeaders fromJsonArray = DittoHeaders.newBuilder()
+                .readGrantedSubjects(renderedSubjectIds)
+                .build();
+        final DittoHeaders fromCollection = DittoHeaders.newBuilder()
+                .readGrantedSubjects(READ_SUBJECTS)
+                .build();
+
+        assertThat(fromJsonArray).isEqualTo(fromCollection);
+        assertThat(fromJsonArray.getReadGrantedSubjects())
+                .containsExactlyInAnyOrderElementsOf(READ_SUBJECTS);
+    }
+
+    @Test
+    public void readGrantedSubjectsFromEmptyJsonArraySetsEmptyArrayHeader() {
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .readGrantedSubjects(JsonArray.empty())
+                .build();
+
+        assertThat(dittoHeaders).containsEntry(DittoHeaderDefinition.READ_SUBJECTS.getKey(), "[]");
+        assertThat(dittoHeaders.getReadGrantedSubjects()).isEmpty();
+    }
+
+    @Test
+    public void readGrantedSubjectsFromJsonArrayWithNonStringValueThrows() {
+        final String readSubjectsKey = DittoHeaderDefinition.READ_SUBJECTS.getKey();
+        final JsonArray invalidSubjectIds = JsonArray.newBuilder().add("valid").add(42).build();
+        final DefaultDittoHeadersBuilder builder = DefaultDittoHeadersBuilder.newInstance();
+
+        assertThatExceptionOfType(DittoHeaderInvalidException.class)
+                .isThrownBy(() -> builder.readGrantedSubjects(invalidSubjectIds))
+                .withMessage("JSON array for <%s> contained non-string values!", readSubjectsKey)
+                .withNoCause();
+    }
+
 }

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/HeaderValueParsingBenchmark.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/HeaderValueParsingBenchmark.java
@@ -135,6 +135,17 @@ public class HeaderValueParsingBenchmark {
         return dittoHeaders.getAuthorizationContext();
     }
 
+    /**
+     * Cold-memo variant of {@link #getReadGrantedSubjects()}: rebuilds the headers from their JSON representation
+     * (as a cluster hop does) so every invocation pays the parse plus the set derivation exactly once. Contrast with
+     * {@link #getReadGrantedSubjects()} to see what same-node consumers (pub/sub extractor, streaming sessions,
+     * connectivity targets) save by sharing one memoized set.
+     */
+    @Benchmark
+    public Object getReadGrantedSubjects_freshHeaders() {
+        return DittoHeaders.newFromTrustedJson(headersJson).getReadGrantedSubjects();
+    }
+
     /** Pre-memoization equivalent of {@link #getReadGrantedSubjects()}: re-parses the array string each call. */
     @Benchmark
     public Object getReadGrantedSubjects_reparse() {

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
@@ -330,6 +330,56 @@ public final class ImmutableDittoHeadersTest {
     }
 
     @Test
+    public void getReadGrantedSubjectsIsMemoizedAcrossRepeatedCalls() {
+        final DittoHeaders underTest = DittoHeaders.newBuilder()
+                .readGrantedSubjects(KNOWN_READ_GRANTED_SUBJECTS)
+                .build();
+
+        assertThat(underTest.getReadGrantedSubjects()).isSameAs(underTest.getReadGrantedSubjects());
+    }
+
+    @Test
+    public void getReadRevokedSubjectsIsMemoizedAcrossRepeatedCalls() {
+        final DittoHeaders underTest = DittoHeaders.newBuilder()
+                .readRevokedSubjects(KNOWN_READ_REVOKED_SUBJECTS)
+                .build();
+
+        assertThat(underTest.getReadRevokedSubjects()).isSameAs(underTest.getReadRevokedSubjects());
+    }
+
+    @Test
+    public void memoizedReadGrantedSubjectsSurviveHeadersCopy() {
+        final DittoHeaders original = DittoHeaders.newBuilder()
+                .readGrantedSubjects(KNOWN_READ_GRANTED_SUBJECTS)
+                .build();
+        final Set<AuthorizationSubject> memoizedByOriginal = original.getReadGrantedSubjects();
+
+        // copying headers re-uses the very same Header entries, hence also their memoized derived values:
+        final DittoHeaders copy = DittoHeaders.newBuilder(original).putHeader("foo", "bar").build();
+
+        assertThat(copy.getReadGrantedSubjects()).isSameAs(memoizedByOriginal);
+    }
+
+    @Test
+    public void getReadGrantedSubjectsReturnsUnmodifiableSet() {
+        final DittoHeaders underTest = DittoHeaders.newBuilder()
+                .readGrantedSubjects(KNOWN_READ_GRANTED_SUBJECTS)
+                .build();
+        final Set<AuthorizationSubject> readGrantedSubjects = underTest.getReadGrantedSubjects();
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> readGrantedSubjects.add(AuthorizationModelFactory.newAuthSubject("foo")));
+    }
+
+    @Test
+    public void getReadGrantedSubjectsReturnsEmptySetIfHeaderIsAbsent() {
+        final DittoHeaders underTest = DittoHeaders.empty();
+
+        assertThat(underTest.getReadGrantedSubjects()).isEmpty();
+        assertThat(underTest.getReadRevokedSubjects()).isEmpty();
+    }
+
+    @Test
     public void isResponseRequiredIsTrueByDefault() {
         final DittoHeaders underTest = DittoHeaders.empty();
 

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/ImmutableDittoHeadersTest.java
@@ -372,6 +372,19 @@ public final class ImmutableDittoHeadersTest {
     }
 
     @Test
+    public void getReadGrantedSubjectsToleratesDuplicateSubjectIds() {
+        // Nothing enforces uniqueness on the wire (the header validator only checks element types), so a duplicate
+        // must be collapsed rather than rejected -- as the previous Collectors.toSet() did.
+        final DittoHeaders underTest = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.READ_SUBJECTS.getKey(), "[\"read\",\"read\",\"subjects\"]")
+                .build();
+
+        assertThat(underTest.getReadGrantedSubjects()).containsExactlyInAnyOrder(
+                AuthorizationModelFactory.newAuthSubject("read"),
+                AuthorizationModelFactory.newAuthSubject("subjects"));
+    }
+
+    @Test
     public void getReadGrantedSubjectsReturnsEmptySetIfHeaderIsAbsent() {
         final DittoHeaders underTest = DittoHeaders.empty();
 

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,7 +34,11 @@ import javax.annotation.concurrent.Immutable;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
@@ -76,6 +82,15 @@ public final class PolicyEnforcer {
     // safe: the instance is replaced wholesale by CachingPolicyEnforcerProvider on every grant change, so the
     // memo is invalidated naturally. Generalizes the former single-slot root-read-classification memo.
     private final Cache<ResourceKey, SubjectClassification> readClassificationCache;
+    // Memoizes the rendered "ditto-read-subjects" header value per resource, layered on top of
+    // readClassificationCache: the value is a pure function of the resolved grants and the resource path, so
+    // rendering it (merge -> sort -> JsonArray -> escaped string + CBOR) once per policy revision instead of once
+    // per emitted ThingEvent is safe. Same natural invalidation as the caches above. Only used for the
+    // include-partial-read-subjects variant, which is the only one depending on the resource key.
+    private final Cache<ResourceKey, JsonArray> readGrantedSubjectsHeaderValueCache;
+    // Single-slot memo for the root-only variant, whose value does not depend on the resource key. Volatile
+    // rather than a Cache because it is a single reference read on the hot path.
+    @Nullable private volatile JsonArray rootOnlyReadGrantedSubjectsHeaderValue;
     // The read-classification bound (<= 0 means unbounded), kept so forNamespace children can inherit it:
     // the things-service hot path calls classifyReadSubjects on the namespace-filtered child, so its cache
     // must be bounded too (unlike the child's namespace cache, which stays empty).
@@ -115,6 +130,11 @@ public final class PolicyEnforcer {
         // <= 0 means unbounded (of/embed/transient instances); provider-cached and forNamespace children
         // inherit the operator-configured bound.
         this.readClassificationCache = readClassificationCacheMaxSize > 0
+                ? Caffeine.newBuilder().maximumSize(readClassificationCacheMaxSize).build()
+                : Caffeine.newBuilder().build();
+        // Entries correspond one-to-one to readClassificationCache entries, so the same bound keeps the retained
+        // memory of both memos proportional; no separate configuration knob is needed.
+        this.readGrantedSubjectsHeaderValueCache = readClassificationCacheMaxSize > 0
                 ? Caffeine.newBuilder().maximumSize(readClassificationCacheMaxSize).build()
                 : Caffeine.newBuilder().build();
     }
@@ -431,6 +451,71 @@ public final class PolicyEnforcer {
         checkNotNull(resourceKey, "resourceKey");
         return readClassificationCache.get(resourceKey,
                 rk -> enforcer.classifySubjects(rk, READ_PERMISSIONS));
+    }
+
+    /**
+     * Returns the rendered value of the {@code ditto-read-subjects} header for the given resource, computed at most
+     * once per distinct {@code resourceKey} and memoized for the lifetime of this instance.
+     * <p>
+     * The subjects are the same ones {@link #classifyReadSubjects(ResourceKey)} yields, namely
+     * {@code unrestricted(resourceKey) ∪ partialOnly(root) ∪ unrestricted(root)} when
+     * {@code includePartialReadSubjects} is set and {@code unrestricted(root)} otherwise. Rendering them into a JSON
+     * array is a pure function of those sets, so — like the classification itself — it is memoized here instead of
+     * being repeated for every emitted ThingEvent. The memo is invalidated naturally, because
+     * {@code CachingPolicyEnforcerProvider} replaces this instance wholesale on every grant change.
+     * <p>
+     * Subject IDs are sorted and de-duplicated, which makes the rendered value stable across pods and restarts.
+     * Consumers parse the array back into a Set, so the ordering is not semantically relevant.
+     *
+     * @param resourceKey the resource to render the READ-granted subjects for.
+     * @param includePartialReadSubjects whether subjects with only partial READ access on the root resource are
+     * included.
+     * @return the cached rendered header value; empty if no subject has READ access.
+     * @since 3.9.7
+     */
+    public JsonArray getReadGrantedSubjectsHeaderValue(final ResourceKey resourceKey,
+            final boolean includePartialReadSubjects) {
+
+        checkNotNull(resourceKey, "resourceKey");
+        if (includePartialReadSubjects) {
+            return readGrantedSubjectsHeaderValueCache.get(resourceKey, this::renderReadGrantedSubjectsIncludingPartial);
+        }
+        JsonArray result = rootOnlyReadGrantedSubjectsHeaderValue;
+        if (null == result) {
+            result = renderSubjectIds(getRootResourceReadClassification().getUnrestricted());
+            rootOnlyReadGrantedSubjectsHeaderValue = result;
+        }
+        return result;
+    }
+
+    private JsonArray renderReadGrantedSubjectsIncludingPartial(final ResourceKey resourceKey) {
+        final SubjectClassification rootClassification = getRootResourceReadClassification();
+        final TreeSet<String> subjectIds = new TreeSet<>();
+        collectSubjectIds(classifyReadSubjects(resourceKey).getUnrestricted(), subjectIds);
+        collectSubjectIds(rootClassification.getPartialOnly(), subjectIds);
+        collectSubjectIds(rootClassification.getUnrestricted(), subjectIds);
+        return toJsonArray(subjectIds);
+    }
+
+    private static JsonArray renderSubjectIds(final Set<AuthorizationSubject> subjects) {
+        final TreeSet<String> subjectIds = new TreeSet<>();
+        collectSubjectIds(subjects, subjectIds);
+        return toJsonArray(subjectIds);
+    }
+
+    private static void collectSubjectIds(final Set<AuthorizationSubject> subjects, final TreeSet<String> target) {
+        for (final AuthorizationSubject subject : subjects) {
+            target.add(subject.getId());
+        }
+    }
+
+    private static JsonArray toJsonArray(final TreeSet<String> subjectIds) {
+        if (subjectIds.isEmpty()) {
+            return JsonArray.empty();
+        }
+        return subjectIds.stream()
+                .map(JsonFactory::newValue)
+                .collect(JsonCollectors.valuesToArray());
     }
 
     /**

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.model.AllowedAddition;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
@@ -192,6 +194,101 @@ public final class PolicyEnforcerTest {
 
         assertThat(classificationAgain.getUnrestricted()).isEqualTo(classificationA.getUnrestricted());
         assertThat(classificationAgain.getPartialOnly()).isEqualTo(classificationA.getPartialOnly());
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueMemoizesRepeatedCalls() {
+        final PolicyEnforcer policyEnforcer = PolicyEnforcer.of(partialGrantsPolicy());
+        final ResourceKey attributeX = PoliciesResourceType.thingResource("/attributes/x");
+
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, true))
+                .isSameAs(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, true));
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, false))
+                .isSameAs(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, false));
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueRendersClassificationUnion() {
+        final PolicyEnforcer policyEnforcer = PolicyEnforcer.of(partialGrantsPolicy());
+        final ResourceKey attributeX = PoliciesResourceType.thingResource("/attributes/x");
+
+        // includePartial: unrestricted(/attributes/x) = alice + bob, plus root partial readers = carol
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, true))
+                .isEqualTo(JsonArray.of("[\"user:alice\",\"user:bob\",\"user:carol\"]"));
+        // without partial: only root-unrestricted readers
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(attributeX, false))
+                .isEqualTo(JsonArray.of("[\"user:alice\"]"));
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueIsSortedAndDeduplicated() {
+        final PolicyEnforcer policyEnforcer = PolicyEnforcer.of(partialGrantsPolicy());
+
+        // alice is both root-unrestricted and unrestricted on the resource, so she must appear exactly once;
+        // sorting makes the rendered value stable across pods and restarts.
+        final JsonArray headerValue = policyEnforcer.getReadGrantedSubjectsHeaderValue(
+                PoliciesResourceType.thingResource("/attributes/x"), true);
+
+        assertThat(headerValue.stream().map(JsonValue::asString))
+                .containsExactly("user:alice", "user:bob", "user:carol");
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueIsEmptyWithoutReadGrants() {
+        final Policy writeOnlyPolicy = Policy.newBuilder(PolicyId.of("test:policy"))
+                .setRevision(1L)
+                .setSubjectFor("alice", Subject.newInstance(SubjectId.newInstance("user:alice")))
+                .setGrantedPermissionsFor("alice", ResourceKey.newInstance("thing", "/"), Permission.WRITE)
+                .build();
+        final PolicyEnforcer policyEnforcer = PolicyEnforcer.of(writeOnlyPolicy);
+
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(
+                PoliciesResourceType.thingResource("/"), false)).isEmpty();
+        assertThat(policyEnforcer.getReadGrantedSubjectsHeaderValue(
+                PoliciesResourceType.thingResource("/"), true)).isEmpty();
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueStaysCorrectUnderBoundedCache() {
+        // Tiny bound: correctness must not depend on capacity — an evicted entry simply re-renders an equal value.
+        final PolicyEnforcer bounded = PolicyEnforcer.of(partialGrantsPolicy(), 100, 1);
+        final ResourceKey a = PoliciesResourceType.thingResource("/attributes/x");
+        final ResourceKey b = PoliciesResourceType.thingResource("/attributes/y");
+
+        final JsonArray valueA = bounded.getReadGrantedSubjectsHeaderValue(a, true);
+        bounded.getReadGrantedSubjectsHeaderValue(b, true);
+
+        assertThat(bounded.getReadGrantedSubjectsHeaderValue(a, true)).isEqualTo(valueA);
+    }
+
+    @Test
+    public void getReadGrantedSubjectsHeaderValueOfNamespaceChildIsComputedIndependently() {
+        final Policy policy = PoliciesModelFactory.newPolicyBuilder(PolicyId.of("test:policy"))
+                .set(newScopedEntry("restricted", "google:tenant-user", Arrays.asList("com.acme", "com.acme.*")))
+                .set(newScopedEntry("global", "google:global-user", Collections.emptyList()))
+                .build();
+        final PolicyEnforcer parent = PolicyEnforcer.of(policy, 100, 100);
+        final ResourceKey root = PoliciesResourceType.thingResource("/");
+
+        final JsonArray unfiltered = parent.getReadGrantedSubjectsHeaderValue(root, false);
+        final JsonArray filtered = parent.forNamespace("org.example").getReadGrantedSubjectsHeaderValue(root, false);
+
+        assertThat(unfiltered.stream().map(JsonValue::asString))
+                .containsExactly("google:global-user", "google:tenant-user");
+        assertThat(filtered.stream().map(JsonValue::asString)).containsExactly("google:global-user");
+    }
+
+    /** alice: unrestricted READ at root; bob: READ only on /attributes/x; carol: READ only on /attributes/y. */
+    private static Policy partialGrantsPolicy() {
+        return Policy.newBuilder(PolicyId.of("test:policy"))
+                .setRevision(1L)
+                .setSubjectFor("alice", Subject.newInstance(SubjectId.newInstance("user:alice")))
+                .setGrantedPermissionsFor("alice", ResourceKey.newInstance("thing", "/"), Permission.READ)
+                .setSubjectFor("bob", Subject.newInstance(SubjectId.newInstance("user:bob")))
+                .setGrantedPermissionsFor("bob", ResourceKey.newInstance("thing", "/attributes/x"), Permission.READ)
+                .setSubjectFor("carol", Subject.newInstance(SubjectId.newInstance("user:carol")))
+                .setGrantedPermissionsFor("carol", ResourceKey.newInstance("thing", "/attributes/y"), Permission.READ)
+                .build();
     }
 
     private static PolicyEntry newScopedEntry(final String label, final String subjectId, final List<String> namespaces) {

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
@@ -28,7 +28,6 @@ import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.base.model.auth.AuthorizationContext;
-import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -482,25 +481,15 @@ final class ThingCommandEnforcement
         final var eventResourcePath = signal.getResourcePath();
         final var eventResourceKey = ResourceKey.newInstance(ThingConstants.ENTITY_TYPE, eventResourcePath);
 
-        // classifyReadSubjects memoizes the (single) policy-tree walk per resource on the PolicyEnforcer, so
-        // value-only telemetry updates that repeat the same resource path do not re-walk the tree per event.
-        // The result set below is identical to the previous
+        // getReadGrantedSubjectsHeaderValue memoizes both the policy-tree walk and the rendering of the resulting
+        // header value per resource on the PolicyEnforcer, so repeated events on the same resource path neither
+        // re-walk the tree nor re-serialize the (unchanged) subject list per event. The rendered set is identical
+        // to the previous
         //   getSubjectsWithUnrestrictedPermission(eventResourceKey) ∪ getSubjectsWithPartialPermission(root)
         // because getSubjectsWithPartialPermission(root, READ) == partialOnly(root) ∪ unrestricted(root).
-        final Set<AuthorizationSubject> allReadSubjects;
-        if (includePartialReadSubjects) {
-            final var rootClassification = policyEnforcer.getRootResourceReadClassification();
-            allReadSubjects = new java.util.HashSet<>(
-                    policyEnforcer.classifyReadSubjects(eventResourceKey).getUnrestricted());
-            allReadSubjects.addAll(rootClassification.getPartialOnly());
-            allReadSubjects.addAll(rootClassification.getUnrestricted());
-        } else {
-            allReadSubjects = new java.util.HashSet<>(
-                    policyEnforcer.getRootResourceReadClassification().getUnrestricted());
-        }
-
         final var newHeaders = DittoHeaders.newBuilder(signal.getDittoHeaders())
-                .readGrantedSubjects(allReadSubjects)
+                .readGrantedSubjects(
+                        policyEnforcer.getReadGrantedSubjectsHeaderValue(eventResourceKey, includePartialReadSubjects))
                 .build();
 
         return signal.setDittoHeaders(newHeaders);

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/AddEffectedReadSubjectsTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/AddEffectedReadSubjectsTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -88,6 +89,25 @@ public final class AddEffectedReadSubjectsTest {
         assertThat(actual).isEqualTo(legacyReadSubjects(policyEnforcer.getEnforcer(), event, false));
         // without partial subjects only root-unrestricted readers (alice) are granted
         assertThat(actual).containsExactly(AuthorizationSubject.newInstance("user:alice"));
+    }
+
+    @Test
+    public void emptyReadGrantsStillRenderAnEmptyArrayHeader() {
+        final Policy writeOnlyPolicy = Policy.newBuilder(POLICY_ID)
+                .setRevision(1L)
+                .setSubjectFor("alice", subject("user:alice"))
+                .setGrantedPermissionsFor("alice", ResourceKey.newInstance("thing", "/"), Permission.WRITE)
+                .build();
+        final PolicyEnforcer policyEnforcer = PolicyEnforcer.of(writeOnlyPolicy);
+
+        final AttributeModified enriched = ThingCommandEnforcement.addEffectedReadSubjectsToThingSignal(
+                attributeModified("x"), policyEnforcer, false);
+
+        // The header must be present and empty rather than absent: downstream readers distinguish
+        // "nobody may read" from "no read-grant information attached".
+        assertThat(enriched.getDittoHeaders())
+                .containsEntry(DittoHeaderDefinition.READ_SUBJECTS.getKey(), "[]");
+        assertThat(enriched.getDittoHeaders().getReadGrantedSubjects()).isEmpty();
     }
 
     /** The exact computation the code performed before the PolicyEnforcer memo was introduced. */

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ClassifyReadSubjectsBenchmark.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ClassifyReadSubjectsBenchmark.java
@@ -96,7 +96,15 @@ public class ClassifyReadSubjectsBenchmark {
         }
     }
 
+    /**
+     * Subject count of a production policy after the authz-format migration, where every human role is granted to
+     * both a tenant-wildcard and a tenant-qualified subject. The rendering cost this benchmark measures scales with
+     * this number, so a two-subject fixture would understate it by an order of magnitude.
+     */
+    private static final int WIDE_SUBJECT_COUNT = 22;
+
     private PolicyEnforcer memoizedEnforcer;
+    private PolicyEnforcer wideEnforcer;
     private PolicyEnforcer boundedEnforcer;
     private Enforcer rawEnforcer;
     private AttributeModified event;
@@ -119,6 +127,18 @@ public class ClassifyReadSubjectsBenchmark {
         memoizedEnforcer = PolicyEnforcer.of(policy);
         boundedEnforcer = PolicyEnforcer.of(policy, 100, BOUNDED_MAX);
         rawEnforcer = PolicyEnforcer.of(policy).getEnforcer();
+
+        // Production-shaped policy: every role granted to both subject variants the authz format emits, with
+        // realistically long subject IDs.
+        final PolicyBuilder wideBuilder = Policy.newBuilder(POLICY_ID).setRevision(1L);
+        for (int i = 0; i < WIDE_SUBJECT_COUNT / 2; i++) {
+            final String role = "ddm-smartheating:grid-operator-" + i;
+            wideBuilder.setSubjectFor("wildcard" + i, subject("dex:authz:###prod:" + role))
+                    .setGrantedPermissionsFor("wildcard" + i, ResourceKey.newInstance("thing", "/"), Permission.READ)
+                    .setSubjectFor("tenant" + i, subject("dex:authz:io.beyonnex#kalo##prod:" + role))
+                    .setGrantedPermissionsFor("tenant" + i, ResourceKey.newInstance("thing", "/"), Permission.READ);
+        }
+        wideEnforcer = PolicyEnforcer.of(wideBuilder.build());
 
         event = AttributeModified.of(THING_ID, JsonPointer.of("x"), JsonValue.of(1), 2L,
                 Instant.now(), DittoHeaders.empty(), null);
@@ -152,14 +172,30 @@ public class ClassifyReadSubjectsBenchmark {
      */
     @Benchmark
     public void endToEndRenderPerEvent(final Blackhole bh) {
-        final SubjectClassification rootClassification = memoizedEnforcer.getRootResourceReadClassification();
+        bh.consume(renderPerEvent(memoizedEnforcer));
+    }
+
+    /** The new path on a production-shaped subject set -- the case the memo actually targets. */
+    @Benchmark
+    public void endToEndMemoizedWideSubjects(final Blackhole bh) {
+        bh.consume(ThingCommandEnforcement.addEffectedReadSubjectsToThingSignal(event, wideEnforcer, true));
+    }
+
+    /** The frozen baseline on the same production-shaped subject set. */
+    @Benchmark
+    public void endToEndRenderPerEventWideSubjects(final Blackhole bh) {
+        bh.consume(renderPerEvent(wideEnforcer));
+    }
+
+    private AttributeModified renderPerEvent(final PolicyEnforcer policyEnforcer) {
+        final SubjectClassification rootClassification = policyEnforcer.getRootResourceReadClassification();
         final Set<AuthorizationSubject> allReadSubjects =
-                new HashSet<>(memoizedEnforcer.classifyReadSubjects(EVENT_KEY).getUnrestricted());
+                new HashSet<>(policyEnforcer.classifyReadSubjects(EVENT_KEY).getUnrestricted());
         allReadSubjects.addAll(rootClassification.getPartialOnly());
         allReadSubjects.addAll(rootClassification.getUnrestricted());
-        bh.consume(event.setDittoHeaders(DittoHeaders.newBuilder(event.getDittoHeaders())
+        return event.setDittoHeaders(DittoHeaders.newBuilder(event.getDittoHeaders())
                 .readGrantedSubjects(allReadSubjects)
-                .build()));
+                .build());
     }
 
     private static Subject subject(final String id) {

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ClassifyReadSubjectsBenchmark.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/ClassifyReadSubjectsBenchmark.java
@@ -13,6 +13,8 @@
 package org.eclipse.ditto.things.service.enforcement;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -28,7 +30,9 @@ import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.policies.model.enforcers.SubjectClassification;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.events.AttributeModified;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -139,6 +143,23 @@ public class ClassifyReadSubjectsBenchmark {
     @Benchmark
     public void endToEndMemoized(final Blackhole bh) {
         bh.consume(ThingCommandEnforcement.addEffectedReadSubjectsToThingSignal(event, memoizedEnforcer, true));
+    }
+
+    /**
+     * Frozen baseline of {@link #endToEndMemoized}: the body the enforcement had before the rendered header value
+     * was memoized on the PolicyEnforcer — merge the classifications into a fresh HashSet and re-serialize the
+     * subject IDs into the header on every event.
+     */
+    @Benchmark
+    public void endToEndRenderPerEvent(final Blackhole bh) {
+        final SubjectClassification rootClassification = memoizedEnforcer.getRootResourceReadClassification();
+        final Set<AuthorizationSubject> allReadSubjects =
+                new HashSet<>(memoizedEnforcer.classifyReadSubjects(EVENT_KEY).getUnrestricted());
+        allReadSubjects.addAll(rootClassification.getPartialOnly());
+        allReadSubjects.addAll(rootClassification.getUnrestricted());
+        bh.consume(event.setDittoHeaders(DittoHeaders.newBuilder(event.getDittoHeaders())
+                .readGrantedSubjects(allReadSubjects)
+                .build()));
     }
 
     private static Subject subject(final String id) {


### PR DESCRIPTION
## What

Removes two per-signal costs around the `ditto-read-subjects` header that scale with the number of READ-granted subjects of a policy: the repeated *parsing* of the header value into `Set<AuthorizationSubject>`, and the repeated *rendering* of that value for every emitted `ThingEvent`.

## Why

After a policy migration that roughly doubled the number of READ-granted subjects per Thing (and lengthened each subject ID), things-service CPU rose by ~25% permanently. A production JFR profile attributed the increase to paths that scale with the read-subject payload rather than with request volume: `DittoHeaders` construction and copies (~17%), enforcer tree walks plus per-event subject-set merging (~10%), and serialization including header-value escaping (~19%).

Both costs are recomputations of something that only changes when the policy does:

- `DittoHeaders#getReadGrantedSubjects()` / `#getReadRevokedSubjects()` allocate N `AuthorizationSubject` instances plus a `HashSet` on *every* call, although the result is a pure function of the immutable header value. On the hot path this happens once per publish and then again on every subscriber node per received message (`ReadSubjectExtractor`), per connection target (`SignalFilter`) and per streaming session (`StreamingSessionActor`) — so the cost is (number of granted subjects) × (local fan-out).
- `ThingCommandEnforcement#addEffectedReadSubjectsToThingSignal` merges the READ classifications into a fresh `HashSet` and re-serializes the subject IDs for every emitted `ThingEvent`. Rendering means allocating a `JsonValue` per subject, building a `JsonArray` (which eagerly builds its CBOR representation) and escaping the whole array into a header string — repeated per event, all of it scaling with the number of granted subjects.

This follows the memoization precedents already in the code base: `Header.parsedValue` and `PolicyEnforcer`'s read-classification memo.

## What changed

**Memoized parsed read-subject sets (`base/model`)**

- `Header` gets a second lazily populated memo slot next to `parsedValue`, and `AbstractDittoHeaders#getAuthorizationSubjectSet` derives the subject set through it. `Header` instances are shared by reference across header copies, so the memo also survives `DittoHeaders.newBuilder(existing).build()`.
- The derived value is built with `Set.copyOf`, not `Collections.unmodifiableSet(new HashSet<>(…))`: the memo field is deliberately non-volatile — the same benign-data-race pattern as `String#hashCode()` — so only final-field freeze semantics (JLS 17.5) keep a racily published set from being observed partially constructed. Both read-subject header keys share a single derivation function, which keeps the untyped memo slot free of type confusion. The constraints are documented on the accessor.
- No new field on `AbstractDittoHeaders`, so the existing `EqualsVerifier` tests stay valid; the memo does not participate in `equals`/`hashCode`.

**Memoized rendered header value (`policies/enforcement`, `things/service`)**

- New `PolicyEnforcer#getReadGrantedSubjectsHeaderValue(ResourceKey, boolean)` performs the merge and the rendering, memoized per resource key alongside the existing read-classification memo and invalidated the same way — `CachingPolicyEnforcerProvider` replaces the instance wholesale on every grant change. The include-partial variant is keyed by resource and bounded by the existing read-classification cache size (entries are 1:1 with classification entries, so no new configuration knob); the root-only variant does not depend on the resource and gets a single slot.
- Subject IDs are sorted and de-duplicated, so the rendered value is stable across nodes and restarts. Consumers parse it back into a `Set`, so ordering is not semantically relevant.
- New `DittoHeadersBuilder#readGrantedSubjects(JsonArray)` lets the enforcement hand the memoized array to the builder without re-rendering or re-parsing it. It keeps the element-type check the parse-based validator would have done, so an invalid value still cannot reach a reader that would fail on `asString()`. Empty arrays are put as `[]`, exactly as the collection variant does. `JsonArray` is not a `Collection`, so there is no overload ambiguity.
- `putJsonValue` now also seeds the new `Header`'s JSON memo with the value it just rendered: that `Header` is fresh per built signal, so otherwise the next reader — typically the pub/sub topic extractor on the very same node — would parse the string straight back into the object already at hand.
- `ThingCommandEnforcement#addEffectedReadSubjectsToThingSignal` keeps its signature, so `LiveSignalEnforcement` and `StreamRequestingCommandEnforcement` benefit unchanged.

## Behavior & compatibility

- The rendered header value is set-equal to the previous one; only element order changes (sorted instead of `HashSet` iteration order). During a rolling upgrade, mixed nodes therefore emit differently ordered values — harmless, since every consumer parses the header into a `Set`.
- The `Set` returned by `getReadGrantedSubjects()` / `getReadRevokedSubjects()` is now unmodifiable and may be a shared instance. The javadoc already stated that changes to it are not reflected back into the headers, and no in-repo caller mutates it. `Set.copyOf` tolerates duplicate subject IDs and collapses them, matching what the previous `Collectors.toSet()` did — nothing on the wire enforces uniqueness, so a test pins that behaviour.
- Only an interface method is added (`METHOD_ADDED_TO_INTERFACE`); japicmp is clean on both `base/model` and `policies/enforcement`. `readGrantedSubjects(null)` written as a bare literal becomes an ambiguous overload at compile time (source-only, no binary impact).
- Memory: the new memo holds at most one small `JsonArray` per cached resource classification, whose strings are already retained by the classification memo.
- New tests cover the memo identity and immutability, survival across header copies, the `JsonArray` builder overload (round-trip, non-string element rejection, empty array, equality with the collection variant), the memoized render formula (sorted, de-duplicated, per-resource, `forNamespace` children independent, empty-grant policy) and the empty-value end-to-end case. The existing JMH benchmarks were extended with a production-shaped policy — 22 granted subjects, realistic ID lengths — because the previous two-subject fixture understates the cost in exactly the dimension that caused the regression.
