### PR TITLE
Backport #2478: mount the Swagger UI OIDC JS in the Helm chart

### DIFF
--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -15,6 +15,12 @@ sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
 ## [Unreleased]
 
+### Fixed
+- Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
+  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478)). This was
+  previously listed under `4.3.0`, but the change had not actually been part of the release branch — see the
+  corrected note there
+
 ## [4.6.0]
 
 Bumped Ditto `appVersion` to `3.9.6`.
@@ -72,8 +78,12 @@ Bumped Ditto `appVersion` to `3.9.3`.
   ([#2480](https://github.com/eclipse-ditto/ditto/pull/2480))
 
 ### Fixed
-- Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
-  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478))
+- ~~Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
+  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478))~~
+  **Correction:** this entry was premature. [#2478](https://github.com/eclipse-ditto/ditto/pull/2478) was
+  merged to `master` before `4.3.0` was cut, but was never cherry-picked to the release branch, so the mount
+  is **not** contained in chart versions `4.3.0` through `4.6.0`. It ships with the next chart release; see
+  `[Unreleased]`
 
 ## [4.2.0]
 

--- a/deployment/helm/ditto/templates/swaggerui-deployment.yaml
+++ b/deployment/helm/ditto/templates/swaggerui-deployment.yaml
@@ -130,10 +130,16 @@ spec:
             - name: swaggerui-index
               mountPath: /usr/share/nginx/html/index.html
               subPath: index.html
+            - name: swaggerui-oidc
+              mountPath: /usr/share/nginx/html/swagger-oidc.js
+              subPath: swagger-oidc.js
       volumes:
         - name: swagger-ui-init-config
           emptyDir: {}
         - name: swaggerui-index
           configMap:
             name: {{ .Release.Name }}-swaggerui-config-index-html
+        - name: swaggerui-oidc
+          configMap:
+            name: {{ .Release.Name }}-swaggerui-config-swagger-oidc-js
 {{- end }}


### PR DESCRIPTION
Backports [#2478](https://github.com/eclipse-ditto/ditto/pull/2478) to `release-3.9`, where it was missed.

### What went wrong

#2478 (`168b480011`) was merged to `master` on 2026-06-29 and never cherry-picked to `release-3.9`. It is therefore absent from every chart published since:

| tag   | chart | contains the OIDC mount? |
| ----- | ----- | ------------------------ |
| 3.9.3 | 4.3.0 | no                       |
| 3.9.4 | 4.4.0 | no                       |
| 3.9.5 | 4.5.0 | no                       |
| 3.9.6 | 4.6.0 | no                       |

The omission was masked because the 3.9.3 release-notes commit *documented* the fix as shipped, in both `deployment/helm/ditto/CHANGELOG.md` (`## [4.3.0]` → Fixed) and `release_notes_393.md`. That commit was authored on `master` (`8ebfbf73e3`), where #2478 was present, then cherry-picked to `release-3.9` where the template change was not — so the claim travelled without the code.

The chart-version trail shows the same gap:

- `master`: `4.2.0` → **`4.2.1` (#2478)** → `4.2.2` (#2480) → `4.3.0`
- `release-3.9`: `4.2.0` → `4.3.0`

Neither intermediate bump was mirrored, so cherry-picking `8ebfbf73e3` must have conflicted on `Chart.yaml` (pre-image `4.2.2` onto a `4.2.0` base). That conflict was the available signal.

### Impact

Not cosmetic. On `release-3.9` the ConfigMap *is* rendered — `templates/swaggerui-config.yaml` globs `swaggerui-config/**`, which includes `swagger-oidc.js` — but it was never mounted into `/usr/share/nginx/html/`. Meanwhile `swaggerui-config/index.html:66` does `<script src="./swagger-oidc.js">`. So on every released chart from 4.3.0 to 4.6.0 that script 404s and Swagger UI OIDC login is broken.

`master` is unaffected (chart 4.6.2 has the mount), so the 3.10 line is fine.

### Changes

- `22672ba309` — cherry-pick of `168b480011`, original authorship preserved. The commit's `Chart.yaml` bump (`4.2.0` → `4.2.1`) is dropped as obsolete; `release-3.9` is at `4.6.0`.
- `f27b0fb4fe` — strike the premature `4.3.0` CHANGELOG entry with a correction naming the affected chart versions, and list the fix under `[Unreleased]`.

`Chart.yaml` is deliberately left at `4.6.0`: patch versions staged between releases are never published (`4.3.1` on this branch, `4.6.1`/`4.6.2` on `master`), and `4.6.1` is already taken by an unrelated staged change on `master`. The fix picks up its version when the release job cuts the next chart release.

### Verification

- `swaggerui-deployment.yaml` on this branch is byte-identical to `master`'s.
- `helm lint` clean.
- `helm template --set swaggerui.enabled=true` renders ConfigMap `ditto-swaggerui-config-swagger-oidc-js` and a deployment volume referencing exactly that name, mounted at `/usr/share/nginx/html/swagger-oidc.js`.
