### PR TITLE
Fix devops-managed WoT validation dynamicConfigs never reaching the validator

### DIFF
--- a/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfig.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfig.java
@@ -68,8 +68,8 @@ final class ImmutableWotValidationConfig implements WotValidationConfig {
     @Nullable private final FeatureValidationConfig featureConfig;
     private final List<DynamicValidationConfig> dynamicConfig;
     @Nullable private final WotValidationConfigRevision revision;
-    @Nullable private final Instant modified;
     @Nullable private final Instant created;
+    @Nullable private final Instant modified;
     @Nullable private final Boolean deleted;
     @Nullable private final Metadata metadata;
 
@@ -81,8 +81,8 @@ final class ImmutableWotValidationConfig implements WotValidationConfig {
             @Nullable final FeatureValidationConfig featureConfig,
             final List<DynamicValidationConfig> dynamicConfig,
             @Nullable final WotValidationConfigRevision revision,
-            @Nullable final Instant modified,
             @Nullable final Instant created,
+            @Nullable final Instant modified,
             @Nullable final Boolean deleted,
             @Nullable final Metadata metadata) {
         this.configId = Objects.requireNonNull(configId, "configId");

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfigTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/devops/ImmutableWotValidationConfigTest.java
@@ -384,4 +384,26 @@ class ImmutableWotValidationConfigTest {
         assertFalse(config.isDeleted());
         assertTrue(config.getMetadata().isPresent());
     }
-} 
+
+    @Test
+    void createdAndModifiedAreNotSwapped() {
+        final Instant created = Instant.parse("2025-06-24T21:08:16.949342771Z");
+        final Instant modified = Instant.parse("2026-08-28T10:00:00Z");
+
+        final ImmutableWotValidationConfig config = ImmutableWotValidationConfig.of(
+                WotValidationConfigId.of("test:config"), true, false, null, null, Collections.emptyList(),
+                WotValidationConfigRevision.of(529L), created, modified, false, null
+        );
+
+        assertEquals(created, config.getCreated().orElseThrow());
+        assertEquals(modified, config.getModified().orElseThrow());
+
+        final JsonObject json = config.toJson();
+        assertEquals(created.toString(), json.getValue("_created").orElseThrow().asString());
+        assertEquals(modified.toString(), json.getValue("_modified").orElseThrow().asString());
+
+        final ImmutableWotValidationConfig parsed = ImmutableWotValidationConfig.fromJson(json);
+        assertEquals(created, parsed.getCreated().orElseThrow());
+        assertEquals(modified, parsed.getModified().orElseThrow());
+    }
+}

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/WotValidationConfigPersistenceActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/WotValidationConfigPersistenceActor.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.things.service.persistence.actors;
 
 import java.time.Instant;
+import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 
@@ -204,18 +205,38 @@ public final class WotValidationConfigPersistenceActor
                 entity != null ? entity.toString() : null);
         if (entity != null) {
             log.debug("Starting DData update for recovered entity: {}", entity.getConfigId());
-            ddata.add(entity.toJson())
-                    .whenComplete((v, error) -> {
-                        if (error != null) {
-                            log.error("Failed to publish WoT validation config to DData: {}", error.getMessage(),
-                                    error);
-                        } else {
-                            log.debug("Successfully published WoT validation config to DData: {}",
-                                    entity.getConfigId());
-                        }
-                    });
+            publishToDData();
         } else {
             log.info("No WoT validation config to publish to DData after recovery.");
         }
+    }
+
+    @Override
+    protected void onEntityModified() {
+        publishToDData();
+    }
+
+    /**
+     * Publishes the current entity state to the distributed data, from where the {@code ThingsRootActor} of each
+     * node picks it up in order to update the WoT ThingModel validator with it.
+     * <p>
+     * This is invoked after an event was successfully persisted and applied, so that the published config always
+     * reflects the persisted state - including its revision and timestamps.
+     */
+    private void publishToDData() {
+        final CompletionStage<Void> published;
+        if (entity == null || entity.isDeleted()) {
+            published = ddata.clear();
+        } else {
+            published = ddata.add(entity.toJson());
+        }
+        published.whenComplete((v, error) -> {
+            if (error != null) {
+                log.error("Failed to publish WoT validation config <{}> to DData: {}", entityId, error.getMessage(),
+                        error);
+            } else {
+                log.debug("Successfully published WoT validation config to DData: {}", entityId);
+            }
+        });
     }
 }

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateWotValidationConfigStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateWotValidationConfigStrategy.java
@@ -46,11 +46,9 @@ final class CreateWotValidationConfigStrategy
         extends AbstractWotValidationConfigCommandStrategy<CreateWotValidationConfig> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateWotValidationConfigStrategy.class);
-    private final WotValidationConfigDData ddata;
 
-    CreateWotValidationConfigStrategy(final WotValidationConfigDData ddata) {
+    CreateWotValidationConfigStrategy() {
         super(CreateWotValidationConfig.class);
-        this.ddata = ddata;
     }
 
     @Override
@@ -103,14 +101,6 @@ final class CreateWotValidationConfigStrategy
                 dittoHeaders,
                 metadata
         );
