### PR TITLE
Document PUT create for connections #1746

### DIFF
--- a/documentation/src/main/resources/pages/ditto/connectivity-manage-connections.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-manage-connections.md
@@ -38,7 +38,8 @@ for configuration details.
 
 ### Create a connection
 
-Send an HTTP `POST` request:
+Send an HTTP `POST` request. Ditto generates the connection ID. Do not put an `id` in the body
+(that returns `connectivity:id.notsettable`).
 
 ```
 POST /api/2/connections
@@ -55,6 +56,16 @@ POST /api/2/connections
 }
 ```
 
+To pick the ID yourself, use `PUT` instead:
+
+```
+PUT /api/2/connections/{connectionId}
+If-None-Match: *
+```
+
+`If-None-Match: *` makes this create-only. Without that header, the same `PUT` updates the
+connection if it already exists.
+
 The connection configuration format is described in the [Connections](basic-connections.html) section.
 For protocol-specific examples, see the relevant binding page:
 * [AMQP 0.9.1](connectivity-protocol-bindings-amqp091.html)
@@ -63,6 +74,7 @@ For protocol-specific examples, see the relevant binding page:
 * [MQTT 5](connectivity-protocol-bindings-mqtt5.html)
 * [HTTP 1.1](connectivity-protocol-bindings-http.html)
 * [Kafka 2.x](connectivity-protocol-bindings-kafka2.html)
+* [Eclipse Hono](connectivity-protocol-bindings-hono.html)
 
 #### Dry run
 
@@ -83,7 +95,8 @@ Send an HTTP `PUT` request:
 PUT /api/2/connections/{connectionId}
 ```
 
-The connection must already exist before you can modify it.
+If the connection does not exist yet, Ditto creates it. Add `If-None-Match: *` when you want
+the request to fail instead of overwriting an existing connection.
 
 ### Retrieve a connection
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-hono.md
@@ -24,6 +24,20 @@ with the exceptions described below.
             each tenant. The tenant ID is configured via `specificConfig.honoTenantId`."
 %}
 
+## Creating a Hono connection
+
+`POST /api/2/connections` generates a random ID and rejects an `id` in the JSON body.
+Create a Hono connection with `PUT` so the connection ID can be the tenant ID
+(that ID is used when `honoTenantId` is omitted):
+
+```
+PUT /api/2/connections/{honoTenantId}
+If-None-Match: *
+```
+
+`If-None-Match: *` fails if that connection already exists, so the request cannot
+turn into an update. See [Managing Connections](connectivity-manage-connections.html).
+
 ## Connection URI format
 
 You do **not** specify the `uri` in a Hono connection -- it is generated automatically from the


### PR DESCRIPTION
POST `/api/2/connections` still generates the ID and rejects one in the body. I documented `PUT /api/2/connections/{connectionId}` with `If-None-Match: *` as the create-only path, and pointed the Hono page at that so the connection ID can be the tenant ID.

Fixes #1746