### PR TITLE
Harden the release supply chain: image scanning, attestations, reproducible builds, dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 version: 2
+# Note on scope: Dependabot *security* updates are enabled through the repository
+# settings and already cover every ecosystem here (they need no entry in this file) -
+# that is what keeps known-vulnerable dependencies patched. The entries below add
+# *version* updates on top, to limit dependency drift between releases. They are
+# deliberately monthly and grouped so they do not bury the release-relevant PRs.
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -24,5 +29,73 @@ updates:
       include: scope
     groups:
       github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: maven
+    directory: "/bom"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/ui"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      ui-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/benchmark-tool/artillery-test"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      benchmark-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/documentation/src/main/resources/openapi/sources"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      openapi-npm:
         patterns:
           - "*"

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -99,6 +99,12 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
+          # Supply-chain attestations, attached to the pushed manifest:
+          # an SPDX SBOM of the image contents plus max-mode SLSA provenance.
+          # Downstream consumers need these for their own CRA technical documentation;
+          # inspect with `docker buildx imagetools inspect <image> --format '{{json .SBOM}}'`.
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-policies:${{ env.IMAGE_TAG }}
       -
@@ -114,6 +120,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things:${{ env.IMAGE_TAG }}
       -
@@ -129,6 +137,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-gateway:${{ env.IMAGE_TAG }}
       -
@@ -144,6 +154,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things-search:${{ env.IMAGE_TAG }}
       -
@@ -160,6 +172,8 @@ jobs:
             JVM_CMD_ARGS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}
       -
@@ -184,6 +198,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-ui:${{ env.IMAGE_TAG }}
       - 

--- a/.github/workflows/push-dockerhub-on-demand.yml
+++ b/.github/workflows/push-dockerhub-on-demand.yml
@@ -137,6 +137,12 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
+          # Supply-chain attestations, attached to the pushed manifest:
+          # an SPDX SBOM of the image contents plus max-mode SLSA provenance.
+          # Downstream consumers need these for their own CRA technical documentation;
+          # inspect with `docker buildx imagetools inspect <image> --format '{{json .SBOM}}'`.
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-policies:${{ env.IMAGE_TAG }}
             eclipse/ditto-policies:${{ env.IMAGE_MINOR_TAG }}
@@ -156,6 +162,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things:${{ env.IMAGE_TAG }}
             eclipse/ditto-things:${{ env.IMAGE_MINOR_TAG }}
@@ -175,6 +183,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-gateway:${{ env.IMAGE_TAG }}
             eclipse/ditto-gateway:${{ env.IMAGE_MINOR_TAG }}
@@ -194,6 +204,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things-search:${{ env.IMAGE_TAG }}
             eclipse/ditto-things-search:${{ env.IMAGE_MINOR_TAG }}
@@ -214,6 +226,8 @@ jobs:
             JVM_CMD_ARGS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}
             eclipse/ditto-connectivity:${{ env.IMAGE_MINOR_TAG }}
@@ -242,6 +256,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-ui:${{ env.IMAGE_TAG }}
             eclipse/ditto-ui:${{ env.IMAGE_MINOR_TAG }}
@@ -261,6 +277,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-policies:${{ env.IMAGE_TAG }}
       -
@@ -277,6 +295,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things:${{ env.IMAGE_TAG }}
       -
@@ -293,6 +313,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-gateway:${{ env.IMAGE_TAG }}
       -
@@ -309,6 +331,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things-search:${{ env.IMAGE_TAG }}
       -
@@ -326,6 +350,8 @@ jobs:
             JVM_CMD_ARGS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}
       -
@@ -338,5 +364,72 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-ui:${{ env.IMAGE_TAG }}
+      -
+        # Scan the released images with the same CRITICAL gate the nightly build uses.
+        # These steps necessarily run AFTER the push (the images are built and pushed in
+        # one buildx step, for two platforms), so this is a detective control: a red run
+        # here does not un-publish anything, it means a fixed patch release is needed.
+        # Keep the settings in sync with docker-nightly.yml.
+        name: Run Trivy vulnerability scanner for ditto-policies
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-policies:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-things
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-things:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-gateway
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-gateway:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-things-search
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-things-search:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-connectivity
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-ui
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-ui:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -162,6 +162,12 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
+          # Supply-chain attestations, attached to the pushed manifest:
+          # an SPDX SBOM of the image contents plus max-mode SLSA provenance.
+          # Downstream consumers need these for their own CRA technical documentation;
+          # inspect with `docker buildx imagetools inspect <image> --format '{{json .SBOM}}'`.
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_POLICIES }}
       -
         name: Build and push ditto-things
@@ -177,6 +183,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_THINGS }}
       -
         name: Build and push ditto-gateway
@@ -192,6 +200,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_GATEWAY }}
       -
         name: Build and push ditto-thingsearch
@@ -207,6 +217,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_THINGS_SEARCH }}
       -
         name: Build and push ditto-connectivity
@@ -223,6 +235,8 @@ jobs:
             JVM_CMD_ARGS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_CONNECTIVITY }}
       -
         name: Use Node.js 18.x
@@ -247,6 +261,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ env.TAGS_DITTO_UI }}
       -
         name: Build and push ditto-policies milestone/RC
@@ -262,6 +278,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-policies:${{ env.IMAGE_TAG }}
       -
@@ -278,6 +296,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things:${{ env.IMAGE_TAG }}
       -