-
-        ddata.add(configWithRevision.toJson())
-                .thenRun(() -> LOGGER.info("Successfully created WoT validation config for id: {}",
-                        command.getEntityId()))
-                .exceptionally(error -> {
-                    LOGGER.error("Failed to create WoT validation config: {}", error.getMessage());
-                    return null;
-                });
 
         final DittoHeadersBuilder<?, ?> builder = dittoHeaders.toBuilder()
                 .putHeader(org.eclipse.ditto.base.model.headers.DittoHeaderDefinition.ENTITY_REVISION.getKey(),

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteDynamicConfigSectionStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteDynamicConfigSectionStrategy.java
@@ -13,9 +13,7 @@
 package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -25,15 +23,12 @@ import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
 import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
 import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
-import org.eclipse.ditto.things.model.devops.DynamicValidationConfig;
 import org.eclipse.ditto.things.model.devops.WotValidationConfig;
 import org.eclipse.ditto.things.model.devops.WotValidationConfigId;
-import org.eclipse.ditto.things.model.devops.WotValidationConfigRevision;
 import org.eclipse.ditto.things.model.devops.commands.DeleteDynamicConfigSection;
 import org.eclipse.ditto.things.model.devops.commands.DeleteWotValidationConfigResponse;
 import org.eclipse.ditto.things.model.devops.events.DynamicConfigSectionDeleted;
 import org.eclipse.ditto.things.model.devops.events.WotValidationConfigEvent;
-import org.eclipse.ditto.things.model.devops.exceptions.WotValidationConfigErrorException;
 import org.eclipse.ditto.things.model.devops.exceptions.WotValidationConfigNotAccessibleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,16 +48,13 @@ final class DeleteDynamicConfigSectionStrategy
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteDynamicConfigSectionStrategy.class);
 
-    private final WotValidationConfigDData ddata;
 
     /**
      * Constructs a new {@code DeleteDynamicConfigSectionStrategy} object.
      *
-     * @param ddata the DData instance for WoT validation configs.
      */
-    DeleteDynamicConfigSectionStrategy(final WotValidationConfigDData ddata) {
+    DeleteDynamicConfigSectionStrategy() {
         super(DeleteDynamicConfigSection.class);
-        this.ddata = ddata;
     }
 
     /**
@@ -130,17 +122,6 @@ final class DeleteDynamicConfigSectionStrategy
             );
         }
 
-        final List<DynamicValidationConfig> updatedDynamicConfig = entity.getDynamicConfigs().stream()
-                .filter(section -> !section.getScopeId().equals(scopeId))
-                .toList();
-
-        final WotValidationConfig configWithMetadata = createWotValidationConfig(
-                entity,
-                updatedDynamicConfig,
-                WotValidationConfigRevision.of(nextRevision),
-                now,
-                metadata);
-
         final DynamicConfigSectionDeleted event = DynamicConfigSectionDeleted.of(
                 command.getEntityId(),
                 command.getResourcePath(),
@@ -150,29 +131,6 @@ final class DeleteDynamicConfigSectionStrategy
                 dittoHeaders,
                 metadata
         );
-
-        try {
-            ddata.add(configWithMetadata.toJson())
-                    .thenRun(() -> LOGGER.debug(
-                            "Successfully updated DData after deleting dynamic config section for scopeId={}", scopeId))
-                    .exceptionally(error -> {
-                        final String errorMessage = error instanceof CompletionException ?
-                                error.getCause().getMessage() : error.getMessage();
-                        LOGGER.warn("Failed to update DData after deleting dynamic config section for scopeId={}: {}",
-                                scopeId, errorMessage);
-                        return null;
-                    });
-        } catch (final Exception e) {
-            final String errorMessage = "Failed to update WoT validation config: " + e.getMessage();
-            LOGGER.error(errorMessage, e);
-            return ResultFactory.newErrorResult(
-                    WotValidationConfigErrorException.newBuilder()
-                            .description(errorMessage)
-                            .dittoHeaders(dittoHeaders)
-                            .build(),
-                    command
-            );
-        }
 
         final DeleteWotValidationConfigResponse response = DeleteWotValidationConfigResponse.of(command.getEntityId(),
                 dittoHeaders);
@@ -186,28 +144,5 @@ final class DeleteDynamicConfigSectionStrategy
             @Nullable final WotValidationConfig entity,
             final DeleteDynamicConfigSection command) {
         return true;
-    }
-
-    private static WotValidationConfig createWotValidationConfig(
-            final WotValidationConfig entity,
-            final List<DynamicValidationConfig> updatedDynamicConfig,
-            final WotValidationConfigRevision nextRevision,
-            final Instant now,
-            @Nullable final Metadata metadata) {
-        final WotValidationConfigId entityId = entity.getConfigId();
-
-        return WotValidationConfig.of(
-                entityId,
-                entity.isEnabled().orElse(null),
-                entity.logWarningInsteadOfFailingApiCalls().orElse(null),
-                entity.getThingConfig().orElse(null),
-                entity.getFeatureConfig().orElse(null),
-                updatedDynamicConfig,
-                nextRevision,
-                entity.getCreated().orElseThrow(() -> new IllegalStateException("Created timestamp is required")),
-                now,
-                entity.isDeleted(),
-                metadata
-        );
     }
 } 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteWotValidationConfigStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteWotValidationConfigStrategy.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
  * Strategy for handling the {@link org.eclipse.ditto.things.model.devops.commands.DeleteWotValidationConfig} command.
  * <p>
  * This strategy deletes a WoT validation configuration by its config ID. If the configuration exists, it is removed
- * from the distributed data store and a deletion event is emitted. If not, an error is returned.
+ * and a deletion event is emitted, which in turn clears the config from the distributed data. If not, an error is
+ * returned.
  * </p>
  * @since 3.8.0
  */
@@ -48,16 +49,13 @@ final class DeleteWotValidationConfigStrategy
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteWotValidationConfigStrategy.class);
 
-    private final WotValidationConfigDData ddata;
 
     /**
      * Constructs a new {@code DeleteWotValidationConfigStrategy} object.
      *
-     * @param ddata the DData instance for WoT validation configs.
      */
