### PR TITLE
Harden host validation of connection targets

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/DefaultHostValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/DefaultHostValidator.java
@@ -12,9 +12,11 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.validation;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -24,8 +26,8 @@ import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.apache.pekko.event.LoggingAdapter;
 
 /**
- * Validates a given hostname against a set of fixed blocked addresses (e.g. loopback, multicast, ...), a set of
- * blocked/allowed hostnames and a set of blocked subnets from configuration.
+ * Validates a given hostname against a set of fixed blocked addresses (e.g. loopback, link-local, multicast, ...), a
+ * set of blocked/allowed hostnames and a set of blocked subnets from configuration.
  * <p>
  * The allowed hostnames override the blocked hostnames e.g. if a host would be blocked because it resolves to a blocked
  * address (localhost, site-local, ...), the host can be allowed by adding it to the list allowed hostnames.
@@ -58,13 +60,17 @@ final class DefaultHostValidator implements HostValidator {
     DefaultHostValidator(final ConnectivityConfig connectivityConfig, final LoggingAdapter loggingAdapter,
             final AddressResolver resolver) {
         this.resolver = resolver;
-        this.allowedHostnames = connectivityConfig.getConnectionConfig().getAllowedHostnames();
+        // hostnames are case-insensitive (RFC 4343), so normalize the allow-list to lower-case for comparison:
+        this.allowedHostnames = connectivityConfig.getConnectionConfig().getAllowedHostnames().stream()
+                .map(hostname -> hostname.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
         final Collection<String> blockedHostnames = connectivityConfig.getConnectionConfig().getBlockedHostnames();
         this.blockedAddresses = calculateBlockedAddresses(blockedHostnames, loggingAdapter);
         final Collection<String> blockedSubnetsList = connectivityConfig.getConnectionConfig().getBlockedSubnets();
         this.blockedSubnets = filterEmptyBlockedSubnets(blockedSubnetsList);
         final var regex = connectivityConfig.getConnectionConfig().getBlockedHostRegex();
-        this.hostRegexPattern = Pattern.compile(regex);
+        // compile the blocked-host regex case-insensitively so an attacker cannot bypass it by changing host casing:
+        this.hostRegexPattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
     }
 
     /**
@@ -73,7 +79,8 @@ final class DefaultHostValidator implements HostValidator {
      *     <li>if the block-list is empty, this completely disables validation, every host is allowed</li>
      *     <li>if the host is contained in the allow-list, the host is allowed</li>
      *     <li>if the host matches the kubernetes cluster dns name suffix, the host is blocked</li>
-     *     <li>if the host is resolved to a blocked ip (loopback, site-local, multicast, wildcard ip), the host is blocked</li>
+     *     <li>if the host is resolved to a blocked ip (loopback, link-local, site-local, IPv6 unique-local,
+     *     multicast, wildcard ip), the host is blocked</li>
      *     <li>if the host is contained in the block-list, the host is blocked</li>
      *     <li>if the host is contained in the blocked-subnet list, the host is blocked</li>
      *  </ul>
@@ -85,13 +92,15 @@ final class DefaultHostValidator implements HostValidator {
      */
     @Override
     public HostValidationResult validateHost(final String host) {
+        // hostnames are case-insensitive; normalize before comparing against the allow-list / regex:
+        final String normalizedHost = host.toLowerCase(Locale.ROOT);
         if (blockedAddresses.isEmpty()) {
             // If not even localhost is blocked, then permit even private, loopback, multicast and wildcard IPs.
             return HostValidationResult.valid();
-        } else if (allowedHostnames.contains(host)) {
+        } else if (allowedHostnames.contains(normalizedHost)) {
             // the host is contained in the allow-list, do not block
             return HostValidationResult.valid();
-        } else if (hostRegexPattern.matcher(host).matches()) {
+        } else if (hostRegexPattern.matcher(normalizedHost).matches()) {
             // the host matches the regex pattern --> block
             return HostValidationResult.blocked(host);
         } else {
@@ -108,6 +117,12 @@ final class DefaultHostValidator implements HostValidator {
                 if (requestAddress.isLoopbackAddress()) {
                     return HostValidationResult.blocked(host,
                             String.format("the hostname resolved to a loopback address (%s).", resolvedAddress));
+                } else if (requestAddress.isLinkLocalAddress()) {
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a link local address (%s).", resolvedAddress));
+                } else if (isUniqueLocalAddress(requestAddress)) {
+                    return HostValidationResult.blocked(host,
+                            String.format("the hostname resolved to a unique local address (%s).", resolvedAddress));
                 } else if (requestAddress.isSiteLocalAddress()) {
                     return HostValidationResult.blocked(host,
                             String.format("the hostname resolved to a site local address (%s).", resolvedAddress));
@@ -135,6 +150,20 @@ final class DefaultHostValidator implements HostValidator {
         }
         // if nothing matches the host is valid
         return HostValidationResult.valid();
+    }
+
+    /**
+     * Checks whether the given address is an IPv6 unique-local address ({@code fc00::/7}, RFC 4193) - the IPv6
+     * counterpart of the IPv4 private ranges. This has to be checked explicitly, because
+     * {@link InetAddress#isSiteLocalAddress()} only covers the deprecated {@code fec0::/10} site-local prefix (RFC
+     * 3879) and therefore does <em>not</em> match unique-local addresses such as the IPv6 cloud instance-metadata
+     * endpoint {@code fd00:ec2::254}.
+     *
+     * @param address the address to check.
+     * @return whether the address is an IPv6 unique-local address.
+     */
+    private static boolean isUniqueLocalAddress(final InetAddress address) {
+        return address instanceof Inet6Address && (address.getAddress()[0] & 0xfe) == 0xfc;
     }
 
     /**

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidatorTest.java
@@ -38,6 +38,7 @@ import org.apache.pekko.event.LoggingAdapter;
 public class HostValidatorTest {
 
     private static final DittoHeaders DITTO_HEADERS = DittoHeaders.newBuilder().correlationId("ditto").build();
+    private static final String BLOCKED_HOSTNAME = "dummy.org";
     private ConnectionConfig connectionConfig;
     private ConnectivityConfig connectivityConfig;
     private LoggingAdapter loggingAdapter;
@@ -133,6 +134,8 @@ public class HostValidatorTest {
         final HostValidator underTest = getHostValidatorWithBlockedRegexPattern();
 
         assertFalse(underTest.validateHost("gateway.things.svc.cluster.local").isValid());
+        // a host that does not match the regex has to pass, otherwise the assertion above would prove nothing:
+        assertValid(underTest.validateHost("gateway.things.example.com"));
     }
 
     @Test
@@ -179,7 +182,8 @@ public class HostValidatorTest {
     public void expectBlockedHostRegexIsCaseInsensitive() {
         final HostValidator underTest = getHostValidatorWithBlockedRegexPattern();
 
-        // an attacker must not be able to bypass the blocked-host regex by changing the casing of the host:
+        // an attacker must not be able to bypass the blocked-host regex by changing the casing of the host - the
+        // host resolves to a public address, so the regex is the only check that can reject it:
         assertFalse(underTest.validateHost("gateway.things.SVC.Cluster.LOCAL").isValid());
     }
 
@@ -205,9 +209,18 @@ public class HostValidatorTest {
         return new DefaultHostValidator(connectivityConfig, loggingAdapter, resolver);
     }
 
+    /**
+     * Builds a validator in which the blocked-host regex is the <em>only</em> thing that can block a host: the
+     * configured blocked hostname and every other host resolve to two distinct public addresses, and the blocked
+     * subnets are cleared. Without this, a host that simply fails to resolve comes back as {@code invalid} - which is
+     * also {@code isValid() == false} - and the assertion would hold even when the regex never matched.
+     */
     private HostValidator getHostValidatorWithBlockedRegexPattern() {
-        when(connectionConfig.getBlockedHostRegex()).thenReturn("^.*\\.svc.cluster.local$");
-        return new DefaultHostValidator(connectivityConfig, loggingAdapter);
+        when(connectionConfig.getBlockedHostnames()).thenReturn(List.of(BLOCKED_HOSTNAME));
+        when(connectionConfig.getBlockedSubnets()).thenReturn(emptyList());
+        when(connectionConfig.getBlockedHostRegex()).thenReturn("^.*\\.svc\\.cluster\\.local$");
+        return getHostValidatorWithCustomResolver(host -> resolveHost(host,
+                BLOCKED_HOSTNAME.equals(host) ? new byte[]{1, 2, 3, 4} : new byte[]{8, 8, 8, 8}));
     }
 
     private void assertValid(final HostValidationResult result) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/validation/HostValidatorTest.java
@@ -135,6 +135,54 @@ public class HostValidatorTest {
         assertFalse(underTest.validateHost("gateway.things.svc.cluster.local").isValid());
     }
 
+    @Test
+    public void expectLinkLocalCloudMetadataAddressIsBlocked() {
+        // 169.254.169.254 is the cloud instance-metadata endpoint and is a *link-local* address - it must be blocked
+        // by the address-class check itself, not only when an operator happens to configure the 169.254.0.0/16 subnet:
+        when(connectionConfig.getBlockedSubnets()).thenReturn(emptyList());
+
+        final HostValidator underTest = getHostValidatorWithAllowlist();
+
+        assertFalse(underTest.validateHost("169.254.169.254").isValid());
+        assertFalse(underTest.validateHost("fe80::1").isValid());
+    }
+
+    @Test
+    public void expectIpv6UniqueLocalAddressIsBlocked() {
+        // fd00:ec2::254 is the IPv6 cloud instance-metadata endpoint; unique-local addresses (fc00::/7) are not
+        // covered by InetAddress#isSiteLocalAddress, which only matches the deprecated fec0::/10 prefix:
+        when(connectionConfig.getBlockedSubnets()).thenReturn(emptyList());
+
+        final HostValidator underTest = getHostValidatorWithAllowlist();
+
+        assertFalse(underTest.validateHost("fd00:ec2::254").isValid());
+        assertFalse(underTest.validateHost("fd00::1").isValid());
+        assertFalse(underTest.validateHost("fc00::1").isValid());
+        // a public IPv6 address stays valid:
+        assertValid(underTest.validateHost("2001:db8::1"));
+    }
+
+    @Test
+    public void expectAllowListIsCaseInsensitive() throws Exception {
+        final String theHost = "My-Registry.Example";
+        final DefaultHostValidator.AddressResolver resolveToLoopback =
+                host -> resolveHost(theHost, InetAddress.getLoopbackAddress().getAddress());
+
+        // the allow-list is configured in a different casing than the host being validated:
+        final HostValidator underTest =
+                getHostValidatorWithCustomResolver(resolveToLoopback, "my-registry.example");
+
+        assertValid(underTest.validateHost(theHost));
+    }
+
+    @Test
+    public void expectBlockedHostRegexIsCaseInsensitive() {
+        final HostValidator underTest = getHostValidatorWithBlockedRegexPattern();
+
+        // an attacker must not be able to bypass the blocked-host regex by changing the casing of the host:
+        assertFalse(underTest.validateHost("gateway.things.SVC.Cluster.LOCAL").isValid());
+    }
+
     private static InetAddress[] resolveHost(final String host, byte... address) throws UnknownHostException {
         return new InetAddress[]{
                 InetAddress.getByAddress(host, address.length != 4 ? new byte[]{1, 2, 3, 4} : address)


### PR DESCRIPTION
Tightens the outbound host validation applied to connection targets (`DefaultHostValidator`) in three ways:

* **Case-insensitive matching** of the allow-list and of the blocked-host regex. Hostnames are case-insensitive (RFC 4343), so a configured block rule such as `.*\.internal` previously did not match a differently cased host, and allow-list entries could be missed for the same reason.
* **Link-local addresses are blocked** (`169.254.0.0/16`, `fe80::/10`). These cover the cloud instance-metadata endpoint `169.254.169.254`, which was previously only blocked when an operator happened to configure the corresponding subnet.
* **IPv6 unique-local addresses are blocked** (`fc00::/7`, RFC 4193). `InetAddress#isSiteLocalAddress` only matches the deprecated `fec0::/10` prefix, so unique-local addresses such as `fd00:ec2::254` passed every built-in address-class check.

The default configuration is deliberately left unchanged: connectivity ships `blocked-hostnames = ""`, which short-circuits validation entirely, so these checks only take effect for deployments that have host validation enabled.

`HostValidatorTest` is extended accordingly: link-local and IPv6 unique-local blocking (both halves of `fc00::/7`, plus a public IPv6 address as control), and case-insensitivity of both the allow-list and the blocked-host regex.