@@ -294,6 +314,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-gateway:${{ env.IMAGE_TAG }}
       -
@@ -310,6 +332,8 @@ jobs:
             MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-things-search:${{ env.IMAGE_TAG }}
       -
@@ -327,6 +351,8 @@ jobs:
             JVM_CMD_ARGS=--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}
       -
@@ -339,5 +365,72 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          sbom: true
+          provenance: mode=max
           tags: |
             eclipse/ditto-ui:${{ env.IMAGE_TAG }}
+      -
+        # Scan the released images with the same CRITICAL gate the nightly build uses.
+        # These steps necessarily run AFTER the push (the images are built and pushed in
+        # one buildx step, for two platforms), so this is a detective control: a red run
+        # here does not un-publish anything, it means a fixed patch release is needed.
+        # Keep the settings in sync with docker-nightly.yml.
+        name: Run Trivy vulnerability scanner for ditto-policies
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-policies:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-things
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-things:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-gateway
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-gateway:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-things-search
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-things-search:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-connectivity
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-connectivity:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'
+      -
+        name: Run Trivy vulnerability scanner for ditto-ui
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'docker.io/eclipse/ditto-ui:${{ env.IMAGE_TAG }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL'

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,15 @@
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
+        <!-- Reproducible builds: pins the timestamp of every entry in the produced archives
+             so that building the same sources twice yields byte-identical artifacts.
+             Deliberately NOT ${maven.build.timestamp} - that would defeat the purpose.
+             The release job overrides this with the tagged commit's date:
+               mvn ... -Dproject.build.outputTimestamp=2026-09-08T10:00:00Z
+             Note: this does not affect ${maven.build.timestamp} above (verified on Maven
+             3.9.x), so the date injected into the legal docs still tracks the build date. -->
+        <project.build.outputTimestamp>2026-01-01T00:00:00Z</project.build.outputTimestamp>
+
         <release.scm.connection>scm:git:git@github.com:eclipse-ditto/ditto.git</release.scm.connection>
         <release.scm.developerConnection>scm:git:https://github.com/eclipse-ditto/ditto.git</release.scm.developerConnection>
         <release.scm.url>https://github.com/eclipse-ditto/ditto.git</release.scm.url>


### PR DESCRIPTION
Four independent supply-chain improvements, motivated by looking at where Ditto stands relative to the Cyber Resilience Act. Ditto itself is not a CRA *manufacturer* — the Eclipse Foundation is an open-source software steward under Art. 24, and Ditto has no obligation to produce SBOMs or declarations of conformity. Its adopters *are* manufacturers, though, and everything below either helps them or is plain good hygiene.

### Scan released images (`push-dockerhub.yml`, `push-dockerhub-on-demand.yml`)

The Trivy `CRITICAL` gate so far only guarded the nightly images, not the ones adopters deploy. Both release workflows now run the same six scans with the same settings as `docker-nightly.yml`.

Because images are built and pushed in a single multi-platform buildx step, these run *after* the push. That makes them a detective control: a red run means a fixed patch release is needed, it does not un-publish anything. Making it preventive would mean building single-arch locally, scanning, then rebuilding to push — a much larger restructure, deliberately not attempted here.

### Attach SBOM and provenance attestations (all three image workflows)

Every image build now passes `sbom: true` and `provenance: mode=max`, so each pushed manifest carries an SPDX SBOM of its contents plus max-mode SLSA provenance:

```
docker buildx imagetools inspect eclipse/ditto-things:<tag> --format "{{json .SBOM}}"
```

Downstream manufacturers have to account for Ditto’s components in their own technical documentation; shipping the SBOM with the image saves them reconstructing it. Enabled for the nightly images too, so the attestation path is exercised daily rather than first exercised during a release.

### Reproducible builds (`pom.xml`)

Sets `project.build.outputTimestamp` so archive entries no longer carry the wall-clock build time.

Verified on `utils/jsr305`: two `clean install` runs are byte-identical with the property and differ without it (entry timestamps were wall-clock). Note this does **not** change `${maven.build.timestamp}`, so the date injected into the legal docs still tracks the actual build date — checked on Maven 3.9.x.

Two limitations worth flagging for review:
- Verified on one small module, not the full reactor. The shade plugin (`*-allinone.jar`) and javadoc jars are the usual places full reproducibility breaks; confirming that needs `artifact:compare` over a complete build.
- The committed `2026-01-01T00:00:00Z` is a deterministic default, not a meaningful date. Reproducibility only needs determinism, but the release job can pass the tagged commit’s date via `-Dproject.build.outputTimestamp=...` if we want it to mean something. Not wired into the release workflow here.

### Dependabot version updates (`.github/dependabot.yml`)

This file configured version updates for `github-actions` only. Dependabot **security** updates come from the repository settings and already cover maven and all three npm projects — that is what keeps known-vulnerable dependencies patched, and it is untouched by this change.

What was missing is **version** updates, so non-vulnerable dependencies drift until someone notices. Added for `bom/` (where third-party versions are declared centrally) and for `ui/`, `benchmark-tool/artillery-test/` and `documentation/src/main/resources/openapi/sources/`.

Deliberately monthly, grouped per ecosystem, low PR limits, and keeping the existing 7-day cooldown so freshly published versions get a chance to be yanked first. Commit prefix matches the `ci(deps):` convention the existing Dependabot PRs already use. A comment now records the security-vs-version distinction so the absence of maven entries is not mistaken for missing coverage again.