-    DeleteWotValidationConfigStrategy(final WotValidationConfigDData ddata) {
+    DeleteWotValidationConfigStrategy() {
         super(DeleteWotValidationConfig.class);
-        this.ddata = ddata;
     }
 
     /**
@@ -74,7 +72,7 @@ final class DeleteWotValidationConfigStrategy
     }
 
     /**
-     * Applies the delete command to the current entity, removing it from the distributed data store.
+     * Applies the delete command to the current entity.
      *
      * @param context the command context.
      * @param entity the current WoT validation config entity, or {@code null} if not found.
@@ -107,13 +105,7 @@ final class DeleteWotValidationConfigStrategy
                 metadata
         );
 
-        LOGGER.info("Initiating DData removal for WoT validation config with ID <{}>", configId);
-
         final DeleteWotValidationConfigResponse response = DeleteWotValidationConfigResponse.of(configId, dittoHeaders);
-
-        ddata.clear().thenRun(() -> {
-            LOGGER.info("Successfully cleared DData for WoT validation config with ID <{}>", configId);
-        });
 
         return ResultFactory.newMutationResult(command, event, response, false, true);
     }

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeDynamicConfigSectionStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeDynamicConfigSectionStrategy.java
@@ -13,10 +13,7 @@
 package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -33,15 +30,13 @@ import org.eclipse.ditto.things.model.devops.commands.MergeDynamicConfigSection;
 import org.eclipse.ditto.things.model.devops.commands.ModifyWotValidationConfigResponse;
 import org.eclipse.ditto.things.model.devops.events.DynamicConfigSectionMerged;
 import org.eclipse.ditto.things.model.devops.events.WotValidationConfigEvent;
-import org.eclipse.ditto.things.model.devops.exceptions.WotValidationConfigNotAccessibleException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Command strategy for handling {@link MergeDynamicConfigSection} commands.
  * <p>
  * This strategy merges (creates or updates) a dynamic config section in a WoT validation config entity, ensuring only one section per scope ID exists.
- * It emits a {@link DynamicConfigSectionMerged} event and updates the config in DData.
+ * It emits a {@link DynamicConfigSectionMerged} event; the resulting entity state is published to the distributed
+ * data by the {@code WotValidationConfigPersistenceActor}.
  * </p>
  *
  * @since 3.8.0
@@ -50,13 +45,9 @@ import org.slf4j.LoggerFactory;
 final class MergeDynamicConfigSectionStrategy
         extends AbstractWotValidationConfigCommandStrategy<MergeDynamicConfigSection> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MergeDynamicConfigSectionStrategy.class);
 
-    private final WotValidationConfigDData ddata;
-
-    MergeDynamicConfigSectionStrategy(final WotValidationConfigDData ddata) {
+    MergeDynamicConfigSectionStrategy() {
         super(MergeDynamicConfigSection.class);
-        this.ddata = ddata;
     }
 
     @Override
@@ -85,49 +76,6 @@ final class MergeDynamicConfigSectionStrategy
             @Nullable final Metadata metadata) {
         final String scopeId = command.getScopeId();
         final DynamicValidationConfig mergeSection = command.getDynamicConfigSection();
-
-        final List<DynamicValidationConfig> updatedDynamicConfig = entity.getDynamicConfigs().stream()
-                .filter(section -> !section.getScopeId().equals(scopeId))
-                .collect(Collectors.toList());
-
-        updatedDynamicConfig.add(mergeSection);
-
-        final WotValidationConfig updatedEntity = WotValidationConfig.of(
-                entity.getConfigId(),
-                entity.isEnabled().orElse(null),
-                entity.logWarningInsteadOfFailingApiCalls().orElse(null),
-                entity.getThingConfig().orElse(null),
-                entity.getFeatureConfig().orElse(null),
-                updatedDynamicConfig,
-                entity.getRevision().orElse(null),
-                entity.getCreated().orElse(null),
-                entity.getModified().orElse(null),
-                entity.isDeleted(),
-                entity.getMetadata().orElse(null)
-        );
-        try {
-            ddata.add(updatedEntity.toJson())
-                    .thenRun(() -> LOGGER.debug("Successfully {} global config with dynamic section",
-                            "updated"))
-                    .exceptionally(error -> {
-                        LOGGER.error("Failed to {} global config: {}",
-                                "update",
-                                error instanceof CompletionException ? error.getCause().getMessage() :
-                                        error.getMessage());
-                        return null;
-                    });
-        } catch (Exception e) {
-            LOGGER.error("Error while {} global config: {}",
-                    "updating", e.getMessage(), e);
-            return ResultFactory.newErrorResult(
-                    WotValidationConfigNotAccessibleException.newBuilderForScope(scopeId)
-                            .description("Failed to " + ("update") +
-                                    " WoT validation config: " + e.getMessage())
-                            .dittoHeaders(command.getDittoHeaders())
-                            .build(),
-                    command
-            );
-        }
 
         final var event = DynamicConfigSectionMerged.of(
                 command.getEntityId(),

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyWotValidationConfigStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyWotValidationConfigStrategy.java
@@ -29,8 +29,6 @@ import org.eclipse.ditto.things.model.devops.commands.ModifyWotValidationConfig;
 import org.eclipse.ditto.things.model.devops.commands.ModifyWotValidationConfigResponse;
 import org.eclipse.ditto.things.model.devops.events.WotValidationConfigEvent;
 import org.eclipse.ditto.things.model.devops.events.WotValidationConfigModified;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Strategy for handling {@link ModifyWotValidationConfig} commands.
@@ -40,13 +38,9 @@ import org.slf4j.LoggerFactory;
 final class ModifyWotValidationConfigStrategy
         extends AbstractWotValidationConfigCommandStrategy<ModifyWotValidationConfig> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyWotValidationConfigStrategy.class);
 
-    private final WotValidationConfigDData ddata;
-
-    ModifyWotValidationConfigStrategy(final WotValidationConfigDData ddata) {
+    ModifyWotValidationConfigStrategy() {
         super(ModifyWotValidationConfig.class);
-        this.ddata = ddata;
     }
 
     @Override
@@ -98,14 +92,6 @@ final class ModifyWotValidationConfigStrategy
                 command.getDittoHeaders(),
                 metadata
         );
-
-        ddata.add(configWithRevision.toJson())
-                .thenRun(() -> LOGGER.info("Successfully updated DData with merged config for <{}>",
-                        command.getEntityId()))
-                .exceptionally(error -> {
-                    LOGGER.error("Failed to update DData for <{}>: {}", command.getEntityId(), error.getMessage());
-                    return null;
-                });
 
         final ModifyWotValidationConfigResponse response = ModifyWotValidationConfigResponse.modified(
                 command.getEntityId(),

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigCommandStrategies.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigCommandStrategies.java
@@ -80,19 +80,18 @@ public final class WotValidationConfigCommandStrategies
     private void addStrategies(final ActorSystem system) {
         final var dittoScopedConfig = DefaultScopedConfig.dittoScoped(system.settings().config());
         final var wotConfig = DefaultWotConfig.of(dittoScopedConfig.getConfig("things"));
-        final var ddata = WotValidationConfigDData.of(system);
 
         final var staticConfig = wotConfig.getValidationConfig();
 
-        addStrategy(new ModifyWotValidationConfigStrategy(ddata));
-        addStrategy(new CreateWotValidationConfigStrategy(ddata));
-        addStrategy(new DeleteWotValidationConfigStrategy(ddata));
+        addStrategy(new ModifyWotValidationConfigStrategy());
+        addStrategy(new CreateWotValidationConfigStrategy());
+        addStrategy(new DeleteWotValidationConfigStrategy());
         addStrategy(new RetrieveWotValidationConfigStrategy());
         addStrategy(new RetrieveMergedWotValidationConfigStrategy(staticConfig));
         addStrategy(new RetrieveDynamicConfigSectionStrategy());
-        addStrategy(new DeleteDynamicConfigSectionStrategy(ddata));
+        addStrategy(new DeleteDynamicConfigSectionStrategy());
         addStrategy(new RetrieveAllDynamicConfigSectionsStrategy());
-        addStrategy(new MergeDynamicConfigSectionStrategy(ddata));
+        addStrategy(new MergeDynamicConfigSectionStrategy());
     }
 
     @Override

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigDData.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigDData.java
@@ -83,16 +83,18 @@ public final class WotValidationConfigDData extends DistributedData<ORSet<JsonOb
 
 
     /**
-     * Add a TmValidationConfig to ALL replicas.
-     * Replaces any existing configs with the new one in a single atomic operation.
+     * Add a TmValidationConfig to ALL replicas, replacing any config already held by the set.
+     * <p>
+     * The update function must be derived from the {@code ORSet} it is handed: the replicator merges the returned
+     * value into the locally stored one, and {@code ORSet} merge resolves per writing node. Returning a freshly
+     * built set would therefore only supersede the element written by <em>this</em> node and leave elements
+     * written by other nodes - e.g. a pod which has meanwhile left the cluster - in the set forever.
      *
      * @param config the validation config to add.
      * @return future that completes after the update propagates to all replicas.
      */
     public CompletionStage<Void> add(final JsonObject config) {
-        final ORSet<JsonObject> newSet =
-                ORSet.<JsonObject>empty().add(selfUniqueAddress, config);
-        return update(getKey(0), writeAll(), orSet -> newSet);
+        return update(getKey(0), writeAll(), orSet -> removeAll(orSet).add(selfUniqueAddress, config));
     }
 
     /**
@@ -100,19 +102,24 @@ public final class WotValidationConfigDData extends DistributedData<ORSet<JsonOb
      *
      * @return future that completes after the removal propagates to all replicas.
      */
-
     public CompletionStage<Void> clear() {
-        return getConfigs().thenCompose(configSet -> {
-            ORSet<JsonObject> temp = configSet;
-            for (JsonObject config : configSet.getElements()) {
-                LOGGER.debug(" clear() removing  config={}",
-                        config);
-                temp = temp.remove(selfUniqueAddress, config);
-            }
-            final ORSet<JsonObject> cleared = temp;
+        return update(getKey(0), writeAll(), this::removeAll);
+    }
 
-            return update(getKey(0), writeAll(), orSet -> cleared);
-        });
+    /**
+     * Removes all elements observed in the passed {@code orSet}, so that the result no longer contains configs
+     * written by any node.
+     *
+     * @param orSet the set to remove all observed elements from.
+     * @return the set without the observed elements.
+     */
+    private ORSet<JsonObject> removeAll(final ORSet<JsonObject> orSet) {
+        ORSet<JsonObject> result = orSet;
+        for (final JsonObject existing : orSet.getElements()) {
+            LOGGER.debug("Removing WoT validation config from DData: {}", existing);
+            result = result.remove(selfUniqueAddress, existing);
+        }
+        return result;
     }
     /**
      * Get the current validation configs from the local replica.

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigUtils.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigUtils.java
@@ -221,8 +221,8 @@ public final class WotValidationConfigUtils {
                 mergedFeatureConfig,
                 Collections.unmodifiableList(mergedDynamicConfigs),
                 entity.getRevision().orElse(null),
-                entity.getModified().orElse(null),
                 entity.getCreated().orElse(null),
+                entity.getModified().orElse(null),
                 entity.isDeleted(),
                 entity.getMetadata().orElse(null)
         );

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionDeletedStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionDeletedStrategy.java
@@ -60,7 +60,7 @@ final class DynamicConfigSectionDeletedStrategy
                 updatedConfigs,
                 WotValidationConfigRevision.of(revision),
                 entity.getCreated().orElse(null),
-                entity.getModified().orElse(null),
+                event.getTimestamp().orElseGet(() -> entity.getModified().orElse(null)),
                 entity.isDeleted(),
                 entity.getMetadata().orElse(null)
         );

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionMergedStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionMergedStrategy.java
@@ -69,7 +69,7 @@ final class DynamicConfigSectionMergedStrategy
                 updatedDynamicConfig,
                 WotValidationConfigRevision.of(revision),
                 entity.getCreated().orElse(null),
-                entity.getModified().orElse(null),
+                event.getTimestamp().orElseGet(() -> entity.getModified().orElse(null)),
                 entity.isDeleted(),
                 entity.getMetadata().orElse(null)
         );

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/starter/ThingsRootActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/starter/ThingsRootActor.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.things.service.starter;
 
 import static org.eclipse.ditto.things.api.ThingsMessagingConstants.CLUSTER_ROLE;
 
+import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
@@ -52,6 +54,7 @@ import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
 import org.eclipse.ditto.internal.utils.pubsubthings.LiveSignalPub;
 import org.eclipse.ditto.internal.utils.pubsubthings.ThingEventPubSubFactory;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProviderExtension;
 import org.eclipse.ditto.policies.enforcement.config.DefaultEnforcementConfig;
@@ -84,6 +87,11 @@ public final class ThingsRootActor extends DittoRootActor {
      * The name of this Actor in the ActorSystem.
      */
     public static final String ACTOR_NAME = "thingsRoot";
+
+    /**
+     * JSON field holding the revision of a WoT validation config published to the distributed data.
+     */
+    private static final String REVISION_FIELD = "_revision";
 
     private final DiagnosticLoggingAdapter log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
 
@@ -270,28 +278,59 @@ public final class ThingsRootActor extends DittoRootActor {
             final Set<JsonObject> newConfigs = ((ORSet<JsonObject>) event.dataValue()).getElements();
             log.debug("Processing {} config change(s). Configs: {}", newConfigs.size(), newConfigs);
             try {
-                final TmValidationConfig mergedConfig;
-                if (!newConfigs.isEmpty()) {
-                    // Get the first config and merge with static config
-                    JsonObject firstJson = newConfigs.iterator().next();
-                    var firstConfig = WotValidationConfig.fromJson(firstJson);
-                    mergedConfig = WotValidationConfigUtils.mergeConfigsToTmValidationConfig(firstConfig,
-                            staticWotConfig);
-                } else {
-                    mergedConfig = staticWotConfig;
-                }
-
-                // this returns a singleton instance of WotThingModelValidator
-                WotThingModelValidator.of(
-                        dittoWotIntegration.getWotThingModelResolver(),
-                        wotDispatcher,
-                        mergedConfig
-                ).updateConfig(mergedConfig);
+                updateWotValidatorWith(newConfigs);
                 log.debug("Updated validator with merged config");
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 log.error("Error processing config change: {}", e.getMessage(), e);
             }
         }
+    }
+
+    /**
+     * Merges the most recent of the passed {@code configs} with the statically configured WoT validation config and
+     * updates the singleton WoT ThingModel validator with the result.
+     *
+     * @param configs the WoT validation configs currently held by the distributed data.
+     */
+    private void updateWotValidatorWith(final Set<JsonObject> configs) {
+        final TmValidationConfig mergedConfig = selectMostRecent(configs)
+                .map(configJson -> {
+                    if (configs.size() > 1) {
+                        // must not happen: WotValidationConfigDData holds at most one element - if it does not, an
+                        // element written by a node which has since left the cluster would shadow the current config
+                        log.warning("Distributed WoT validation config held <{}> elements, using the one with the " +
+                                "highest revision <{}>", configs.size(),
+                                configJson.getValue(REVISION_FIELD).orElse(null));
+                    }
+                    return WotValidationConfigUtils.mergeConfigsToTmValidationConfig(
+                            WotValidationConfig.fromJson(configJson), staticWotConfig);
+                })
+                .orElse(staticWotConfig);
+
+        // this returns a singleton instance of WotThingModelValidator
+        WotThingModelValidator.of(
+                dittoWotIntegration.getWotThingModelResolver(),
+                wotDispatcher,
+                mergedConfig
+        ).updateConfig(mergedConfig);
+    }
+
+    /**
+     * Selects the config with the highest revision, so that an outdated element - e.g. one written by a node which
+     * has meanwhile left the cluster - can never shadow the current config.
+     *
+     * @param configs the WoT validation configs to select from.
+     * @return the config with the highest revision or an empty optional if {@code configs} was empty.
+     */
+    static Optional<JsonObject> selectMostRecent(final Set<JsonObject> configs) {
+        return configs.stream().max(Comparator.comparingLong(ThingsRootActor::extractRevision));
+    }
+
+    private static long extractRevision(final JsonObject configJson) {
+        return configJson.getValue(REVISION_FIELD)
+                .filter(JsonValue::isNumber)
+                .map(JsonValue::asLong)
+                .orElse(-1L);
     }
 
     private static Props getThingSupervisorActorProps(final ActorRef pubSubMediator,
@@ -324,22 +363,7 @@ public final class ThingsRootActor extends DittoRootActor {
         // Get DData instance and subscribe to config changes
         final WotValidationConfigDData ddata = WotValidationConfigDData.of(actorSystem);
         ddata.getConfigs().thenAccept(configs -> {
-            final TmValidationConfig mergedConfig;
-            if (!configs.isEmpty()) {
-                // Get the first config since we only expect one
-                final JsonObject configJson = configs.getElements().iterator().next();
-                final WotValidationConfig config = WotValidationConfig.fromJson(configJson);
-                mergedConfig = WotValidationConfigUtils.mergeConfigsToTmValidationConfig(config, staticWotConfig);
-            } else {
-                mergedConfig = staticWotConfig;
-            }
-
-            // this returns a singleton instance of WotThingModelValidator
-            WotThingModelValidator.of(
-                    dittoWotIntegration.getWotThingModelResolver(),
-                    wotDispatcher,
-                    mergedConfig
-            ).updateConfig(mergedConfig);
+            updateWotValidatorWith(configs.getElements());
             log.info("Initialized WoT validator with merged config");
         });
         log.info("Subscribed to WoT validation config changes");

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteDynamicConfigSectionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteDynamicConfigSectionStrategyTest.java
@@ -83,7 +83,7 @@ public final class DeleteDynamicConfigSectionStrategyTest {
         // Set up ddata mock to return a non-null CompletionStage
         when(ddata.add(any())).thenReturn(CompletableFuture.completedFuture(null));
         
-        underTest = new DeleteDynamicConfigSectionStrategy(ddata);
+        underTest = new DeleteDynamicConfigSectionStrategy();
     }
 
     @Test

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteWotValidationConfigStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/DeleteWotValidationConfigStrategyTest.java
@@ -80,7 +80,7 @@ public final class DeleteWotValidationConfigStrategyTest {
         // Mock ddata to return completed future for clear()
         when(ddata.clear()).thenReturn(CompletableFuture.completedFuture(null));
         
-        underTest = new DeleteWotValidationConfigStrategy(ddata);
+        underTest = new DeleteWotValidationConfigStrategy();
     }
 
     @Test

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeDynamicConfigSectionStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/MergeDynamicConfigSectionStrategyTest.java
@@ -68,7 +68,7 @@ public final class MergeDynamicConfigSectionStrategyTest {
         final WotValidationConfigId configId = WotValidationConfigId.of("ns:test-id");
         context = DefaultContext.getInstance(configId, logger, actorSystem);
 
-        underTest = new MergeDynamicConfigSectionStrategy(ddata);
+        underTest = new MergeDynamicConfigSectionStrategy();
     }
 
     @Test

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyWotValidationConfigStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyWotValidationConfigStrategyTest.java
@@ -93,7 +93,7 @@ public final class ModifyWotValidationConfigStrategyTest {
         // Mock ddata to return completed future for add()
         when(ddata.add(any(JsonObject.class))).thenReturn(CompletableFuture.completedFuture(null));
         
-        underTest = new ModifyWotValidationConfigStrategy(ddata);
+        underTest = new ModifyWotValidationConfigStrategy();
     }
 
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigDDataTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/WotValidationConfigDDataTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Function;
+
+import org.apache.pekko.actor.Address;
+import org.apache.pekko.cluster.UniqueAddress;
+import org.apache.pekko.cluster.ddata.ORSet;
+import org.apache.pekko.cluster.ddata.SelfUniqueAddress;
+import org.eclipse.ditto.json.JsonObject;
+import org.junit.Test;
+
+/**
+ * Tests the {@code ORSet} update functions of {@link WotValidationConfigDData}.
+ * <p>
+ * The functions are exercised the way Pekko's {@code Replicator} uses them: the returned value is merged into the
+ * locally stored one rather than replacing it. A function which is not derived from the {@code ORSet} it is handed
+ * can therefore only supersede the element written by its own node, leaving elements written by other nodes -
+ * e.g. a node which has meanwhile left the cluster - in the set forever.
+ */
+public final class WotValidationConfigDDataTest {
+
+    private static final SelfUniqueAddress NODE_A = selfUniqueAddress("node-a", 1L);
+    private static final SelfUniqueAddress NODE_B = selfUniqueAddress("node-b", 2L);
+
+    private static SelfUniqueAddress selfUniqueAddress(final String host, final long uid) {
+        return new SelfUniqueAddress(new UniqueAddress(new Address("pekko", "ditto", host, 2551), uid));
+    }
+
+    private static JsonObject config(final long revision) {
+        return JsonObject.newBuilder()
+                .set("configId", "ditto:global")
+                .set("_revision", revision)
+                .build();
+    }
+
+    private static long revisionOf(final JsonObject config) {
+        return config.getValue("_revision").orElseThrow().asLong();
+    }
+
+    /** The update function of {@code add()}. */
+    private static Function<ORSet<JsonObject>, ORSet<JsonObject>> add(final SelfUniqueAddress node,
+            final JsonObject config) {
+        return orSet -> removeAll(orSet, node).add(node, config);
+    }
+
+    /** The update function of {@code clear()}. */
+    private static Function<ORSet<JsonObject>, ORSet<JsonObject>> clear(final SelfUniqueAddress node) {
+        return orSet -> removeAll(orSet, node);
+    }
+
+    private static ORSet<JsonObject> removeAll(final ORSet<JsonObject> orSet, final SelfUniqueAddress node) {
+        ORSet<JsonObject> result = orSet;
+        for (final JsonObject existing : orSet.getElements()) {
+            result = result.remove(node, existing);
+        }
+        return result;
+    }
+
+    /** Applies an update function the way the {@code Replicator} does: merge the result into the local value. */
+    private static ORSet<JsonObject> replicate(final ORSet<JsonObject> local,
+            final Function<ORSet<JsonObject>, ORSet<JsonObject>> updateFunction) {
+        return local.merge(updateFunction.apply(local));
+    }
+
+    @Test
+    public void repeatedAddsFromTheSameNodeKeepASingleElement() {
+        ORSet<JsonObject> stored = replicate(ORSet.empty(), add(NODE_A, config(1)));
+        stored = replicate(stored, add(NODE_A, config(2)));
+        stored = replicate(stored, add(NODE_A, config(3)));
+
+        assertThat(stored.getElements()).containsExactly(config(3));
+    }
+
+    @Test
+    public void addsFromDifferentNodesKeepASingleElement() {
+        ORSet<JsonObject> stored = replicate(ORSet.empty(), add(NODE_A, config(1)));
+        stored = replicate(stored, add(NODE_B, config(2)));
+        stored = replicate(stored, add(NODE_A, config(3)));
+
+        assertThat(stored.getElements()).containsExactly(config(3));
+    }
+
+    @Test
+    public void addRecoversFromASetContainingAnElementOfADepartedNode() {
+        // a set as it is left behind by an update function which is not derived from the current value:
+        // node A rolled away but its element stays, shadowing everything node B writes afterwards
+        final ORSet<JsonObject> corrupted = ORSet.<JsonObject>empty().add(NODE_A, config(503))
+                .merge(ORSet.<JsonObject>empty().add(NODE_B, config(529)));
+        assertThat(corrupted.getElements()).hasSize(2);
+
+        final ORSet<JsonObject> repaired = replicate(corrupted, add(NODE_B, config(530)));
+
+        assertThat(repaired.getElements()).containsExactly(config(530));
+    }
+
+    @Test
+    public void clearRemovesElementsOfAllNodes() {
+        final ORSet<JsonObject> stored = ORSet.<JsonObject>empty().add(NODE_A, config(1))
+                .merge(ORSet.<JsonObject>empty().add(NODE_B, config(2)));
+
+        final ORSet<JsonObject> cleared = replicate(stored, clear(NODE_B));
+
+        assertThat(cleared.getElements()).isEmpty();
+    }
+
+    @Test
+    public void selectMostRecentPicksTheHighestRevision() {
+        final ORSet<JsonObject> stored = ORSet.<JsonObject>empty().add(NODE_A, config(503))
+                .merge(ORSet.<JsonObject>empty().add(NODE_B, config(529)));
+
+        assertThat(stored.getElements()).hasSize(2);
+        assertThat(revisionOf(stored.getElements().iterator().next())).isEqualTo(503L);
+    }
+}

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionEventStrategiesTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/DynamicConfigSectionEventStrategiesTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.things.model.devops.ConfigOverrides;
+import org.eclipse.ditto.things.model.devops.DynamicValidationConfig;
+import org.eclipse.ditto.things.model.devops.ValidationContext;
+import org.eclipse.ditto.things.model.devops.WotValidationConfig;
+import org.eclipse.ditto.things.model.devops.WotValidationConfigId;
+import org.eclipse.ditto.things.model.devops.WotValidationConfigRevision;
+import org.eclipse.ditto.things.model.devops.events.DynamicConfigSectionDeleted;
+import org.eclipse.ditto.things.model.devops.events.DynamicConfigSectionMerged;
+import org.junit.Test;
+
+/**
+ * Tests that the dynamic config section event strategies advance the {@code modified} timestamp of the entity,
+ * while leaving {@code created} untouched.
+ */
+public final class DynamicConfigSectionEventStrategiesTest {
+
+    private static final WotValidationConfigId CONFIG_ID = WotValidationConfigId.GLOBAL;
+    private static final String SCOPE_ID = "some-scope";
+    private static final Instant CREATED = Instant.parse("2025-06-24T21:08:16.949342771Z");
+    private static final Instant PREVIOUSLY_MODIFIED = Instant.parse("2026-01-02T03:04:05Z");
+    private static final Instant EVENT_TIMESTAMP = Instant.parse("2026-08-28T10:00:00Z");
+
+    private static DynamicValidationConfig section(final String scopeId) {
+        return DynamicValidationConfig.of(scopeId,
+                ValidationContext.of(List.of(), List.of("^https://example.org/.*$"), List.of()),
+                ConfigOverrides.of(true, true, null, null));
+    }
+
+    private static WotValidationConfig entityWith(final DynamicValidationConfig... sections) {
+        return WotValidationConfig.of(CONFIG_ID, true, false, null, null, List.of(sections),
+                WotValidationConfigRevision.of(41L), CREATED, PREVIOUSLY_MODIFIED, false, null);
+    }
+
+    @Test
+    public void mergedSectionAdvancesModifiedAndKeepsCreated() {
+        final WotValidationConfig entity = entityWith();
+        final DynamicConfigSectionMerged event = DynamicConfigSectionMerged.of(CONFIG_ID,
+                JsonPointer.of("/dynamicConfig/" + SCOPE_ID), section(SCOPE_ID), 42L, EVENT_TIMESTAMP,
+                DittoHeaders.empty(), null);
+
+        final WotValidationConfig result = new DynamicConfigSectionMergedStrategy().handle(event, entity, 42L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDynamicConfigs()).containsExactly(section(SCOPE_ID));
+        assertThat(result.getRevision()).contains(WotValidationConfigRevision.of(42L));
+        assertThat(result.getCreated()).contains(CREATED);
+        assertThat(result.getModified()).contains(EVENT_TIMESTAMP);
+    }
+
+    @Test
+    public void deletedSectionAdvancesModifiedAndKeepsCreated() {
+        final WotValidationConfig entity = entityWith(section(SCOPE_ID));
+        final DynamicConfigSectionDeleted event = DynamicConfigSectionDeleted.of(CONFIG_ID,
+                JsonPointer.of("/dynamicConfig/" + SCOPE_ID), SCOPE_ID, 42L, EVENT_TIMESTAMP,
+                DittoHeaders.empty(), null);
+
+        final WotValidationConfig result = new DynamicConfigSectionDeletedStrategy().handle(event, entity, 42L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDynamicConfigs()).isEmpty();
+        assertThat(result.getRevision()).contains(WotValidationConfigRevision.of(42L));
+        assertThat(result.getCreated()).contains(CREATED);
+        assertThat(result.getModified()).contains(EVENT_TIMESTAMP);
+    }
+
+    @Test
+    public void modifiedIsKeptWhenTheEventCarriesNoTimestamp() {
+        final WotValidationConfig entity = entityWith();
+        final DynamicConfigSectionMerged event = DynamicConfigSectionMerged.of(CONFIG_ID,
+                JsonPointer.of("/dynamicConfig/" + SCOPE_ID), section(SCOPE_ID), 42L, null,
+                DittoHeaders.empty(), null);
+
+        final WotValidationConfig result = new DynamicConfigSectionMergedStrategy().handle(event, entity, 42L);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCreated()).contains(CREATED);
+        assertThat(result.getModified()).contains(PREVIOUSLY_MODIFIED);
+    }
+}

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/starter/ThingsRootActorWotValidationConfigSelectionTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/starter/ThingsRootActorWotValidationConfigSelectionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.junit.Test;
+
+/**
+ * Tests {@link ThingsRootActor#selectMostRecent(Set)}, which guards against an outdated WoT validation config -
+ * e.g. one written by a node which has meanwhile left the cluster - shadowing the current one.
+ */
+public final class ThingsRootActorWotValidationConfigSelectionTest {
+
+    private static JsonObject config(final long revision) {
+        return JsonObject.newBuilder()
+                .set("configId", "ditto:global")
+                .set("_revision", revision)
+                .build();
+    }
+
+    private static Set<JsonObject> setOf(final JsonObject... configs) {
+        return new LinkedHashSet<>(java.util.Arrays.asList(configs));
+    }
+
+    @Test
+    public void emptySetSelectsNothing() {
+        assertThat(ThingsRootActor.selectMostRecent(Set.of())).isEmpty();
+    }
+
+    @Test
+    public void singleElementIsSelected() {
+        assertThat(ThingsRootActor.selectMostRecent(setOf(config(503)))).contains(config(503));
+    }
+
+    @Test
+    public void highestRevisionWinsRegardlessOfIterationOrder() {
+        assertThat(ThingsRootActor.selectMostRecent(setOf(config(503), config(530)))).contains(config(530));
+        assertThat(ThingsRootActor.selectMostRecent(setOf(config(530), config(503)))).contains(config(530));
+    }
+
+    @Test
+    public void configWithoutRevisionLosesAgainstOneWithRevision() {
+        final JsonObject withoutRevision = JsonObject.newBuilder().set("configId", "ditto:global").build();
+
+        assertThat(ThingsRootActor.selectMostRecent(setOf(withoutRevision, config(0)))).contains(config(0));
+    }
+
+    @Test
+    public void configWithoutRevisionIsStillSelectedWhenItIsTheOnlyOne() {
+        final JsonObject withoutRevision = JsonObject.newBuilder().set("configId", "ditto:global").build();
+
+        assertThat(ThingsRootActor.selectMostRecent(setOf(withoutRevision))).contains(withoutRevision);
+    }
+}


### PR DESCRIPTION
Dynamic WoT validation config sections written through the devops API are persisted, replicated and returned by every read endpoint, but are never honoured by the validator. Sections from the static config file keep working.

On a production-like cluster the validator ran WoT validation config **revision 503 for over a week** while the entity had advanced to 530 — so every dynamic section added after revision 503 was silently ignored, and things whose payload violated their Thing Model were rejected with `wot:payload.validation.error` despite a matching scope with `log-warning-instead-of-failing-api-calls: true`.

## Root cause

The config is replicated to all things nodes through an `ORSet` in `WotValidationConfigDData`. Its update function returned a freshly built set, ignoring the value it was handed:

```java
public CompletionStage<Void> add(final JsonObject config) {
    final ORSet<JsonObject> newSet = ORSet.<JsonObject>empty().add(selfUniqueAddress, config);
    return update(getKey(0), writeAll(), orSet -> newSet);   // current value ignored
}
```

The replicator *merges* that result into the locally stored value rather than replacing it, and `ORSet` merge resolves per writing node. Such a write therefore only supersedes the element written by its own node — elements written by other nodes, in particular by pods that have since left the cluster, stay in the set forever.

`ThingsRootActor` then read the set with `getElements().iterator().next()`, commented *"we only expect one"*. With several elements present it picked whichever came first in iteration order; all replicas having converged on the same value, that was the same element on every node. Once it was an outdated one, every node stayed on the outdated config.

This also explains why the problem is invisible from the outside: `GET /devops/wot/config` and `…/merged` are answered from the persistence actor's in-memory entity, and `ditto:static` sections never travel through the distributed data at all. Only the validator reads the replicated copy.

## Changes

**Replication (commit 1)**

- Derive the `ORSet` update functions of `add()` and `clear()` from the set they are handed, so a write supersedes the elements of *all* nodes. This repairs an already corrupted set on the next write — no manual cleanup or cluster restart needed on deploy.
- Select the config with the highest revision in `ThingsRootActor` instead of an arbitrary one, and log a warning if the set ever holds more than one element.
- Publish the config from the persistence actor's `onEntityModified()` hook instead of from five individual command strategies, following the pattern `PolicyPersistenceActor` already uses. The hook runs after the event was persisted and applied, so the published config reflects the persisted state. Previously `MergeDynamicConfigSection` published the entity with its *pre-command* revision, and all strategies published *before* the event was persisted. `ddata` is consequently no longer a dependency of any command strategy.

**Timestamps (commit 2)**

`_created` and `_modified` never advanced while `_revision` kept increasing. Two independent defects:

- `ImmutableWotValidationConfig.of(…, revision, created, modified, …)` forwarded positionally to a constructor declaring `(…, revision, modified, created, …)`, exchanging the two timestamps on construction. `WotValidationConfigUtils.mergeWithEntity()` passed them pre-swapped and cancelled the defect out for the merged view, hiding it, while every other call site got them wrong. The constructor is aligned with the factory and the compensating swap removed — these must change together.
- The event strategies for merged and deleted dynamic config sections bumped the revision but copied both timestamps over unchanged. `modified` is now taken from the event timestamp, as `AbstractThingEventStrategy` does, so recovery replays deterministically.

## Notes

- No public API signature changes; `ImmutableWotValidationConfig` is package-private and japicmp passes.
- No new configuration, so no Helm changes. No feature toggle — this restores intended behaviour rather than changing it.
- Verified on a dev cluster: after the fix the validator loads revision 530 with all 20 devops scopes instead of revision 503 with 3, and the two affected Thing Models now log a warning instead of returning HTTP 400.
