### PR TITLE
Fix nightly Docker build: build allinone jars in the workflow

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -64,10 +64,33 @@ jobs:
         run: |
           echo $IMAGE_TAG
       -
+        name: Set up JDK 25
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          cache: 'maven'
+      -
+        name: Build allinone jars from sources
+        # The *-allinone.jar artifacts are no longer published to a Maven repository (they
+        # exceed the repo.eclipse.org upload size limit). Build them here from the master
+        # sources so the Docker image build can consume them from the local context.
+        # The version stays at the master 'revision' default: 0-SNAPSHOT.
+        run: |
+          mvn clean install -T4 --batch-mode --errors -DskipTests -Dmaven.javadoc.skip=true \
+            -pl policies/service,things/service,gateway/service,connectivity/service,thingsearch/service -am
+      -
+        name: Stage allinone jars for the Docker build context
+        run: |
+          mkdir -p docker-libs
+          find . -path '*/service/target/*-allinone.jar' -exec cp -v {} docker-libs/ \;
+          echo "Staged allinone jars:"
+          ls -lh docker-libs
+      -
         name: Build and push ditto-policies
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -82,7 +105,7 @@ jobs:
         name: Build and push ditto-things
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -97,7 +120,7 @@ jobs:
         name: Build and push ditto-gateway
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -112,7 +135,7 @@ jobs:
         name: Build and push ditto-thingsearch
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -127,7 +150,7 @@ jobs:
         name: Build and push ditto-connectivity
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: .
+          context: docker-libs
           file: dockerfile-release
           platforms: linux/amd64,linux/arm64
           build-args: |


### PR DESCRIPTION
The scheduled `push-dockerhub-nightly` job has failed every night since 2026-07-29, e.g. [run 33459208059](https://github.com/eclipse-ditto/ditto/actions/runs/33459208059/job/99705606549):

```
buildx failed with: ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/ditto-policies-service-0-SNAPSHOT-allinone.jar": not found
```

### Cause

c6b1ec313a moved the `*-allinone.jar` creation into GitHub Actions and changed `dockerfile-release` to `COPY` the jar from the Docker build context instead of `curl`ing it from a Maven repository. That commit adapted `push-dockerhub.yml` and `push-dockerhub-on-demand.yml`, but not `docker-nightly.yml` — which also builds from `dockerfile-release`, yet never runs Maven and still passed `context: .`. So the jar is simply not in the context.

### Fix

Mirror the release workflow in `docker-nightly.yml`:

- set up JDK 25 (temurin, Maven cache),
- build the five service allinone jars from the `master` sources — the version stays at the `revision` default `0-SNAPSHOT`, matching the `SERVICE_VERSION` build-arg already used there,
- stage them into `docker-libs/`,
- point the five service image builds at `context: docker-libs`.

The `ditto-ui` image build is unaffected (`context: ./ui`).

### Side note

The nightly images were arguably already broken before c6b1ec313a. The old `dockerfile-release` fetched the jar from `MAVEN_REPO`, which defaulted to the **releases** repository, and the nightly never overrode it — so requesting `0-SNAPSHOT` there returns 404 (still reproducible today). As the `curl` had no `-f`, the 404 body was written into the file named `*-allinone.jar` and the build exited 0, publishing `eclipse/ditto-*:nightly` images without a usable jar. Building from sources removes that class of silent failure.

Worth watching on the first green run: the Trivy `CRITICAL` scan steps have not actually scanned a real fat jar in a long time, so they may now surface findings and fail the job.