### PR TITLE
Correct the chart CHANGELOG entry claiming #2478 shipped in 4.3.0

### DIFF
--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -15,6 +15,12 @@ sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
 ## [Unreleased]
 
+### Fixed
+- Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
+  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478)). This was
+  previously listed under `4.3.0`, but the change had not actually been part of the release branch — see the
+  corrected note there
+
 ## [4.6.0]
 
 Bumped Ditto `appVersion` to `3.9.6`.
@@ -72,8 +78,12 @@ Bumped Ditto `appVersion` to `3.9.3`.
   ([#2480](https://github.com/eclipse-ditto/ditto/pull/2480))
 
 ### Fixed
-- Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
-  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478))
+- ~~Swagger UI deployment: add the volumes and `volumeMounts` required to mount the OpenID Connect JavaScript,
+  fixing the Swagger UI OIDC login ([#2478](https://github.com/eclipse-ditto/ditto/pull/2478))~~
+  **Correction:** this entry was premature. [#2478](https://github.com/eclipse-ditto/ditto/pull/2478) was
+  merged to `master` before `4.3.0` was cut, but was never cherry-picked to the release branch, so the mount
+  is **not** contained in chart versions `4.3.0` through `4.6.0`. It ships with the next chart release; see
+  `[Unreleased]`
 
 ## [4.2.0]
 


### PR DESCRIPTION
Master-side counterpart to #2533 (the `release-3.9` backport of [#2478](https://github.com/eclipse-ditto/ditto/pull/2478)). CHANGELOG-only; no template or `Chart.yaml` change.

### Why master needs this too

The `## [4.3.0]` section claims the #2478 Swagger UI OIDC JS mount shipped in chart 4.3.0. It did not. #2478 was merged to `master` on 2026-06-29, before 4.3.0 was cut, but was never cherry-picked to `release-3.9` — the branch the release job publishes charts from. The mount is absent from published charts 4.3.0 (3.9.3), 4.4.0 (3.9.4), 4.5.0 (3.9.5) and 4.6.0 (3.9.6).

That entry was written **here, on master**, where #2478 was present, and then cherry-picked to `release-3.9` where it was not — carrying the claim across without the change itself. Since the CHANGELOG documents *published* chart versions, the claim is equally wrong in master's copy of the file, which is byte-identical to the release branch's.

### Changes

- Strike the `4.3.0` entry with a correction naming the affected chart versions.
- List the fix under `[Unreleased]`: the template change has been in this tree since 2026-06-29 but has never been part of a published chart.

Wording is kept identical to #2533 so the two copies of the file stay byte-identical and the sections remain conflict-free on future cherry-picks.

### Out of scope

- `Chart.yaml` is untouched (stays at the staged `4.6.2`).
- `release_notes_393.md:62` carries the same claim. Left alone deliberately — release notes are a historical announcement, the chart CHANGELOG is the operative upgrade reference. Happy to annotate it if reviewers prefer.
- Chart `4.6.1` (`6f467d6140`, operator-metrics MongoDB read preference/concern `values.yaml` additions) is staged on master but undocumented in the CHANGELOG. Pre-existing and unrelated, so not addressed here.
