### PR TITLE
Render Helm customIndexes at the config path Ditto actually reads

### DIFF
--- a/deployment/helm/ditto/CHANGELOG.md
+++ b/deployment/helm/ditto/CHANGELOG.md
@@ -15,6 +15,18 @@ sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
 
 ## [Unreleased]
 
+## [4.7.1]
+
+### Fixed
+- `thingsSearch.config.customIndexes` never reached Ditto: the template rendered the block under
+  `ditto.search.updater.persistence.custom-indexes`, while `SearchConfigValue.CUSTOM_INDEXES` declares the
+  path `index-initialization.custom-indexes` (as documented in `search.conf`, where `custom-indexes` sits
+  inside the `index-initialization` block next to `activated-index-names`). Because
+  `IndexInitializer.dropUndefinedIndices()` removes every index that is neither built-in nor a *configured*
+  custom index, declaring a custom index made Ditto **drop** it on startup instead of creating and keeping
+  it. Operators who had pre-created the index manually lost it on the next things-search restart. The fix
+  is positional only — the emitted HOCON shape is unchanged
+
 ## [4.7.0]
 
 Bumped Ditto `appVersion` to `3.9.7`.

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 4.7.0  # chart version is effectively set by release-job
+version: 4.7.1  # chart version is effectively set by release-job
 appVersion: 3.9.7
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/service-config/search-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/search-extension.conf.tpl
@@ -40,11 +40,7 @@ ditto {
         {{- end }}
         ]
     {{- end }}
-    }
-
     {{- if .Values.thingsSearch.config.customIndexes }}
-    updater {
-      persistence {
         custom-indexes {
         {{- range $indexName, $fields := .Values.thingsSearch.config.customIndexes }}
           "{{$indexName}}" {
@@ -56,9 +52,8 @@ ditto {
           }
         {{- end }}
         }
-      }
-    }
     {{- end }}
+    }
 
     {{- if .Values.thingsSearch.config.indexedFieldsLimiting.enabled }}
     namespace-indexed-fields = [


### PR DESCRIPTION
`thingsSearch.config.customIndexes` never reached Ditto. The template emitted the block under

```
  ditto.search.updater.persistence.custom-indexes
```

while SearchConfigValue declares

```
  CUSTOM_INDEXES("index-initialization.custom-indexes", Collections.emptyMap())
```

so DittoSearchConfig#loadCustomIndexes looks under `ditto.search.index-initialization.custom-indexes` and finds nothing. search.conf documents the same location - `custom-indexes {}` sits inside the `index-initialization { }` block, next to `activated-index-names`.

The consequence is worse than the feature silently doing nothing. Because IndexInitializer.dropUndefinedIndices() removes every index whose name is neither built-in nor a *configured* custom index, declaring an index in the chart made Ditto drop it on startup rather than create and keep it. Operators who had pre-created the index by hand - the recommended approach on a large collection, where a rolling build avoids a cold create - lost it on the next things-search restart.