### PR TITLE
fix(ui): package the OIDC silent-callback page so it actually works

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,13 @@
+# The image serves static files only: the Dockerfile copies index.html,
+# silent-callback.html and dist/, and nothing else is needed at build time.
+#
+# Without this file the whole ui/ tree is sent to the daemon as build context -
+# node_modules alone dwarfs everything the image actually contains, which makes a
+# three-COPY build take minutes.
+#
+# Allowlist rather than denylist: adding a COPY without extending this list fails
+# the build instead of silently depending on whatever happens to be lying around.
+*
+!index.html
+!silent-callback.html
+!dist

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -14,4 +14,5 @@ FROM nginxinc/nginx-unprivileged:alpine
 WORKDIR /usr/share/nginx/html
 
 COPY ./index.html           .
+COPY ./silent-callback.html .
 COPY ./dist                 ./dist

--- a/ui/build.mjs
+++ b/ui/build.mjs
@@ -3,7 +3,7 @@ import * as esbuild from 'esbuild';
 import {sassPlugin} from 'esbuild-sass-plugin';
 
 const config = {
-  entryPoints: ['main.ts'],
+  entryPoints: ['main.ts', 'silent-callback.ts'],
   bundle: true,
   outdir: 'dist',
   loader: {

--- a/ui/silent-callback.html
+++ b/ui/silent-callback.html
@@ -4,28 +4,6 @@
     <title>Silent Refresh Callback</title>
 </head>
 <body>
-    <script>
-        try {
-            import('oidc-client-ts').then(({ UserManager }) => {
-                const userManager = new UserManager();
-                
-                userManager.signinSilentCallback()
-                    .then(() => {
-                        if (window.opener) {
-                            window.close();
-                        }
-                    })
-                    .catch(error => {
-                        console.error('Silent refresh callback failed:', error);
-                    });
-            }).catch(error => {
-                console.error('Failed to load oidc-client-ts:', error);
-            });
-        } catch (error) {
-            console.error('Silent callback error:', error);
-        }
-    </script>
+    <script type="module" src="./dist/silent-callback.js"></script>
 </body>
 </html>
-
-

--- a/ui/silent-callback.ts
+++ b/ui/silent-callback.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import { UserManager, UserManagerSettings } from 'oidc-client-ts';
+
+/*
+ * Entry point for silent-callback.html, the page oidc-client-ts loads in a hidden iframe as
+ * `silent_redirect_uri` when renewing an access token without a refresh token.
+ *
+ * The page's only job is to hand the response URL back to the parent frame;
+ * `signinSilentCallback()` delegates to IFrameNavigator.callback(), which reads nothing from
+ * the settings except the optional `iframeNotifyParentOrigin` (defaulting to this page's own
+ * origin). Hence the placeholder settings below: `authority` and `client_id` are required by
+ * UserManagerSettings but are never touched on this path.
+ *
+ * Passing an object at all is what matters - `new UserManager()` throws, because
+ * UserManagerSettingsStore dereferences `args.redirect_uri` before any defaulting.
+ */
+const callbackOnlySettings: UserManagerSettings = {
+  authority: '',
+  client_id: '',
+};
+
+new UserManager(callbackOnlySettings)
+    .signinSilentCallback()
+    .catch((error) => {
+      // Nothing is recoverable from inside the iframe: oidc-client-ts times the silent
+      // request out and raises a SilentRenewError on the UserManager that started it.
+      console.error('Silent refresh callback failed:', error);
+    });


### PR DESCRIPTION
## Problem

`ui/silent-callback.html` has never worked in any environment. It was added by c2eda4fa96 *"support silent token refresh"* alongside the OIDC wiring in `authorization.ts`, but the packaging half was never done — and the page carried two further defects that only a real browser would surface.

**1. It never reaches the image.** `ui/Dockerfile` copies only `./index.html` and `./dist`; the page sits at `ui/` root, so it is copied by neither. Confirmed inside a running `eclipse/ditto-ui` container rather than inferred: the web root holds `index.html`, `50x.html` and `dist/{main.css,main.js}`, and a filesystem-wide search for `*callback*` returns nothing.

**2. `build.mjs` could not have supplied it either.** It has a single entry point (`main.ts`), and its `.html` loader is `text` — which inlines HTML *imported from TypeScript* as a string rather than emitting standalone HTML files. Nothing imports the page, so `COPY ./dist` had nothing to pick up.

**3. The page could not run even if served.** It did:

```js
import('oidc-client-ts').then(({ UserManager }) => {
    const userManager = new UserManager();
```

`'oidc-client-ts'` is a bare ESM specifier — unresolvable without an import map, and the page has none. And `new UserManager()` with no argument throws: `UserManagerSettingsStore` dereferences `args.redirect_uri` before any defaulting.

**Why it went unnoticed.** The only reference to the page anywhere is the `environmentTemplates.json` default, `http://localhost:8000/silent-callback.html` — the esbuild dev server, whose `servedir: '.'` made the file reachable during local development and masked all three problems. Beyond that, `UserManager.signinSilent()` returns from its refresh-token branch whenever `user?.refresh_token` is set:

```js
if (user?.refresh_token) {
  return await this._useRefreshToken({ ... });
}
```

so any client requesting `offline_access` never loads this page at all.

## Fix

- **`ui/silent-callback.ts`** (new) — the script becomes a real entry point, so esbuild resolves and bundles `oidc-client-ts` instead of leaving a bare specifier.
- **`ui/build.mjs`** — `entryPoints: ['main.ts', 'silent-callback.ts']`.
- **`ui/silent-callback.html`** — loads `./dist/silent-callback.js`, mirroring how `index.html` loads `./dist/main.js`.
- **`ui/Dockerfile`** — `COPY ./silent-callback.html .`

The placeholder settings in `silent-callback.ts` are deliberate and commented: `signinSilentCallback()` delegates to `IFrameNavigator.callback()`, which reads nothing from the settings but the optional `iframeNotifyParentOrigin` (defaulting to the page's own origin). `authority` and `client_id` are required by `UserManagerSettings` but never touched on this path — and passing an object *at all* is what avoids the constructor throw.

## Also included: `ui/.dockerignore`

With no `.dockerignore`, the whole `ui/` tree went to the daemon as build context — `node_modules` included — so a three-`COPY` build took minutes. An allowlist was chosen over a denylist so that adding a `COPY` without extending the list fails the build rather than silently depending on whatever is lying around in the working tree.

Build time drops from minutes to **~10s**, and the image contains a byte-for-byte identical set of files.

## Verification

- `npm run build` (`tsc -noEmit && node build.mjs`) passes, emitting `dist/silent-callback.js` (65 kB).
- The bundle carries the real contract — the `"oidc-client"` message source, `postMessage` and `keepOpen` are all present — with **0** dynamic imports and **0** unresolved bare specifiers.
- Building `ui/Dockerfile` and serving the image:

| Path | Status | Content-Type | Bytes |
| ---- | -----: | ------------ | ----: |
| `/silent-callback.html` | 200 | `text/html` | 172 |
| `/dist/silent-callback.js` | 200 | `application/javascript` | 65705 |
| `/index.html` | 200 | `text/html` | 7401 |
| `/dist/main.js` | 200 | `application/javascript` | 945817 |

- Image contents identical before and after adding `.dockerignore`: `50x.html`, `index.html`, `silent-callback.html`, `dist/{main.css, main.css.map, main.js, main.js.map, silent-callback.js}` at the same sizes.

## Not verified

The renewal round trip itself needs a browser session with an IdP that issues **no** refresh token, waiting for an access token to approach expiry — I could not exercise that. What is verified is that the page and its bundle are served correctly and that the bundled code contains the message contract `AbstractChildWindow` validates.
