### PR TITLE
Stop Dependabot rewriting Ditto's own CI-friendly versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,35 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+    ignore:
+      # Ditto's own modules use Maven CI-friendly versions: every pom declares
+      # <version>${revision}</version> and the real version is supplied per build
+      # with -Drevision=<x>. Dependabot resolves that placeholder to the literal
+      # "0-SNAPSHOT", concludes the modules are behind the last release and tries
+      # to "update" them - in PR #2555 it rewrote the root project's own <version>
+      # to 3.9.7, which breaks parent resolution for all 20 modules. Ditto's
+      # internal versions are never dependency updates, so ignore them outright.
+      - dependency-name: "org.eclipse.ditto:*"
     groups:
+      # Dependabot reaches the root pom as the parent of bom/pom.xml, so its
+      # <pluginManagement> versions are in scope too. Keep the build plugins in
+      # their own PR: a japicmp or maven-compiler bump changes build and
+      # API-compatibility semantics and needs reviewing on its own, not buried in
+      # a group PR alongside library upgrades. Listed before the catch-all group
+      # below, because a dependency lands in the first group whose patterns match.
+      maven-build-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "org.codehaus.mojo:*"
+          - "org.jacoco:*"
+          - "com.github.siom79.japicmp:*"
+          - "com.mycila:*"
+          - "org.apache.felix:*"
+          - "net.alchim31.maven:*"
+          - "org.sonatype.plugins:*"
+          - "org.sonatype.central:*"
+          - "org.eclipse.cbi.maven.plugins:*"
+          - "de.saumya.mojo:*"
       maven-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
Fixes the fallout from the maven version updates added in #2547.

### The bug

[#2555](https://github.com/eclipse-ditto/ditto/pull/2555) rewrote the root project’s own version:

```diff
     <groupId>org.eclipse.ditto</groupId>
     <artifactId>ditto</artifactId>
     <packaging>pom</packaging>
-    <version>${revision}</version>
+    <version>3.9.7</version>
```

Ditto uses Maven CI-friendly versions: every pom declares `<version>${revision}</version>` and the real version is supplied per build with `-Drevision=<x>`. Dependabot resolves that placeholder to the literal `0-SNAPSHOT`, concludes the modules are behind the last release, and “updates” them.

The result does not build. Child poms still reference the parent as `${revision}`, so with the root at a literal `3.9.7` parent resolution fails:

```
[ERROR] The build could not read 20 projects
[ERROR]   The project org.eclipse.ditto:ditto-base:${revision} has 1 error
```

So #2555 is broken rather than dangerous — CI would have caught it — but it should be **closed, not merged**.

Ditto’s internal module versions are never dependency updates, so this ignores `org.eclipse.ditto:*` outright.

### Second issue in the same PR

#2555 carried **123 updates across two files**. Dependabot reaches the root pom as the parent of `bom/pom.xml`, so the root `<pluginManagement>` versions are in scope too — the PR bumped the whole build plugin stack (japicmp 0.18.3 → 0.26.1, maven-compiler 3.13.0 → 3.16.0, shade, jacoco, …) mixed in with third-party library upgrades.

That is not reviewable as one change, and a japicmp or compiler bump alters build and API-compatibility semantics — precisely the thing the `binary-compatibility-check.version` comment in the root pom warns about. Build plugins now form their own group so they arrive as a separate PR from library updates.

The plugin group is listed first because a dependency lands in the first group whose patterns match; the `"*"` catch-all keeps everything else in `maven-dependencies`.

### What to expect next month

Two Maven PRs instead of one: `maven-build-plugins` and `maven-dependencies`, neither touching `org.eclipse.ditto:*`. The github-actions and three npm entries are unchanged.